### PR TITLE
Force site to redirect to https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM nginx
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY cashaddress.org.html /usr/share/nginx/html/index.html

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    if ( $http_x_forwarded_proto = 'http' ) {
+        return 301 https://$host$request_uri;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+


### PR DESCRIPTION
Since this site generates wallets, we don't want anyone injecting malicious payloads into the page stealing the private keys.

This merely adds a custom nginx.conf so we always redirect to https on https://cashaddress.org.

NOTE: This is already live so you can test it. =)