### PR TITLE
Misc. Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/**
+package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY cashaddress.org.html /usr/share/nginx/html/index.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 var packageObject = require('./package.json');
+var shell = require('shelljs');
 
 module.exports = function (grunt) {
 	// Project configuration.
@@ -76,4 +77,10 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks("grunt-combine");
 	grunt.loadNpmTasks('grunt-lineending');
 	grunt.registerTask("default", ["combine:single", "lineending"]);
+	grunt.registerTask('docker-build', "build docker image", function() {
+		shell.exec('docker build -t cashaddress .');
+	});
+	grunt.registerTask('docker-run', "run docker image", function() {
+		shell.exec('docker run -d -p 8888:80 cashaddress');
+	});
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
 		combine: {
 			single: {
 				input: "./src/bitaddress-ui.html",
-				output: "./bitaddress.org.html",
+				output: "./cashaddress.org.html",
 				tokens: [
 					{ token: "//biginteger.js", file: "./src/biginteger.js" },
 					{ token: "//bitcoinjs-lib.js", file: "./src/bitcoinjs-lib.js" },
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
 					eol: 'lf'
 				},
 				files: {                // Files to process
-					'./bitaddress.org.html': ['./bitaddress.org.html']
+					'./cashaddress.org.html': ['./cashaddress.org.html']
 				}
 			}
 		}

--- a/kube/cashaddress-autoscale.yml
+++ b/kube/cashaddress-autoscale.yml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cashaddress
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: cashaddress
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 90

--- a/kube/cashaddress-deployment.yml
+++ b/kube/cashaddress-deployment.yml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: default
+  labels:
+    service: cashaddress
+  name: cashaddress
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        service: cashaddress
+    spec:
+      containers:
+      - image: zquestz/cashaddress
+        name: cashaddress
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            memory: "64Mi"
+      restartPolicy: Always

--- a/kube/cashaddress-ingress-tls.yml
+++ b/kube/cashaddress-ingress-tls.yml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: cashaddress-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "gce"
+spec:
+  tls:
+  - hosts:
+    - cashaddress.org
+    secretName: cashaddress-tls
+  backend:
+    serviceName: cashaddress
+    servicePort: 88
+  rules:
+  - host: cashaddress.org
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: cashaddress
+          servicePort: 88

--- a/kube/cashaddress-srv.yml
+++ b/kube/cashaddress-srv.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cashaddress
+  namespace: default
+spec:
+  ports:
+    - port: 88
+      targetPort: 80
+  selector:
+    service: cashaddress
+  type: NodePort

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
   "dependencies": {
     "grunt": "~0.4.1",
     "grunt-combine": "~0.8.3",
-    "grunt-lineending": "~0.2.4"
+    "grunt-lineending": "~0.2.4",
+    "shelljs": "~0.7.8"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-combine": "~0.8.3",
-    "grunt-lineending": "~0.2.4"
+    "grunt-lineending": "~0.2.4",
+    "shelljs": "~0.7.8"
   },
   "scripts": {
     "test": ""

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "dependencies": {
     "grunt": "~0.4.1",
     "grunt-combine": "~0.8.3",
-	"grunt-lineending": "~0.2.4"
+    "grunt-lineending": "~0.2.4"
   },
   "devDependencies": {
-	"grunt": "~0.4.1",
+    "grunt": "~0.4.1",
     "grunt-combine": "~0.8.3",
     "grunt-lineending": "~0.2.4"
   },


### PR DESCRIPTION
Just some small improvements.

* Fixed some spacing in package.json
* Added .gitignore for node_modules and package-lock.json
* Updated the Gruntfile to build cashaddress.org.html
* Added Dockerfile to easily generate and run a docker image. Use `grunt docker-build` or `grunt docker-run`
* Added kubernetes configurations for GCE.

NOTE: be careful using Grunt. I haven't fixed the source files yet so your changes will be lost!

Docker image is available, pushed to docker hub. `zquestz/cashaddress`