### PR TITLE
Prefix all addresses and private keys with 'bitcoincash:'

### DIFF
--- a/cashaddress.org.html
+++ b/cashaddress.org.html
@@ -7467,6 +7467,10 @@ ninja.publicKey = {
 	<script type="text/javascript">
  ﻿(function (ninja) {
 	var qrC = ninja.qrCode = {
+		scheme: function() {
+			return 'bitcoincash:';
+		},
+
 		// determine which type number is big enough for the input text length
 		getTypeNumber: function (text) {
 			var lengthCalculation = text.length * 8 + 12; // length as calculated by the QRCode
@@ -7484,7 +7488,6 @@ ninja.publicKey = {
 		},
 
 		createCanvas: function (text, sizeMultiplier) {
-			sizeMultiplier = (sizeMultiplier == undefined) ? 2 : sizeMultiplier; // default 2
 			// create the qrcode itself
 			var typeNumber = qrC.getTypeNumber(text);
 			var qrcode = new QRCode(typeNumber, QRCode.ErrorCorrectLevel.H);
@@ -7521,12 +7524,26 @@ ninja.publicKey = {
 		//		"id1" is the id of a div element where you want a QRCode inserted.
 		//		"string1" is the string you want encoded into the QRCode.
 		showQrCode: function (keyValuePair, sizeMultiplier) {
+			sizeMultiplier = (sizeMultiplier == undefined) ? 2 : sizeMultiplier; // default 2
+
 			for (var key in keyValuePair) {
 				var value = keyValuePair[key];
+				origValueSize = value.length;
+				value = ninja.qrCode.scheme() + value;
+				valueSize = value.length;
+				adjustment = 0;
+				// Tweak adjustment for addresses and regular
+				// private keys.
+				if (value.length == 46) {
+					adjustment = 0.065;
+				} else if (value.length == 64) {
+					adjustment = 0.1;
+				}
+				multiplier = sizeMultiplier * ((origValueSize/valueSize) + adjustment);
 				try {
 					if (document.getElementById(key)) {
 						document.getElementById(key).innerHTML = "";
-						document.getElementById(key).appendChild(qrC.createCanvas(value, sizeMultiplier));
+						document.getElementById(key).appendChild(qrC.createCanvas(value, multiplier));
 					}
 				}
 				catch (e) {	}

--- a/src/ninja.qrcode.js
+++ b/src/ninja.qrcode.js
@@ -1,5 +1,9 @@
 ﻿(function (ninja) {
 	var qrC = ninja.qrCode = {
+		scheme: function() {
+			return 'bitcoincash:';
+		},
+
 		// determine which type number is big enough for the input text length
 		getTypeNumber: function (text) {
 			var lengthCalculation = text.length * 8 + 12; // length as calculated by the QRCode
@@ -17,7 +21,6 @@
 		},
 
 		createCanvas: function (text, sizeMultiplier) {
-			sizeMultiplier = (sizeMultiplier == undefined) ? 2 : sizeMultiplier; // default 2
 			// create the qrcode itself
 			var typeNumber = qrC.getTypeNumber(text);
 			var qrcode = new QRCode(typeNumber, QRCode.ErrorCorrectLevel.H);
@@ -54,12 +57,26 @@
 		//		"id1" is the id of a div element where you want a QRCode inserted.
 		//		"string1" is the string you want encoded into the QRCode.
 		showQrCode: function (keyValuePair, sizeMultiplier) {
+			sizeMultiplier = (sizeMultiplier == undefined) ? 2 : sizeMultiplier; // default 2
+
 			for (var key in keyValuePair) {
 				var value = keyValuePair[key];
+				origValueSize = value.length;
+				value = ninja.qrCode.scheme() + value;
+				valueSize = value.length;
+				adjustment = 0;
+				// Tweak adjustment for addresses and regular
+				// private keys.
+				if (value.length == 46) {
+					adjustment = 0.065;
+				} else if (value.length == 64) {
+					adjustment = 0.1;
+				}
+				multiplier = sizeMultiplier * ((origValueSize/valueSize) + adjustment);
 				try {
 					if (document.getElementById(key)) {
 						document.getElementById(key).innerHTML = "";
-						document.getElementById(key).appendChild(qrC.createCanvas(value, sizeMultiplier));
+						document.getElementById(key).appendChild(qrC.createCanvas(value, multiplier));
 					}
 				}
 				catch (e) {	}


### PR DESCRIPTION
After reading this article https://www.yours.org/content/increasing-merchant-adoption-of-bitcoin-cash-e3167e2fa326 I realized that we didn't prefix addresses and keys with `bitcoincash:` and that wallets might scan them as bitcoin addresses/keys.

This PR updates all generated QR codes to add the `bitcoincash:` scheme, and resizes the QR codes so they fit nicely in the layout.

PLEASE test and confirm this is working as expected and that the layouts look good. I will not merge until I get verification from others that this PR is ready!

Items tested:
1) Default Single Wallet
2) Default Paper Wallet
3) BIP38 Encrypted Paper Wallet.
4) Hidden art Paper Wallets (BIP38 and regular).