### PR TITLE
[Feature] Updated to use cashaddr addresses

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function (grunt) {
 				input: "./src/bitaddress-ui.html",
 				output: "./cashaddress.org.html",
 				tokens: [
+					{ token: "//bchaddr.js", file: "./src/bchaddr.js" },
 					{ token: "//biginteger.js", file: "./src/biginteger.js" },
 					{ token: "//bitcoinjs-lib.js", file: "./src/bitcoinjs-lib.js" },
 					{ token: "//bitcoinjs-lib.address.js", file: "./src/bitcoinjs-lib.address.js" },

--- a/cashaddress.org.html
+++ b/cashaddress.org.html
@@ -50,6 +50,9339 @@
 	<meta charset="utf-8">
 
 	<script type="text/javascript">
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.bchaddr = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+  // base-x encoding
+  // Forked from https://github.com/cryptocoinjs/bs58
+  // Originally written by Mike Hearn for BitcoinJ
+  // Copyright (c) 2011 Google Inc
+  // Ported to JavaScript by Stefan Thomas
+  // Merged Buffer refactorings from base58-native by Stephen Pair
+  // Copyright (c) 2013 BitPay Inc
+  
+  var Buffer = require('safe-buffer').Buffer
+  
+  module.exports = function base (ALPHABET) {
+    var ALPHABET_MAP = {}
+    var BASE = ALPHABET.length
+    var LEADER = ALPHABET.charAt(0)
+  
+    // pre-compute lookup table
+    for (var z = 0; z < ALPHABET.length; z++) {
+      var x = ALPHABET.charAt(z)
+  
+      if (ALPHABET_MAP[x] !== undefined) throw new TypeError(x + ' is ambiguous')
+      ALPHABET_MAP[x] = z
+    }
+  
+    function encode (source) {
+      if (source.length === 0) return ''
+  
+      var digits = [0]
+      for (var i = 0; i < source.length; ++i) {
+        for (var j = 0, carry = source[i]; j < digits.length; ++j) {
+          carry += digits[j] << 8
+          digits[j] = carry % BASE
+          carry = (carry / BASE) | 0
+        }
+  
+        while (carry > 0) {
+          digits.push(carry % BASE)
+          carry = (carry / BASE) | 0
+        }
+      }
+  
+      var string = ''
+  
+      // deal with leading zeros
+      for (var k = 0; source[k] === 0 && k < source.length - 1; ++k) string += LEADER
+      // convert digits to a string
+      for (var q = digits.length - 1; q >= 0; --q) string += ALPHABET[digits[q]]
+  
+      return string
+    }
+  
+    function decodeUnsafe (string) {
+      if (typeof string !== 'string') throw new TypeError('Expected String')
+      if (string.length === 0) return Buffer.allocUnsafe(0)
+  
+      var bytes = [0]
+      for (var i = 0; i < string.length; i++) {
+        var value = ALPHABET_MAP[string[i]]
+        if (value === undefined) return
+  
+        for (var j = 0, carry = value; j < bytes.length; ++j) {
+          carry += bytes[j] * BASE
+          bytes[j] = carry & 0xff
+          carry >>= 8
+        }
+  
+        while (carry > 0) {
+          bytes.push(carry & 0xff)
+          carry >>= 8
+        }
+      }
+  
+      // deal with leading zeros
+      for (var k = 0; string[k] === LEADER && k < string.length - 1; ++k) {
+        bytes.push(0)
+      }
+  
+      return Buffer.from(bytes.reverse())
+    }
+  
+    function decode (string) {
+      var buffer = decodeUnsafe(string)
+      if (buffer) return buffer
+  
+      throw new Error('Non-base' + BASE + ' character')
+    }
+  
+    return {
+      encode: encode,
+      decodeUnsafe: decodeUnsafe,
+      decode: decode
+    }
+  }
+  
+  },{"safe-buffer":40}],2:[function(require,module,exports){
+  'use strict'
+  
+  exports.byteLength = byteLength
+  exports.toByteArray = toByteArray
+  exports.fromByteArray = fromByteArray
+  
+  var lookup = []
+  var revLookup = []
+  var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
+  
+  var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  for (var i = 0, len = code.length; i < len; ++i) {
+    lookup[i] = code[i]
+    revLookup[code.charCodeAt(i)] = i
+  }
+  
+  revLookup['-'.charCodeAt(0)] = 62
+  revLookup['_'.charCodeAt(0)] = 63
+  
+  function placeHoldersCount (b64) {
+    var len = b64.length
+    if (len % 4 > 0) {
+      throw new Error('Invalid string. Length must be a multiple of 4')
+    }
+  
+    // the number of equal signs (place holders)
+    // if there are two placeholders, than the two characters before it
+    // represent one byte
+    // if there is only one, then the three characters before it represent 2 bytes
+    // this is just a cheap hack to not do indexOf twice
+    return b64[len - 2] === '=' ? 2 : b64[len - 1] === '=' ? 1 : 0
+  }
+  
+  function byteLength (b64) {
+    // base64 is 4/3 + up to two characters of the original data
+    return (b64.length * 3 / 4) - placeHoldersCount(b64)
+  }
+  
+  function toByteArray (b64) {
+    var i, l, tmp, placeHolders, arr
+    var len = b64.length
+    placeHolders = placeHoldersCount(b64)
+  
+    arr = new Arr((len * 3 / 4) - placeHolders)
+  
+    // if there are placeholders, only get up to the last complete 4 chars
+    l = placeHolders > 0 ? len - 4 : len
+  
+    var L = 0
+  
+    for (i = 0; i < l; i += 4) {
+      tmp = (revLookup[b64.charCodeAt(i)] << 18) | (revLookup[b64.charCodeAt(i + 1)] << 12) | (revLookup[b64.charCodeAt(i + 2)] << 6) | revLookup[b64.charCodeAt(i + 3)]
+      arr[L++] = (tmp >> 16) & 0xFF
+      arr[L++] = (tmp >> 8) & 0xFF
+      arr[L++] = tmp & 0xFF
+    }
+  
+    if (placeHolders === 2) {
+      tmp = (revLookup[b64.charCodeAt(i)] << 2) | (revLookup[b64.charCodeAt(i + 1)] >> 4)
+      arr[L++] = tmp & 0xFF
+    } else if (placeHolders === 1) {
+      tmp = (revLookup[b64.charCodeAt(i)] << 10) | (revLookup[b64.charCodeAt(i + 1)] << 4) | (revLookup[b64.charCodeAt(i + 2)] >> 2)
+      arr[L++] = (tmp >> 8) & 0xFF
+      arr[L++] = tmp & 0xFF
+    }
+  
+    return arr
+  }
+  
+  function tripletToBase64 (num) {
+    return lookup[num >> 18 & 0x3F] + lookup[num >> 12 & 0x3F] + lookup[num >> 6 & 0x3F] + lookup[num & 0x3F]
+  }
+  
+  function encodeChunk (uint8, start, end) {
+    var tmp
+    var output = []
+    for (var i = start; i < end; i += 3) {
+      tmp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+      output.push(tripletToBase64(tmp))
+    }
+    return output.join('')
+  }
+  
+  function fromByteArray (uint8) {
+    var tmp
+    var len = uint8.length
+    var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
+    var output = ''
+    var parts = []
+    var maxChunkLength = 16383 // must be multiple of 3
+  
+    // go through the array every three bytes, we'll deal with trailing stuff later
+    for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+      parts.push(encodeChunk(uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)))
+    }
+  
+    // pad the end with zeros, but make sure to not forget the extra bytes
+    if (extraBytes === 1) {
+      tmp = uint8[len - 1]
+      output += lookup[tmp >> 2]
+      output += lookup[(tmp << 4) & 0x3F]
+      output += '=='
+    } else if (extraBytes === 2) {
+      tmp = (uint8[len - 2] << 8) + (uint8[len - 1])
+      output += lookup[tmp >> 10]
+      output += lookup[(tmp >> 4) & 0x3F]
+      output += lookup[(tmp << 2) & 0x3F]
+      output += '='
+    }
+  
+    parts.push(output)
+  
+    return parts.join('')
+  }
+  
+  },{}],3:[function(require,module,exports){
+  var bigInt = (function (undefined) {
+      "use strict";
+  
+      var BASE = 1e7,
+          LOG_BASE = 7,
+          MAX_INT = 9007199254740992,
+          MAX_INT_ARR = smallToArray(MAX_INT),
+          LOG_MAX_INT = Math.log(MAX_INT);
+  
+      function Integer(v, radix) {
+          if (typeof v === "undefined") return Integer[0];
+          if (typeof radix !== "undefined") return +radix === 10 ? parseValue(v) : parseBase(v, radix);
+          return parseValue(v);
+      }
+  
+      function BigInteger(value, sign) {
+          this.value = value;
+          this.sign = sign;
+          this.isSmall = false;
+      }
+      BigInteger.prototype = Object.create(Integer.prototype);
+  
+      function SmallInteger(value) {
+          this.value = value;
+          this.sign = value < 0;
+          this.isSmall = true;
+      }
+      SmallInteger.prototype = Object.create(Integer.prototype);
+  
+      function isPrecise(n) {
+          return -MAX_INT < n && n < MAX_INT;
+      }
+  
+      function smallToArray(n) { // For performance reasons doesn't reference BASE, need to change this function if BASE changes
+          if (n < 1e7)
+              return [n];
+          if (n < 1e14)
+              return [n % 1e7, Math.floor(n / 1e7)];
+          return [n % 1e7, Math.floor(n / 1e7) % 1e7, Math.floor(n / 1e14)];
+      }
+  
+      function arrayToSmall(arr) { // If BASE changes this function may need to change
+          trim(arr);
+          var length = arr.length;
+          if (length < 4 && compareAbs(arr, MAX_INT_ARR) < 0) {
+              switch (length) {
+                  case 0: return 0;
+                  case 1: return arr[0];
+                  case 2: return arr[0] + arr[1] * BASE;
+                  default: return arr[0] + (arr[1] + arr[2] * BASE) * BASE;
+              }
+          }
+          return arr;
+      }
+  
+      function trim(v) {
+          var i = v.length;
+          while (v[--i] === 0);
+          v.length = i + 1;
+      }
+  
+      function createArray(length) { // function shamelessly stolen from Yaffle's library https://github.com/Yaffle/BigInteger
+          var x = new Array(length);
+          var i = -1;
+          while (++i < length) {
+              x[i] = 0;
+          }
+          return x;
+      }
+  
+      function truncate(n) {
+          if (n > 0) return Math.floor(n);
+          return Math.ceil(n);
+      }
+  
+      function add(a, b) { // assumes a and b are arrays with a.length >= b.length
+          var l_a = a.length,
+              l_b = b.length,
+              r = new Array(l_a),
+              carry = 0,
+              base = BASE,
+              sum, i;
+          for (i = 0; i < l_b; i++) {
+              sum = a[i] + b[i] + carry;
+              carry = sum >= base ? 1 : 0;
+              r[i] = sum - carry * base;
+          }
+          while (i < l_a) {
+              sum = a[i] + carry;
+              carry = sum === base ? 1 : 0;
+              r[i++] = sum - carry * base;
+          }
+          if (carry > 0) r.push(carry);
+          return r;
+      }
+  
+      function addAny(a, b) {
+          if (a.length >= b.length) return add(a, b);
+          return add(b, a);
+      }
+  
+      function addSmall(a, carry) { // assumes a is array, carry is number with 0 <= carry < MAX_INT
+          var l = a.length,
+              r = new Array(l),
+              base = BASE,
+              sum, i;
+          for (i = 0; i < l; i++) {
+              sum = a[i] - base + carry;
+              carry = Math.floor(sum / base);
+              r[i] = sum - carry * base;
+              carry += 1;
+          }
+          while (carry > 0) {
+              r[i++] = carry % base;
+              carry = Math.floor(carry / base);
+          }
+          return r;
+      }
+  
+      BigInteger.prototype.add = function (v) {
+          var n = parseValue(v);
+          if (this.sign !== n.sign) {
+              return this.subtract(n.negate());
+          }
+          var a = this.value, b = n.value;
+          if (n.isSmall) {
+              return new BigInteger(addSmall(a, Math.abs(b)), this.sign);
+          }
+          return new BigInteger(addAny(a, b), this.sign);
+      };
+      BigInteger.prototype.plus = BigInteger.prototype.add;
+  
+      SmallInteger.prototype.add = function (v) {
+          var n = parseValue(v);
+          var a = this.value;
+          if (a < 0 !== n.sign) {
+              return this.subtract(n.negate());
+          }
+          var b = n.value;
+          if (n.isSmall) {
+              if (isPrecise(a + b)) return new SmallInteger(a + b);
+              b = smallToArray(Math.abs(b));
+          }
+          return new BigInteger(addSmall(b, Math.abs(a)), a < 0);
+      };
+      SmallInteger.prototype.plus = SmallInteger.prototype.add;
+  
+      function subtract(a, b) { // assumes a and b are arrays with a >= b
+          var a_l = a.length,
+              b_l = b.length,
+              r = new Array(a_l),
+              borrow = 0,
+              base = BASE,
+              i, difference;
+          for (i = 0; i < b_l; i++) {
+              difference = a[i] - borrow - b[i];
+              if (difference < 0) {
+                  difference += base;
+                  borrow = 1;
+              } else borrow = 0;
+              r[i] = difference;
+          }
+          for (i = b_l; i < a_l; i++) {
+              difference = a[i] - borrow;
+              if (difference < 0) difference += base;
+              else {
+                  r[i++] = difference;
+                  break;
+              }
+              r[i] = difference;
+          }
+          for (; i < a_l; i++) {
+              r[i] = a[i];
+          }
+          trim(r);
+          return r;
+      }
+  
+      function subtractAny(a, b, sign) {
+          var value;
+          if (compareAbs(a, b) >= 0) {
+              value = subtract(a,b);
+          } else {
+              value = subtract(b, a);
+              sign = !sign;
+          }
+          value = arrayToSmall(value);
+          if (typeof value === "number") {
+              if (sign) value = -value;
+              return new SmallInteger(value);
+          }
+          return new BigInteger(value, sign);
+      }
+  
+      function subtractSmall(a, b, sign) { // assumes a is array, b is number with 0 <= b < MAX_INT
+          var l = a.length,
+              r = new Array(l),
+              carry = -b,
+              base = BASE,
+              i, difference;
+          for (i = 0; i < l; i++) {
+              difference = a[i] + carry;
+              carry = Math.floor(difference / base);
+              difference %= base;
+              r[i] = difference < 0 ? difference + base : difference;
+          }
+          r = arrayToSmall(r);
+          if (typeof r === "number") {
+              if (sign) r = -r;
+              return new SmallInteger(r);
+          } return new BigInteger(r, sign);
+      }
+  
+      BigInteger.prototype.subtract = function (v) {
+          var n = parseValue(v);
+          if (this.sign !== n.sign) {
+              return this.add(n.negate());
+          }
+          var a = this.value, b = n.value;
+          if (n.isSmall)
+              return subtractSmall(a, Math.abs(b), this.sign);
+          return subtractAny(a, b, this.sign);
+      };
+      BigInteger.prototype.minus = BigInteger.prototype.subtract;
+  
+      SmallInteger.prototype.subtract = function (v) {
+          var n = parseValue(v);
+          var a = this.value;
+          if (a < 0 !== n.sign) {
+              return this.add(n.negate());
+          }
+          var b = n.value;
+          if (n.isSmall) {
+              return new SmallInteger(a - b);
+          }
+          return subtractSmall(b, Math.abs(a), a >= 0);
+      };
+      SmallInteger.prototype.minus = SmallInteger.prototype.subtract;
+  
+      BigInteger.prototype.negate = function () {
+          return new BigInteger(this.value, !this.sign);
+      };
+      SmallInteger.prototype.negate = function () {
+          var sign = this.sign;
+          var small = new SmallInteger(-this.value);
+          small.sign = !sign;
+          return small;
+      };
+  
+      BigInteger.prototype.abs = function () {
+          return new BigInteger(this.value, false);
+      };
+      SmallInteger.prototype.abs = function () {
+          return new SmallInteger(Math.abs(this.value));
+      };
+  
+      function multiplyLong(a, b) {
+          var a_l = a.length,
+              b_l = b.length,
+              l = a_l + b_l,
+              r = createArray(l),
+              base = BASE,
+              product, carry, i, a_i, b_j;
+          for (i = 0; i < a_l; ++i) {
+              a_i = a[i];
+              for (var j = 0; j < b_l; ++j) {
+                  b_j = b[j];
+                  product = a_i * b_j + r[i + j];
+                  carry = Math.floor(product / base);
+                  r[i + j] = product - carry * base;
+                  r[i + j + 1] += carry;
+              }
+          }
+          trim(r);
+          return r;
+      }
+  
+      function multiplySmall(a, b) { // assumes a is array, b is number with |b| < BASE
+          var l = a.length,
+              r = new Array(l),
+              base = BASE,
+              carry = 0,
+              product, i;
+          for (i = 0; i < l; i++) {
+              product = a[i] * b + carry;
+              carry = Math.floor(product / base);
+              r[i] = product - carry * base;
+          }
+          while (carry > 0) {
+              r[i++] = carry % base;
+              carry = Math.floor(carry / base);
+          }
+          return r;
+      }
+  
+      function shiftLeft(x, n) {
+          var r = [];
+          while (n-- > 0) r.push(0);
+          return r.concat(x);
+      }
+  
+      function multiplyKaratsuba(x, y) {
+          var n = Math.max(x.length, y.length);
+  
+          if (n <= 30) return multiplyLong(x, y);
+          n = Math.ceil(n / 2);
+  
+          var b = x.slice(n),
+              a = x.slice(0, n),
+              d = y.slice(n),
+              c = y.slice(0, n);
+  
+          var ac = multiplyKaratsuba(a, c),
+              bd = multiplyKaratsuba(b, d),
+              abcd = multiplyKaratsuba(addAny(a, b), addAny(c, d));
+  
+          var product = addAny(addAny(ac, shiftLeft(subtract(subtract(abcd, ac), bd), n)), shiftLeft(bd, 2 * n));
+          trim(product);
+          return product;
+      }
+  
+      // The following function is derived from a surface fit of a graph plotting the performance difference
+      // between long multiplication and karatsuba multiplication versus the lengths of the two arrays.
+      function useKaratsuba(l1, l2) {
+          return -0.012 * l1 - 0.012 * l2 + 0.000015 * l1 * l2 > 0;
+      }
+  
+      BigInteger.prototype.multiply = function (v) {
+          var n = parseValue(v),
+              a = this.value, b = n.value,
+              sign = this.sign !== n.sign,
+              abs;
+          if (n.isSmall) {
+              if (b === 0) return Integer[0];
+              if (b === 1) return this;
+              if (b === -1) return this.negate();
+              abs = Math.abs(b);
+              if (abs < BASE) {
+                  return new BigInteger(multiplySmall(a, abs), sign);
+              }
+              b = smallToArray(abs);
+          }
+          if (useKaratsuba(a.length, b.length)) // Karatsuba is only faster for certain array sizes
+              return new BigInteger(multiplyKaratsuba(a, b), sign);
+          return new BigInteger(multiplyLong(a, b), sign);
+      };
+  
+      BigInteger.prototype.times = BigInteger.prototype.multiply;
+  
+      function multiplySmallAndArray(a, b, sign) { // a >= 0
+          if (a < BASE) {
+              return new BigInteger(multiplySmall(b, a), sign);
+          }
+          return new BigInteger(multiplyLong(b, smallToArray(a)), sign);
+      }
+      SmallInteger.prototype._multiplyBySmall = function (a) {
+              if (isPrecise(a.value * this.value)) {
+                  return new SmallInteger(a.value * this.value);
+              }
+              return multiplySmallAndArray(Math.abs(a.value), smallToArray(Math.abs(this.value)), this.sign !== a.sign);
+      };
+      BigInteger.prototype._multiplyBySmall = function (a) {
+              if (a.value === 0) return Integer[0];
+              if (a.value === 1) return this;
+              if (a.value === -1) return this.negate();
+              return multiplySmallAndArray(Math.abs(a.value), this.value, this.sign !== a.sign);
+      };
+      SmallInteger.prototype.multiply = function (v) {
+          return parseValue(v)._multiplyBySmall(this);
+      };
+      SmallInteger.prototype.times = SmallInteger.prototype.multiply;
+  
+      function square(a) {
+          var l = a.length,
+              r = createArray(l + l),
+              base = BASE,
+              product, carry, i, a_i, a_j;
+          for (i = 0; i < l; i++) {
+              a_i = a[i];
+              for (var j = 0; j < l; j++) {
+                  a_j = a[j];
+                  product = a_i * a_j + r[i + j];
+                  carry = Math.floor(product / base);
+                  r[i + j] = product - carry * base;
+                  r[i + j + 1] += carry;
+              }
+          }
+          trim(r);
+          return r;
+      }
+  
+      BigInteger.prototype.square = function () {
+          return new BigInteger(square(this.value), false);
+      };
+  
+      SmallInteger.prototype.square = function () {
+          var value = this.value * this.value;
+          if (isPrecise(value)) return new SmallInteger(value);
+          return new BigInteger(square(smallToArray(Math.abs(this.value))), false);
+      };
+  
+      function divMod1(a, b) { // Left over from previous version. Performs faster than divMod2 on smaller input sizes.
+          var a_l = a.length,
+              b_l = b.length,
+              base = BASE,
+              result = createArray(b.length),
+              divisorMostSignificantDigit = b[b_l - 1],
+              // normalization
+              lambda = Math.ceil(base / (2 * divisorMostSignificantDigit)),
+              remainder = multiplySmall(a, lambda),
+              divisor = multiplySmall(b, lambda),
+              quotientDigit, shift, carry, borrow, i, l, q;
+          if (remainder.length <= a_l) remainder.push(0);
+          divisor.push(0);
+          divisorMostSignificantDigit = divisor[b_l - 1];
+          for (shift = a_l - b_l; shift >= 0; shift--) {
+              quotientDigit = base - 1;
+              if (remainder[shift + b_l] !== divisorMostSignificantDigit) {
+                quotientDigit = Math.floor((remainder[shift + b_l] * base + remainder[shift + b_l - 1]) / divisorMostSignificantDigit);
+              }
+              // quotientDigit <= base - 1
+              carry = 0;
+              borrow = 0;
+              l = divisor.length;
+              for (i = 0; i < l; i++) {
+                  carry += quotientDigit * divisor[i];
+                  q = Math.floor(carry / base);
+                  borrow += remainder[shift + i] - (carry - q * base);
+                  carry = q;
+                  if (borrow < 0) {
+                      remainder[shift + i] = borrow + base;
+                      borrow = -1;
+                  } else {
+                      remainder[shift + i] = borrow;
+                      borrow = 0;
+                  }
+              }
+              while (borrow !== 0) {
+                  quotientDigit -= 1;
+                  carry = 0;
+                  for (i = 0; i < l; i++) {
+                      carry += remainder[shift + i] - base + divisor[i];
+                      if (carry < 0) {
+                          remainder[shift + i] = carry + base;
+                          carry = 0;
+                      } else {
+                          remainder[shift + i] = carry;
+                          carry = 1;
+                      }
+                  }
+                  borrow += carry;
+              }
+              result[shift] = quotientDigit;
+          }
+          // denormalization
+          remainder = divModSmall(remainder, lambda)[0];
+          return [arrayToSmall(result), arrayToSmall(remainder)];
+      }
+  
+      function divMod2(a, b) { // Implementation idea shamelessly stolen from Silent Matt's library http://silentmatt.com/biginteger/
+          // Performs faster than divMod1 on larger input sizes.
+          var a_l = a.length,
+              b_l = b.length,
+              result = [],
+              part = [],
+              base = BASE,
+              guess, xlen, highx, highy, check;
+          while (a_l) {
+              part.unshift(a[--a_l]);
+              trim(part);
+              if (compareAbs(part, b) < 0) {
+                  result.push(0);
+                  continue;
+              }
+              xlen = part.length;
+              highx = part[xlen - 1] * base + part[xlen - 2];
+              highy = b[b_l - 1] * base + b[b_l - 2];
+              if (xlen > b_l) {
+                  highx = (highx + 1) * base;
+              }
+              guess = Math.ceil(highx / highy);
+              do {
+                  check = multiplySmall(b, guess);
+                  if (compareAbs(check, part) <= 0) break;
+                  guess--;
+              } while (guess);
+              result.push(guess);
+              part = subtract(part, check);
+          }
+          result.reverse();
+          return [arrayToSmall(result), arrayToSmall(part)];
+      }
+  
+      function divModSmall(value, lambda) {
+          var length = value.length,
+              quotient = createArray(length),
+              base = BASE,
+              i, q, remainder, divisor;
+          remainder = 0;
+          for (i = length - 1; i >= 0; --i) {
+              divisor = remainder * base + value[i];
+              q = truncate(divisor / lambda);
+              remainder = divisor - q * lambda;
+              quotient[i] = q | 0;
+          }
+          return [quotient, remainder | 0];
+      }
+  
+      function divModAny(self, v) {
+          var value, n = parseValue(v);
+          var a = self.value, b = n.value;
+          var quotient;
+          if (b === 0) throw new Error("Cannot divide by zero");
+          if (self.isSmall) {
+              if (n.isSmall) {
+                  return [new SmallInteger(truncate(a / b)), new SmallInteger(a % b)];
+              }
+              return [Integer[0], self];
+          }
+          if (n.isSmall) {
+              if (b === 1) return [self, Integer[0]];
+              if (b == -1) return [self.negate(), Integer[0]];
+              var abs = Math.abs(b);
+              if (abs < BASE) {
+                  value = divModSmall(a, abs);
+                  quotient = arrayToSmall(value[0]);
+                  var remainder = value[1];
+                  if (self.sign) remainder = -remainder;
+                  if (typeof quotient === "number") {
+                      if (self.sign !== n.sign) quotient = -quotient;
+                      return [new SmallInteger(quotient), new SmallInteger(remainder)];
+                  }
+                  return [new BigInteger(quotient, self.sign !== n.sign), new SmallInteger(remainder)];
+              }
+              b = smallToArray(abs);
+          }
+          var comparison = compareAbs(a, b);
+          if (comparison === -1) return [Integer[0], self];
+          if (comparison === 0) return [Integer[self.sign === n.sign ? 1 : -1], Integer[0]];
+  
+          // divMod1 is faster on smaller input sizes
+          if (a.length + b.length <= 200)
+              value = divMod1(a, b);
+          else value = divMod2(a, b);
+  
+          quotient = value[0];
+          var qSign = self.sign !== n.sign,
+              mod = value[1],
+              mSign = self.sign;
+          if (typeof quotient === "number") {
+              if (qSign) quotient = -quotient;
+              quotient = new SmallInteger(quotient);
+          } else quotient = new BigInteger(quotient, qSign);
+          if (typeof mod === "number") {
+              if (mSign) mod = -mod;
+              mod = new SmallInteger(mod);
+          } else mod = new BigInteger(mod, mSign);
+          return [quotient, mod];
+      }
+  
+      BigInteger.prototype.divmod = function (v) {
+          var result = divModAny(this, v);
+          return {
+              quotient: result[0],
+              remainder: result[1]
+          };
+      };
+      SmallInteger.prototype.divmod = BigInteger.prototype.divmod;
+  
+      BigInteger.prototype.divide = function (v) {
+          return divModAny(this, v)[0];
+      };
+      SmallInteger.prototype.over = SmallInteger.prototype.divide = BigInteger.prototype.over = BigInteger.prototype.divide;
+  
+      BigInteger.prototype.mod = function (v) {
+          return divModAny(this, v)[1];
+      };
+      SmallInteger.prototype.remainder = SmallInteger.prototype.mod = BigInteger.prototype.remainder = BigInteger.prototype.mod;
+  
+      BigInteger.prototype.pow = function (v) {
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value,
+              value, x, y;
+          if (b === 0) return Integer[1];
+          if (a === 0) return Integer[0];
+          if (a === 1) return Integer[1];
+          if (a === -1) return n.isEven() ? Integer[1] : Integer[-1];
+          if (n.sign) {
+              return Integer[0];
+          }
+          if (!n.isSmall) throw new Error("The exponent " + n.toString() + " is too large.");
+          if (this.isSmall) {
+              if (isPrecise(value = Math.pow(a, b)))
+                  return new SmallInteger(truncate(value));
+          }
+          x = this;
+          y = Integer[1];
+          while (true) {
+              if (b & 1 === 1) {
+                  y = y.times(x);
+                  --b;
+              }
+              if (b === 0) break;
+              b /= 2;
+              x = x.square();
+          }
+          return y;
+      };
+      SmallInteger.prototype.pow = BigInteger.prototype.pow;
+  
+      BigInteger.prototype.modPow = function (exp, mod) {
+          exp = parseValue(exp);
+          mod = parseValue(mod);
+          if (mod.isZero()) throw new Error("Cannot take modPow with modulus 0");
+          var r = Integer[1],
+              base = this.mod(mod);
+          while (exp.isPositive()) {
+              if (base.isZero()) return Integer[0];
+              if (exp.isOdd()) r = r.multiply(base).mod(mod);
+              exp = exp.divide(2);
+              base = base.square().mod(mod);
+          }
+          return r;
+      };
+      SmallInteger.prototype.modPow = BigInteger.prototype.modPow;
+  
+      function compareAbs(a, b) {
+          if (a.length !== b.length) {
+              return a.length > b.length ? 1 : -1;
+          }
+          for (var i = a.length - 1; i >= 0; i--) {
+              if (a[i] !== b[i]) return a[i] > b[i] ? 1 : -1;
+          }
+          return 0;
+      }
+  
+      BigInteger.prototype.compareAbs = function (v) {
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value;
+          if (n.isSmall) return 1;
+          return compareAbs(a, b);
+      };
+      SmallInteger.prototype.compareAbs = function (v) {
+          var n = parseValue(v),
+              a = Math.abs(this.value),
+              b = n.value;
+          if (n.isSmall) {
+              b = Math.abs(b);
+              return a === b ? 0 : a > b ? 1 : -1;
+          }
+          return -1;
+      };
+  
+      BigInteger.prototype.compare = function (v) {
+          // See discussion about comparison with Infinity:
+          // https://github.com/peterolson/BigInteger.js/issues/61
+          if (v === Infinity) {
+              return -1;
+          }
+          if (v === -Infinity) {
+              return 1;
+          }
+  
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value;
+          if (this.sign !== n.sign) {
+              return n.sign ? 1 : -1;
+          }
+          if (n.isSmall) {
+              return this.sign ? -1 : 1;
+          }
+          return compareAbs(a, b) * (this.sign ? -1 : 1);
+      };
+      BigInteger.prototype.compareTo = BigInteger.prototype.compare;
+  
+      SmallInteger.prototype.compare = function (v) {
+          if (v === Infinity) {
+              return -1;
+          }
+          if (v === -Infinity) {
+              return 1;
+          }
+  
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value;
+          if (n.isSmall) {
+              return a == b ? 0 : a > b ? 1 : -1;
+          }
+          if (a < 0 !== n.sign) {
+              return a < 0 ? -1 : 1;
+          }
+          return a < 0 ? 1 : -1;
+      };
+      SmallInteger.prototype.compareTo = SmallInteger.prototype.compare;
+  
+      BigInteger.prototype.equals = function (v) {
+          return this.compare(v) === 0;
+      };
+      SmallInteger.prototype.eq = SmallInteger.prototype.equals = BigInteger.prototype.eq = BigInteger.prototype.equals;
+  
+      BigInteger.prototype.notEquals = function (v) {
+          return this.compare(v) !== 0;
+      };
+      SmallInteger.prototype.neq = SmallInteger.prototype.notEquals = BigInteger.prototype.neq = BigInteger.prototype.notEquals;
+  
+      BigInteger.prototype.greater = function (v) {
+          return this.compare(v) > 0;
+      };
+      SmallInteger.prototype.gt = SmallInteger.prototype.greater = BigInteger.prototype.gt = BigInteger.prototype.greater;
+  
+      BigInteger.prototype.lesser = function (v) {
+          return this.compare(v) < 0;
+      };
+      SmallInteger.prototype.lt = SmallInteger.prototype.lesser = BigInteger.prototype.lt = BigInteger.prototype.lesser;
+  
+      BigInteger.prototype.greaterOrEquals = function (v) {
+          return this.compare(v) >= 0;
+      };
+      SmallInteger.prototype.geq = SmallInteger.prototype.greaterOrEquals = BigInteger.prototype.geq = BigInteger.prototype.greaterOrEquals;
+  
+      BigInteger.prototype.lesserOrEquals = function (v) {
+          return this.compare(v) <= 0;
+      };
+      SmallInteger.prototype.leq = SmallInteger.prototype.lesserOrEquals = BigInteger.prototype.leq = BigInteger.prototype.lesserOrEquals;
+  
+      BigInteger.prototype.isEven = function () {
+          return (this.value[0] & 1) === 0;
+      };
+      SmallInteger.prototype.isEven = function () {
+          return (this.value & 1) === 0;
+      };
+  
+      BigInteger.prototype.isOdd = function () {
+          return (this.value[0] & 1) === 1;
+      };
+      SmallInteger.prototype.isOdd = function () {
+          return (this.value & 1) === 1;
+      };
+  
+      BigInteger.prototype.isPositive = function () {
+          return !this.sign;
+      };
+      SmallInteger.prototype.isPositive = function () {
+          return this.value > 0;
+      };
+  
+      BigInteger.prototype.isNegative = function () {
+          return this.sign;
+      };
+      SmallInteger.prototype.isNegative = function () {
+          return this.value < 0;
+      };
+  
+      BigInteger.prototype.isUnit = function () {
+          return false;
+      };
+      SmallInteger.prototype.isUnit = function () {
+          return Math.abs(this.value) === 1;
+      };
+  
+      BigInteger.prototype.isZero = function () {
+          return false;
+      };
+      SmallInteger.prototype.isZero = function () {
+          return this.value === 0;
+      };
+      BigInteger.prototype.isDivisibleBy = function (v) {
+          var n = parseValue(v);
+          var value = n.value;
+          if (value === 0) return false;
+          if (value === 1) return true;
+          if (value === 2) return this.isEven();
+          return this.mod(n).equals(Integer[0]);
+      };
+      SmallInteger.prototype.isDivisibleBy = BigInteger.prototype.isDivisibleBy;
+  
+      function isBasicPrime(v) {
+          var n = v.abs();
+          if (n.isUnit()) return false;
+          if (n.equals(2) || n.equals(3) || n.equals(5)) return true;
+          if (n.isEven() || n.isDivisibleBy(3) || n.isDivisibleBy(5)) return false;
+          if (n.lesser(25)) return true;
+          // we don't know if it's prime: let the other functions figure it out
+      }
+  
+      BigInteger.prototype.isPrime = function () {
+          var isPrime = isBasicPrime(this);
+          if (isPrime !== undefined) return isPrime;
+          var n = this.abs(),
+              nPrev = n.prev();
+          var a = [2, 3, 5, 7, 11, 13, 17, 19],
+              b = nPrev,
+              d, t, i, x;
+          while (b.isEven()) b = b.divide(2);
+          for (i = 0; i < a.length; i++) {
+              x = bigInt(a[i]).modPow(b, n);
+              if (x.equals(Integer[1]) || x.equals(nPrev)) continue;
+              for (t = true, d = b; t && d.lesser(nPrev) ; d = d.multiply(2)) {
+                  x = x.square().mod(n);
+                  if (x.equals(nPrev)) t = false;
+              }
+              if (t) return false;
+          }
+          return true;
+      };
+      SmallInteger.prototype.isPrime = BigInteger.prototype.isPrime;
+  
+      BigInteger.prototype.isProbablePrime = function (iterations) {
+          var isPrime = isBasicPrime(this);
+          if (isPrime !== undefined) return isPrime;
+          var n = this.abs();
+          var t = iterations === undefined ? 5 : iterations;
+          // use the Fermat primality test
+          for (var i = 0; i < t; i++) {
+              var a = bigInt.randBetween(2, n.minus(2));
+              if (!a.modPow(n.prev(), n).isUnit()) return false; // definitely composite
+          }
+          return true; // large chance of being prime
+      };
+      SmallInteger.prototype.isProbablePrime = BigInteger.prototype.isProbablePrime;
+  
+      BigInteger.prototype.modInv = function (n) {
+          var t = bigInt.zero, newT = bigInt.one, r = parseValue(n), newR = this.abs(), q, lastT, lastR;
+          while (!newR.equals(bigInt.zero)) {
+              q = r.divide(newR);
+              lastT = t;
+              lastR = r;
+              t = newT;
+              r = newR;
+              newT = lastT.subtract(q.multiply(newT));
+              newR = lastR.subtract(q.multiply(newR));
+          }
+          if (!r.equals(1)) throw new Error(this.toString() + " and " + n.toString() + " are not co-prime");
+          if (t.compare(0) === -1) {
+              t = t.add(n);
+          }
+          if (this.isNegative()) {
+              return t.negate();
+          }
+          return t;
+      };
+  
+      SmallInteger.prototype.modInv = BigInteger.prototype.modInv;
+  
+      BigInteger.prototype.next = function () {
+          var value = this.value;
+          if (this.sign) {
+              return subtractSmall(value, 1, this.sign);
+          }
+          return new BigInteger(addSmall(value, 1), this.sign);
+      };
+      SmallInteger.prototype.next = function () {
+          var value = this.value;
+          if (value + 1 < MAX_INT) return new SmallInteger(value + 1);
+          return new BigInteger(MAX_INT_ARR, false);
+      };
+  
+      BigInteger.prototype.prev = function () {
+          var value = this.value;
+          if (this.sign) {
+              return new BigInteger(addSmall(value, 1), true);
+          }
+          return subtractSmall(value, 1, this.sign);
+      };
+      SmallInteger.prototype.prev = function () {
+          var value = this.value;
+          if (value - 1 > -MAX_INT) return new SmallInteger(value - 1);
+          return new BigInteger(MAX_INT_ARR, true);
+      };
+  
+      var powersOfTwo = [1];
+      while (2 * powersOfTwo[powersOfTwo.length - 1] <= BASE) powersOfTwo.push(2 * powersOfTwo[powersOfTwo.length - 1]);
+      var powers2Length = powersOfTwo.length, highestPower2 = powersOfTwo[powers2Length - 1];
+  
+      function shift_isSmall(n) {
+          return ((typeof n === "number" || typeof n === "string") && +Math.abs(n) <= BASE) ||
+              (n instanceof BigInteger && n.value.length <= 1);
+      }
+  
+      BigInteger.prototype.shiftLeft = function (n) {
+          if (!shift_isSmall(n)) {
+              throw new Error(String(n) + " is too large for shifting.");
+          }
+          n = +n;
+          if (n < 0) return this.shiftRight(-n);
+          var result = this;
+          while (n >= powers2Length) {
+              result = result.multiply(highestPower2);
+              n -= powers2Length - 1;
+          }
+          return result.multiply(powersOfTwo[n]);
+      };
+      SmallInteger.prototype.shiftLeft = BigInteger.prototype.shiftLeft;
+  
+      BigInteger.prototype.shiftRight = function (n) {
+          var remQuo;
+          if (!shift_isSmall(n)) {
+              throw new Error(String(n) + " is too large for shifting.");
+          }
+          n = +n;
+          if (n < 0) return this.shiftLeft(-n);
+          var result = this;
+          while (n >= powers2Length) {
+              if (result.isZero()) return result;
+              remQuo = divModAny(result, highestPower2);
+              result = remQuo[1].isNegative() ? remQuo[0].prev() : remQuo[0];
+              n -= powers2Length - 1;
+          }
+          remQuo = divModAny(result, powersOfTwo[n]);
+          return remQuo[1].isNegative() ? remQuo[0].prev() : remQuo[0];
+      };
+      SmallInteger.prototype.shiftRight = BigInteger.prototype.shiftRight;
+  
+      function bitwise(x, y, fn) {
+          y = parseValue(y);
+          var xSign = x.isNegative(), ySign = y.isNegative();
+          var xRem = xSign ? x.not() : x,
+              yRem = ySign ? y.not() : y;
+          var xDigit = 0, yDigit = 0;
+          var xDivMod = null, yDivMod = null;
+          var result = [];
+          while (!xRem.isZero() || !yRem.isZero()) {
+              xDivMod = divModAny(xRem, highestPower2);
+              xDigit = xDivMod[1].toJSNumber();
+              if (xSign) {
+                  xDigit = highestPower2 - 1 - xDigit; // two's complement for negative numbers
+              }
+  
+              yDivMod = divModAny(yRem, highestPower2);
+              yDigit = yDivMod[1].toJSNumber();
+              if (ySign) {
+                  yDigit = highestPower2 - 1 - yDigit; // two's complement for negative numbers
+              }
+  
+              xRem = xDivMod[0];
+              yRem = yDivMod[0];
+              result.push(fn(xDigit, yDigit));
+          }
+          var sum = fn(xSign ? 1 : 0, ySign ? 1 : 0) !== 0 ? bigInt(-1) : bigInt(0);
+          for (var i = result.length - 1; i >= 0; i -= 1) {
+              sum = sum.multiply(highestPower2).add(bigInt(result[i]));
+          }
+          return sum;
+      }
+  
+      BigInteger.prototype.not = function () {
+          return this.negate().prev();
+      };
+      SmallInteger.prototype.not = BigInteger.prototype.not;
+  
+      BigInteger.prototype.and = function (n) {
+          return bitwise(this, n, function (a, b) { return a & b; });
+      };
+      SmallInteger.prototype.and = BigInteger.prototype.and;
+  
+      BigInteger.prototype.or = function (n) {
+          return bitwise(this, n, function (a, b) { return a | b; });
+      };
+      SmallInteger.prototype.or = BigInteger.prototype.or;
+  
+      BigInteger.prototype.xor = function (n) {
+          return bitwise(this, n, function (a, b) { return a ^ b; });
+      };
+      SmallInteger.prototype.xor = BigInteger.prototype.xor;
+  
+      var LOBMASK_I = 1 << 30, LOBMASK_BI = (BASE & -BASE) * (BASE & -BASE) | LOBMASK_I;
+      function roughLOB(n) { // get lowestOneBit (rough)
+          // SmallInteger: return Min(lowestOneBit(n), 1 << 30)
+          // BigInteger: return Min(lowestOneBit(n), 1 << 14) [BASE=1e7]
+          var v = n.value, x = typeof v === "number" ? v | LOBMASK_I : v[0] + v[1] * BASE | LOBMASK_BI;
+          return x & -x;
+      }
+  
+      function max(a, b) {
+          a = parseValue(a);
+          b = parseValue(b);
+          return a.greater(b) ? a : b;
+      }
+      function min(a, b) {
+          a = parseValue(a);
+          b = parseValue(b);
+          return a.lesser(b) ? a : b;
+      }
+      function gcd(a, b) {
+          a = parseValue(a).abs();
+          b = parseValue(b).abs();
+          if (a.equals(b)) return a;
+          if (a.isZero()) return b;
+          if (b.isZero()) return a;
+          var c = Integer[1], d, t;
+          while (a.isEven() && b.isEven()) {
+              d = Math.min(roughLOB(a), roughLOB(b));
+              a = a.divide(d);
+              b = b.divide(d);
+              c = c.multiply(d);
+          }
+          while (a.isEven()) {
+              a = a.divide(roughLOB(a));
+          }
+          do {
+              while (b.isEven()) {
+                  b = b.divide(roughLOB(b));
+              }
+              if (a.greater(b)) {
+                  t = b; b = a; a = t;
+              }
+              b = b.subtract(a);
+          } while (!b.isZero());
+          return c.isUnit() ? a : a.multiply(c);
+      }
+      function lcm(a, b) {
+          a = parseValue(a).abs();
+          b = parseValue(b).abs();
+          return a.divide(gcd(a, b)).multiply(b);
+      }
+      function randBetween(a, b) {
+          a = parseValue(a);
+          b = parseValue(b);
+          var low = min(a, b), high = max(a, b);
+          var range = high.subtract(low).add(1);
+          if (range.isSmall) return low.add(Math.floor(Math.random() * range));
+          var length = range.value.length - 1;
+          var result = [], restricted = true;
+          for (var i = length; i >= 0; i--) {
+              var top = restricted ? range.value[i] : BASE;
+              var digit = truncate(Math.random() * top);
+              result.unshift(digit);
+              if (digit < top) restricted = false;
+          }
+          result = arrayToSmall(result);
+          return low.add(typeof result === "number" ? new SmallInteger(result) : new BigInteger(result, false));
+      }
+      var parseBase = function (text, base) {
+          var length = text.length;
+      var i;
+      var absBase = Math.abs(base);
+      for(var i = 0; i < length; i++) {
+        var c = text[i].toLowerCase();
+        if(c === "-") continue;
+        if(/[a-z0-9]/.test(c)) {
+            if(/[0-9]/.test(c) && +c >= absBase) {
+            if(c === "1" && absBase === 1) continue;
+                      throw new Error(c + " is not a valid digit in base " + base + ".");
+          } else if(c.charCodeAt(0) - 87 >= absBase) {
+            throw new Error(c + " is not a valid digit in base " + base + ".");
+          }
+        }
+      }
+          if (2 <= base && base <= 36) {
+              if (length <= LOG_MAX_INT / Math.log(base)) {
+          var result = parseInt(text, base);
+          if(isNaN(result)) {
+            throw new Error(c + " is not a valid digit in base " + base + ".");
+          }
+                  return new SmallInteger(parseInt(text, base));
+              }
+          }
+          base = parseValue(base);
+          var digits = [];
+          var isNegative = text[0] === "-";
+          for (i = isNegative ? 1 : 0; i < text.length; i++) {
+              var c = text[i].toLowerCase(),
+                  charCode = c.charCodeAt(0);
+              if (48 <= charCode && charCode <= 57) digits.push(parseValue(c));
+              else if (97 <= charCode && charCode <= 122) digits.push(parseValue(c.charCodeAt(0) - 87));
+              else if (c === "<") {
+                  var start = i;
+                  do { i++; } while (text[i] !== ">");
+                  digits.push(parseValue(text.slice(start + 1, i)));
+              }
+              else throw new Error(c + " is not a valid character");
+          }
+          return parseBaseFromArray(digits, base, isNegative);
+      };
+  
+      function parseBaseFromArray(digits, base, isNegative) {
+          var val = Integer[0], pow = Integer[1], i;
+          for (i = digits.length - 1; i >= 0; i--) {
+              val = val.add(digits[i].times(pow));
+              pow = pow.times(base);
+          }
+          return isNegative ? val.negate() : val;
+      }
+  
+      function stringify(digit) {
+          var v = digit.value;
+          if (typeof v === "number") v = [v];
+          if (v.length === 1 && v[0] <= 35) {
+              return "0123456789abcdefghijklmnopqrstuvwxyz".charAt(v[0]);
+          }
+          return "<" + v + ">";
+      }
+      function toBase(n, base) {
+          base = bigInt(base);
+          if (base.isZero()) {
+              if (n.isZero()) return "0";
+              throw new Error("Cannot convert nonzero numbers to base 0.");
+          }
+          if (base.equals(-1)) {
+              if (n.isZero()) return "0";
+              if (n.isNegative()) return new Array(1 - n).join("10");
+              return "1" + new Array(+n).join("01");
+          }
+          var minusSign = "";
+          if (n.isNegative() && base.isPositive()) {
+              minusSign = "-";
+              n = n.abs();
+          }
+          if (base.equals(1)) {
+              if (n.isZero()) return "0";
+              return minusSign + new Array(+n + 1).join(1);
+          }
+          var out = [];
+          var left = n, divmod;
+          while (left.isNegative() || left.compareAbs(base) >= 0) {
+              divmod = left.divmod(base);
+              left = divmod.quotient;
+              var digit = divmod.remainder;
+              if (digit.isNegative()) {
+                  digit = base.minus(digit).abs();
+                  left = left.next();
+              }
+              out.push(stringify(digit));
+          }
+          out.push(stringify(left));
+          return minusSign + out.reverse().join("");
+      }
+  
+      BigInteger.prototype.toString = function (radix) {
+          if (radix === undefined) radix = 10;
+          if (radix !== 10) return toBase(this, radix);
+          var v = this.value, l = v.length, str = String(v[--l]), zeros = "0000000", digit;
+          while (--l >= 0) {
+              digit = String(v[l]);
+              str += zeros.slice(digit.length) + digit;
+          }
+          var sign = this.sign ? "-" : "";
+          return sign + str;
+      };
+  
+      SmallInteger.prototype.toString = function (radix) {
+          if (radix === undefined) radix = 10;
+          if (radix != 10) return toBase(this, radix);
+          return String(this.value);
+      };
+      BigInteger.prototype.toJSON = SmallInteger.prototype.toJSON = function() { return this.toString(); }
+  
+      BigInteger.prototype.valueOf = function () {
+          return +this.toString();
+      };
+      BigInteger.prototype.toJSNumber = BigInteger.prototype.valueOf;
+  
+      SmallInteger.prototype.valueOf = function () {
+          return this.value;
+      };
+      SmallInteger.prototype.toJSNumber = SmallInteger.prototype.valueOf;
+  
+      function parseStringValue(v) {
+              if (isPrecise(+v)) {
+                  var x = +v;
+                  if (x === truncate(x))
+                      return new SmallInteger(x);
+                  throw "Invalid integer: " + v;
+              }
+              var sign = v[0] === "-";
+              if (sign) v = v.slice(1);
+              var split = v.split(/e/i);
+              if (split.length > 2) throw new Error("Invalid integer: " + split.join("e"));
+              if (split.length === 2) {
+                  var exp = split[1];
+                  if (exp[0] === "+") exp = exp.slice(1);
+                  exp = +exp;
+                  if (exp !== truncate(exp) || !isPrecise(exp)) throw new Error("Invalid integer: " + exp + " is not a valid exponent.");
+                  var text = split[0];
+                  var decimalPlace = text.indexOf(".");
+                  if (decimalPlace >= 0) {
+                      exp -= text.length - decimalPlace - 1;
+                      text = text.slice(0, decimalPlace) + text.slice(decimalPlace + 1);
+                  }
+                  if (exp < 0) throw new Error("Cannot include negative exponent part for integers");
+                  text += (new Array(exp + 1)).join("0");
+                  v = text;
+              }
+              var isValid = /^([0-9][0-9]*)$/.test(v);
+              if (!isValid) throw new Error("Invalid integer: " + v);
+              var r = [], max = v.length, l = LOG_BASE, min = max - l;
+              while (max > 0) {
+                  r.push(+v.slice(min, max));
+                  min -= l;
+                  if (min < 0) min = 0;
+                  max -= l;
+              }
+              trim(r);
+              return new BigInteger(r, sign);
+      }
+  
+      function parseNumberValue(v) {
+          if (isPrecise(v)) {
+              if (v !== truncate(v)) throw new Error(v + " is not an integer.");
+              return new SmallInteger(v);
+          }
+          return parseStringValue(v.toString());
+      }
+  
+      function parseValue(v) {
+          if (typeof v === "number") {
+              return parseNumberValue(v);
+          }
+          if (typeof v === "string") {
+              return parseStringValue(v);
+          }
+          return v;
+      }
+      // Pre-define numbers in range [-999,999]
+      for (var i = 0; i < 1000; i++) {
+          Integer[i] = new SmallInteger(i);
+          if (i > 0) Integer[-i] = new SmallInteger(-i);
+      }
+      // Backwards compatibility
+      Integer.one = Integer[1];
+      Integer.zero = Integer[0];
+      Integer.minusOne = Integer[-1];
+      Integer.max = max;
+      Integer.min = min;
+      Integer.gcd = gcd;
+      Integer.lcm = lcm;
+      Integer.isInstance = function (x) { return x instanceof BigInteger || x instanceof SmallInteger; };
+      Integer.randBetween = randBetween;
+  
+      Integer.fromArray = function (digits, base, isNegative) {
+          return parseBaseFromArray(digits.map(parseValue), parseValue(base || 10), isNegative);
+      };
+  
+      return Integer;
+  })();
+  
+  // Node.js check
+  if (typeof module !== "undefined" && module.hasOwnProperty("exports")) {
+      module.exports = bigInt;
+  }
+  
+  //amd check
+  if ( typeof define === "function" && define.amd ) {
+    define( "big-integer", [], function() {
+      return bigInt;
+    });
+  }
+  
+  },{}],4:[function(require,module,exports){
+  
+  },{}],5:[function(require,module,exports){
+  var basex = require('base-x')
+  var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+  
+  module.exports = basex(ALPHABET)
+  
+  },{"base-x":1}],6:[function(require,module,exports){
+  'use strict'
+  
+  var base58 = require('bs58')
+  var Buffer = require('safe-buffer').Buffer
+  
+  module.exports = function (checksumFn) {
+    // Encode a buffer as a base58-check encoded string
+    function encode (payload) {
+      var checksum = checksumFn(payload)
+  
+      return base58.encode(Buffer.concat([
+        payload,
+        checksum
+      ], payload.length + 4))
+    }
+  
+    function decodeRaw (buffer) {
+      var payload = buffer.slice(0, -4)
+      var checksum = buffer.slice(-4)
+      var newChecksum = checksumFn(payload)
+  
+      if (checksum[0] ^ newChecksum[0] |
+          checksum[1] ^ newChecksum[1] |
+          checksum[2] ^ newChecksum[2] |
+          checksum[3] ^ newChecksum[3]) return
+  
+      return payload
+    }
+  
+    // Decode a base58-check encoded string to a buffer, no result if checksum is wrong
+    function decodeUnsafe (string) {
+      var buffer = base58.decodeUnsafe(string)
+      if (!buffer) return
+  
+      return decodeRaw(buffer)
+    }
+  
+    function decode (string) {
+      var buffer = base58.decode(string)
+      var payload = decodeRaw(buffer, checksumFn)
+      if (!payload) throw new Error('Invalid checksum')
+      return payload
+    }
+  
+    return {
+      encode: encode,
+      decode: decode,
+      decodeUnsafe: decodeUnsafe
+    }
+  }
+  
+  },{"bs58":5,"safe-buffer":40}],7:[function(require,module,exports){
+  'use strict'
+  
+  var createHash = require('create-hash')
+  var bs58checkBase = require('./base')
+  
+  // SHA256(SHA256(buffer))
+  function sha256x2 (buffer) {
+    var tmp = createHash('sha256').update(buffer).digest()
+    return createHash('sha256').update(tmp).digest()
+  }
+  
+  module.exports = bs58checkBase(sha256x2)
+  
+  },{"./base":6,"create-hash":15}],8:[function(require,module,exports){
+  /*!
+   * The buffer module from node.js, for the browser.
+   *
+   * @author   Feross Aboukhadijeh <https://feross.org>
+   * @license  MIT
+   */
+  /* eslint-disable no-proto */
+  
+  'use strict'
+  
+  var base64 = require('base64-js')
+  var ieee754 = require('ieee754')
+  
+  exports.Buffer = Buffer
+  exports.SlowBuffer = SlowBuffer
+  exports.INSPECT_MAX_BYTES = 50
+  
+  var K_MAX_LENGTH = 0x7fffffff
+  exports.kMaxLength = K_MAX_LENGTH
+  
+  /**
+   * If `Buffer.TYPED_ARRAY_SUPPORT`:
+   *   === true    Use Uint8Array implementation (fastest)
+   *   === false   Print warning and recommend using `buffer` v4.x which has an Object
+   *               implementation (most compatible, even IE6)
+   *
+   * Browsers that support typed arrays are IE 10+, Firefox 4+, Chrome 7+, Safari 5.1+,
+   * Opera 11.6+, iOS 4.2+.
+   *
+   * We report that the browser does not support typed arrays if the are not subclassable
+   * using __proto__. Firefox 4-29 lacks support for adding new properties to `Uint8Array`
+   * (See: https://bugzilla.mozilla.org/show_bug.cgi?id=695438). IE 10 lacks support
+   * for __proto__ and has a buggy typed array implementation.
+   */
+  Buffer.TYPED_ARRAY_SUPPORT = typedArraySupport()
+  
+  if (!Buffer.TYPED_ARRAY_SUPPORT && typeof console !== 'undefined' &&
+      typeof console.error === 'function') {
+    console.error(
+      'This browser lacks typed array (Uint8Array) support which is required by ' +
+      '`buffer` v5.x. Use `buffer` v4.x if you require old browser support.'
+    )
+  }
+  
+  function typedArraySupport () {
+    // Can typed array instances can be augmented?
+    try {
+      var arr = new Uint8Array(1)
+      arr.__proto__ = {__proto__: Uint8Array.prototype, foo: function () { return 42 }}
+      return arr.foo() === 42
+    } catch (e) {
+      return false
+    }
+  }
+  
+  function createBuffer (length) {
+    if (length > K_MAX_LENGTH) {
+      throw new RangeError('Invalid typed array length')
+    }
+    // Return an augmented `Uint8Array` instance
+    var buf = new Uint8Array(length)
+    buf.__proto__ = Buffer.prototype
+    return buf
+  }
+  
+  /**
+   * The Buffer constructor returns instances of `Uint8Array` that have their
+   * prototype changed to `Buffer.prototype`. Furthermore, `Buffer` is a subclass of
+   * `Uint8Array`, so the returned instances will have all the node `Buffer` methods
+   * and the `Uint8Array` methods. Square bracket notation works as expected -- it
+   * returns a single octet.
+   *
+   * The `Uint8Array` prototype remains unmodified.
+   */
+  
+  function Buffer (arg, encodingOrOffset, length) {
+    // Common case.
+    if (typeof arg === 'number') {
+      if (typeof encodingOrOffset === 'string') {
+        throw new Error(
+          'If encoding is specified then the first argument must be a string'
+        )
+      }
+      return allocUnsafe(arg)
+    }
+    return from(arg, encodingOrOffset, length)
+  }
+  
+  // Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
+  if (typeof Symbol !== 'undefined' && Symbol.species &&
+      Buffer[Symbol.species] === Buffer) {
+    Object.defineProperty(Buffer, Symbol.species, {
+      value: null,
+      configurable: true,
+      enumerable: false,
+      writable: false
+    })
+  }
+  
+  Buffer.poolSize = 8192 // not used by this implementation
+  
+  function from (value, encodingOrOffset, length) {
+    if (typeof value === 'number') {
+      throw new TypeError('"value" argument must not be a number')
+    }
+  
+    if (isArrayBuffer(value)) {
+      return fromArrayBuffer(value, encodingOrOffset, length)
+    }
+  
+    if (typeof value === 'string') {
+      return fromString(value, encodingOrOffset)
+    }
+  
+    return fromObject(value)
+  }
+  
+  /**
+   * Functionally equivalent to Buffer(arg, encoding) but throws a TypeError
+   * if value is a number.
+   * Buffer.from(str[, encoding])
+   * Buffer.from(array)
+   * Buffer.from(buffer)
+   * Buffer.from(arrayBuffer[, byteOffset[, length]])
+   **/
+  Buffer.from = function (value, encodingOrOffset, length) {
+    return from(value, encodingOrOffset, length)
+  }
+  
+  // Note: Change prototype *after* Buffer.from is defined to workaround Chrome bug:
+  // https://github.com/feross/buffer/pull/148
+  Buffer.prototype.__proto__ = Uint8Array.prototype
+  Buffer.__proto__ = Uint8Array
+  
+  function assertSize (size) {
+    if (typeof size !== 'number') {
+      throw new TypeError('"size" argument must be a number')
+    } else if (size < 0) {
+      throw new RangeError('"size" argument must not be negative')
+    }
+  }
+  
+  function alloc (size, fill, encoding) {
+    assertSize(size)
+    if (size <= 0) {
+      return createBuffer(size)
+    }
+    if (fill !== undefined) {
+      // Only pay attention to encoding if it's a string. This
+      // prevents accidentally sending in a number that would
+      // be interpretted as a start offset.
+      return typeof encoding === 'string'
+        ? createBuffer(size).fill(fill, encoding)
+        : createBuffer(size).fill(fill)
+    }
+    return createBuffer(size)
+  }
+  
+  /**
+   * Creates a new filled Buffer instance.
+   * alloc(size[, fill[, encoding]])
+   **/
+  Buffer.alloc = function (size, fill, encoding) {
+    return alloc(size, fill, encoding)
+  }
+  
+  function allocUnsafe (size) {
+    assertSize(size)
+    return createBuffer(size < 0 ? 0 : checked(size) | 0)
+  }
+  
+  /**
+   * Equivalent to Buffer(num), by default creates a non-zero-filled Buffer instance.
+   * */
+  Buffer.allocUnsafe = function (size) {
+    return allocUnsafe(size)
+  }
+  /**
+   * Equivalent to SlowBuffer(num), by default creates a non-zero-filled Buffer instance.
+   */
+  Buffer.allocUnsafeSlow = function (size) {
+    return allocUnsafe(size)
+  }
+  
+  function fromString (string, encoding) {
+    if (typeof encoding !== 'string' || encoding === '') {
+      encoding = 'utf8'
+    }
+  
+    if (!Buffer.isEncoding(encoding)) {
+      throw new TypeError('"encoding" must be a valid string encoding')
+    }
+  
+    var length = byteLength(string, encoding) | 0
+    var buf = createBuffer(length)
+  
+    var actual = buf.write(string, encoding)
+  
+    if (actual !== length) {
+      // Writing a hex string, for example, that contains invalid characters will
+      // cause everything after the first invalid character to be ignored. (e.g.
+      // 'abxxcd' will be treated as 'ab')
+      buf = buf.slice(0, actual)
+    }
+  
+    return buf
+  }
+  
+  function fromArrayLike (array) {
+    var length = array.length < 0 ? 0 : checked(array.length) | 0
+    var buf = createBuffer(length)
+    for (var i = 0; i < length; i += 1) {
+      buf[i] = array[i] & 255
+    }
+    return buf
+  }
+  
+  function fromArrayBuffer (array, byteOffset, length) {
+    if (byteOffset < 0 || array.byteLength < byteOffset) {
+      throw new RangeError('\'offset\' is out of bounds')
+    }
+  
+    if (array.byteLength < byteOffset + (length || 0)) {
+      throw new RangeError('\'length\' is out of bounds')
+    }
+  
+    var buf
+    if (byteOffset === undefined && length === undefined) {
+      buf = new Uint8Array(array)
+    } else if (length === undefined) {
+      buf = new Uint8Array(array, byteOffset)
+    } else {
+      buf = new Uint8Array(array, byteOffset, length)
+    }
+  
+    // Return an augmented `Uint8Array` instance
+    buf.__proto__ = Buffer.prototype
+    return buf
+  }
+  
+  function fromObject (obj) {
+    if (Buffer.isBuffer(obj)) {
+      var len = checked(obj.length) | 0
+      var buf = createBuffer(len)
+  
+      if (buf.length === 0) {
+        return buf
+      }
+  
+      obj.copy(buf, 0, 0, len)
+      return buf
+    }
+  
+    if (obj) {
+      if (isArrayBufferView(obj) || 'length' in obj) {
+        if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {
+          return createBuffer(0)
+        }
+        return fromArrayLike(obj)
+      }
+  
+      if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
+        return fromArrayLike(obj.data)
+      }
+    }
+  
+    throw new TypeError('First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.')
+  }
+  
+  function checked (length) {
+    // Note: cannot use `length < K_MAX_LENGTH` here because that fails when
+    // length is NaN (which is otherwise coerced to zero.)
+    if (length >= K_MAX_LENGTH) {
+      throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
+                           'size: 0x' + K_MAX_LENGTH.toString(16) + ' bytes')
+    }
+    return length | 0
+  }
+  
+  function SlowBuffer (length) {
+    if (+length != length) { // eslint-disable-line eqeqeq
+      length = 0
+    }
+    return Buffer.alloc(+length)
+  }
+  
+  Buffer.isBuffer = function isBuffer (b) {
+    return b != null && b._isBuffer === true
+  }
+  
+  Buffer.compare = function compare (a, b) {
+    if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
+      throw new TypeError('Arguments must be Buffers')
+    }
+  
+    if (a === b) return 0
+  
+    var x = a.length
+    var y = b.length
+  
+    for (var i = 0, len = Math.min(x, y); i < len; ++i) {
+      if (a[i] !== b[i]) {
+        x = a[i]
+        y = b[i]
+        break
+      }
+    }
+  
+    if (x < y) return -1
+    if (y < x) return 1
+    return 0
+  }
+  
+  Buffer.isEncoding = function isEncoding (encoding) {
+    switch (String(encoding).toLowerCase()) {
+      case 'hex':
+      case 'utf8':
+      case 'utf-8':
+      case 'ascii':
+      case 'latin1':
+      case 'binary':
+      case 'base64':
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return true
+      default:
+        return false
+    }
+  }
+  
+  Buffer.concat = function concat (list, length) {
+    if (!Array.isArray(list)) {
+      throw new TypeError('"list" argument must be an Array of Buffers')
+    }
+  
+    if (list.length === 0) {
+      return Buffer.alloc(0)
+    }
+  
+    var i
+    if (length === undefined) {
+      length = 0
+      for (i = 0; i < list.length; ++i) {
+        length += list[i].length
+      }
+    }
+  
+    var buffer = Buffer.allocUnsafe(length)
+    var pos = 0
+    for (i = 0; i < list.length; ++i) {
+      var buf = list[i]
+      if (!Buffer.isBuffer(buf)) {
+        throw new TypeError('"list" argument must be an Array of Buffers')
+      }
+      buf.copy(buffer, pos)
+      pos += buf.length
+    }
+    return buffer
+  }
+  
+  function byteLength (string, encoding) {
+    if (Buffer.isBuffer(string)) {
+      return string.length
+    }
+    if (isArrayBufferView(string) || isArrayBuffer(string)) {
+      return string.byteLength
+    }
+    if (typeof string !== 'string') {
+      string = '' + string
+    }
+  
+    var len = string.length
+    if (len === 0) return 0
+  
+    // Use a for loop to avoid recursion
+    var loweredCase = false
+    for (;;) {
+      switch (encoding) {
+        case 'ascii':
+        case 'latin1':
+        case 'binary':
+          return len
+        case 'utf8':
+        case 'utf-8':
+        case undefined:
+          return utf8ToBytes(string).length
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return len * 2
+        case 'hex':
+          return len >>> 1
+        case 'base64':
+          return base64ToBytes(string).length
+        default:
+          if (loweredCase) return utf8ToBytes(string).length // assume utf8
+          encoding = ('' + encoding).toLowerCase()
+          loweredCase = true
+      }
+    }
+  }
+  Buffer.byteLength = byteLength
+  
+  function slowToString (encoding, start, end) {
+    var loweredCase = false
+  
+    // No need to verify that "this.length <= MAX_UINT32" since it's a read-only
+    // property of a typed array.
+  
+    // This behaves neither like String nor Uint8Array in that we set start/end
+    // to their upper/lower bounds if the value passed is out of range.
+    // undefined is handled specially as per ECMA-262 6th Edition,
+    // Section 13.3.3.7 Runtime Semantics: KeyedBindingInitialization.
+    if (start === undefined || start < 0) {
+      start = 0
+    }
+    // Return early if start > this.length. Done here to prevent potential uint32
+    // coercion fail below.
+    if (start > this.length) {
+      return ''
+    }
+  
+    if (end === undefined || end > this.length) {
+      end = this.length
+    }
+  
+    if (end <= 0) {
+      return ''
+    }
+  
+    // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
+    end >>>= 0
+    start >>>= 0
+  
+    if (end <= start) {
+      return ''
+    }
+  
+    if (!encoding) encoding = 'utf8'
+  
+    while (true) {
+      switch (encoding) {
+        case 'hex':
+          return hexSlice(this, start, end)
+  
+        case 'utf8':
+        case 'utf-8':
+          return utf8Slice(this, start, end)
+  
+        case 'ascii':
+          return asciiSlice(this, start, end)
+  
+        case 'latin1':
+        case 'binary':
+          return latin1Slice(this, start, end)
+  
+        case 'base64':
+          return base64Slice(this, start, end)
+  
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return utf16leSlice(this, start, end)
+  
+        default:
+          if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+          encoding = (encoding + '').toLowerCase()
+          loweredCase = true
+      }
+    }
+  }
+  
+  // This property is used by `Buffer.isBuffer` (and the `is-buffer` npm package)
+  // to detect a Buffer instance. It's not possible to use `instanceof Buffer`
+  // reliably in a browserify context because there could be multiple different
+  // copies of the 'buffer' package in use. This method works even for Buffer
+  // instances that were created from another copy of the `buffer` package.
+  // See: https://github.com/feross/buffer/issues/154
+  Buffer.prototype._isBuffer = true
+  
+  function swap (b, n, m) {
+    var i = b[n]
+    b[n] = b[m]
+    b[m] = i
+  }
+  
+  Buffer.prototype.swap16 = function swap16 () {
+    var len = this.length
+    if (len % 2 !== 0) {
+      throw new RangeError('Buffer size must be a multiple of 16-bits')
+    }
+    for (var i = 0; i < len; i += 2) {
+      swap(this, i, i + 1)
+    }
+    return this
+  }
+  
+  Buffer.prototype.swap32 = function swap32 () {
+    var len = this.length
+    if (len % 4 !== 0) {
+      throw new RangeError('Buffer size must be a multiple of 32-bits')
+    }
+    for (var i = 0; i < len; i += 4) {
+      swap(this, i, i + 3)
+      swap(this, i + 1, i + 2)
+    }
+    return this
+  }
+  
+  Buffer.prototype.swap64 = function swap64 () {
+    var len = this.length
+    if (len % 8 !== 0) {
+      throw new RangeError('Buffer size must be a multiple of 64-bits')
+    }
+    for (var i = 0; i < len; i += 8) {
+      swap(this, i, i + 7)
+      swap(this, i + 1, i + 6)
+      swap(this, i + 2, i + 5)
+      swap(this, i + 3, i + 4)
+    }
+    return this
+  }
+  
+  Buffer.prototype.toString = function toString () {
+    var length = this.length
+    if (length === 0) return ''
+    if (arguments.length === 0) return utf8Slice(this, 0, length)
+    return slowToString.apply(this, arguments)
+  }
+  
+  Buffer.prototype.equals = function equals (b) {
+    if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+    if (this === b) return true
+    return Buffer.compare(this, b) === 0
+  }
+  
+  Buffer.prototype.inspect = function inspect () {
+    var str = ''
+    var max = exports.INSPECT_MAX_BYTES
+    if (this.length > 0) {
+      str = this.toString('hex', 0, max).match(/.{2}/g).join(' ')
+      if (this.length > max) str += ' ... '
+    }
+    return '<Buffer ' + str + '>'
+  }
+  
+  Buffer.prototype.compare = function compare (target, start, end, thisStart, thisEnd) {
+    if (!Buffer.isBuffer(target)) {
+      throw new TypeError('Argument must be a Buffer')
+    }
+  
+    if (start === undefined) {
+      start = 0
+    }
+    if (end === undefined) {
+      end = target ? target.length : 0
+    }
+    if (thisStart === undefined) {
+      thisStart = 0
+    }
+    if (thisEnd === undefined) {
+      thisEnd = this.length
+    }
+  
+    if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+      throw new RangeError('out of range index')
+    }
+  
+    if (thisStart >= thisEnd && start >= end) {
+      return 0
+    }
+    if (thisStart >= thisEnd) {
+      return -1
+    }
+    if (start >= end) {
+      return 1
+    }
+  
+    start >>>= 0
+    end >>>= 0
+    thisStart >>>= 0
+    thisEnd >>>= 0
+  
+    if (this === target) return 0
+  
+    var x = thisEnd - thisStart
+    var y = end - start
+    var len = Math.min(x, y)
+  
+    var thisCopy = this.slice(thisStart, thisEnd)
+    var targetCopy = target.slice(start, end)
+  
+    for (var i = 0; i < len; ++i) {
+      if (thisCopy[i] !== targetCopy[i]) {
+        x = thisCopy[i]
+        y = targetCopy[i]
+        break
+      }
+    }
+  
+    if (x < y) return -1
+    if (y < x) return 1
+    return 0
+  }
+  
+  // Finds either the first index of `val` in `buffer` at offset >= `byteOffset`,
+  // OR the last index of `val` in `buffer` at offset <= `byteOffset`.
+  //
+  // Arguments:
+  // - buffer - a Buffer to search
+  // - val - a string, Buffer, or number
+  // - byteOffset - an index into `buffer`; will be clamped to an int32
+  // - encoding - an optional encoding, relevant is val is a string
+  // - dir - true for indexOf, false for lastIndexOf
+  function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
+    // Empty buffer means no match
+    if (buffer.length === 0) return -1
+  
+    // Normalize byteOffset
+    if (typeof byteOffset === 'string') {
+      encoding = byteOffset
+      byteOffset = 0
+    } else if (byteOffset > 0x7fffffff) {
+      byteOffset = 0x7fffffff
+    } else if (byteOffset < -0x80000000) {
+      byteOffset = -0x80000000
+    }
+    byteOffset = +byteOffset  // Coerce to Number.
+    if (numberIsNaN(byteOffset)) {
+      // byteOffset: it it's undefined, null, NaN, "foo", etc, search whole buffer
+      byteOffset = dir ? 0 : (buffer.length - 1)
+    }
+  
+    // Normalize byteOffset: negative offsets start from the end of the buffer
+    if (byteOffset < 0) byteOffset = buffer.length + byteOffset
+    if (byteOffset >= buffer.length) {
+      if (dir) return -1
+      else byteOffset = buffer.length - 1
+    } else if (byteOffset < 0) {
+      if (dir) byteOffset = 0
+      else return -1
+    }
+  
+    // Normalize val
+    if (typeof val === 'string') {
+      val = Buffer.from(val, encoding)
+    }
+  
+    // Finally, search either indexOf (if dir is true) or lastIndexOf
+    if (Buffer.isBuffer(val)) {
+      // Special case: looking for empty string/buffer always fails
+      if (val.length === 0) {
+        return -1
+      }
+      return arrayIndexOf(buffer, val, byteOffset, encoding, dir)
+    } else if (typeof val === 'number') {
+      val = val & 0xFF // Search for a byte value [0-255]
+      if (typeof Uint8Array.prototype.indexOf === 'function') {
+        if (dir) {
+          return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset)
+        } else {
+          return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset)
+        }
+      }
+      return arrayIndexOf(buffer, [ val ], byteOffset, encoding, dir)
+    }
+  
+    throw new TypeError('val must be string, number or Buffer')
+  }
+  
+  function arrayIndexOf (arr, val, byteOffset, encoding, dir) {
+    var indexSize = 1
+    var arrLength = arr.length
+    var valLength = val.length
+  
+    if (encoding !== undefined) {
+      encoding = String(encoding).toLowerCase()
+      if (encoding === 'ucs2' || encoding === 'ucs-2' ||
+          encoding === 'utf16le' || encoding === 'utf-16le') {
+        if (arr.length < 2 || val.length < 2) {
+          return -1
+        }
+        indexSize = 2
+        arrLength /= 2
+        valLength /= 2
+        byteOffset /= 2
+      }
+    }
+  
+    function read (buf, i) {
+      if (indexSize === 1) {
+        return buf[i]
+      } else {
+        return buf.readUInt16BE(i * indexSize)
+      }
+    }
+  
+    var i
+    if (dir) {
+      var foundIndex = -1
+      for (i = byteOffset; i < arrLength; i++) {
+        if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+          if (foundIndex === -1) foundIndex = i
+          if (i - foundIndex + 1 === valLength) return foundIndex * indexSize
+        } else {
+          if (foundIndex !== -1) i -= i - foundIndex
+          foundIndex = -1
+        }
+      }
+    } else {
+      if (byteOffset + valLength > arrLength) byteOffset = arrLength - valLength
+      for (i = byteOffset; i >= 0; i--) {
+        var found = true
+        for (var j = 0; j < valLength; j++) {
+          if (read(arr, i + j) !== read(val, j)) {
+            found = false
+            break
+          }
+        }
+        if (found) return i
+      }
+    }
+  
+    return -1
+  }
+  
+  Buffer.prototype.includes = function includes (val, byteOffset, encoding) {
+    return this.indexOf(val, byteOffset, encoding) !== -1
+  }
+  
+  Buffer.prototype.indexOf = function indexOf (val, byteOffset, encoding) {
+    return bidirectionalIndexOf(this, val, byteOffset, encoding, true)
+  }
+  
+  Buffer.prototype.lastIndexOf = function lastIndexOf (val, byteOffset, encoding) {
+    return bidirectionalIndexOf(this, val, byteOffset, encoding, false)
+  }
+  
+  function hexWrite (buf, string, offset, length) {
+    offset = Number(offset) || 0
+    var remaining = buf.length - offset
+    if (!length) {
+      length = remaining
+    } else {
+      length = Number(length)
+      if (length > remaining) {
+        length = remaining
+      }
+    }
+  
+    // must be an even number of digits
+    var strLen = string.length
+    if (strLen % 2 !== 0) throw new TypeError('Invalid hex string')
+  
+    if (length > strLen / 2) {
+      length = strLen / 2
+    }
+    for (var i = 0; i < length; ++i) {
+      var parsed = parseInt(string.substr(i * 2, 2), 16)
+      if (numberIsNaN(parsed)) return i
+      buf[offset + i] = parsed
+    }
+    return i
+  }
+  
+  function utf8Write (buf, string, offset, length) {
+    return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length)
+  }
+  
+  function asciiWrite (buf, string, offset, length) {
+    return blitBuffer(asciiToBytes(string), buf, offset, length)
+  }
+  
+  function latin1Write (buf, string, offset, length) {
+    return asciiWrite(buf, string, offset, length)
+  }
+  
+  function base64Write (buf, string, offset, length) {
+    return blitBuffer(base64ToBytes(string), buf, offset, length)
+  }
+  
+  function ucs2Write (buf, string, offset, length) {
+    return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length)
+  }
+  
+  Buffer.prototype.write = function write (string, offset, length, encoding) {
+    // Buffer#write(string)
+    if (offset === undefined) {
+      encoding = 'utf8'
+      length = this.length
+      offset = 0
+    // Buffer#write(string, encoding)
+    } else if (length === undefined && typeof offset === 'string') {
+      encoding = offset
+      length = this.length
+      offset = 0
+    // Buffer#write(string, offset[, length][, encoding])
+    } else if (isFinite(offset)) {
+      offset = offset >>> 0
+      if (isFinite(length)) {
+        length = length >>> 0
+        if (encoding === undefined) encoding = 'utf8'
+      } else {
+        encoding = length
+        length = undefined
+      }
+    } else {
+      throw new Error(
+        'Buffer.write(string, encoding, offset[, length]) is no longer supported'
+      )
+    }
+  
+    var remaining = this.length - offset
+    if (length === undefined || length > remaining) length = remaining
+  
+    if ((string.length > 0 && (length < 0 || offset < 0)) || offset > this.length) {
+      throw new RangeError('Attempt to write outside buffer bounds')
+    }
+  
+    if (!encoding) encoding = 'utf8'
+  
+    var loweredCase = false
+    for (;;) {
+      switch (encoding) {
+        case 'hex':
+          return hexWrite(this, string, offset, length)
+  
+        case 'utf8':
+        case 'utf-8':
+          return utf8Write(this, string, offset, length)
+  
+        case 'ascii':
+          return asciiWrite(this, string, offset, length)
+  
+        case 'latin1':
+        case 'binary':
+          return latin1Write(this, string, offset, length)
+  
+        case 'base64':
+          // Warning: maxLength not taken into account in base64Write
+          return base64Write(this, string, offset, length)
+  
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return ucs2Write(this, string, offset, length)
+  
+        default:
+          if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+          encoding = ('' + encoding).toLowerCase()
+          loweredCase = true
+      }
+    }
+  }
+  
+  Buffer.prototype.toJSON = function toJSON () {
+    return {
+      type: 'Buffer',
+      data: Array.prototype.slice.call(this._arr || this, 0)
+    }
+  }
+  
+  function base64Slice (buf, start, end) {
+    if (start === 0 && end === buf.length) {
+      return base64.fromByteArray(buf)
+    } else {
+      return base64.fromByteArray(buf.slice(start, end))
+    }
+  }
+  
+  function utf8Slice (buf, start, end) {
+    end = Math.min(buf.length, end)
+    var res = []
+  
+    var i = start
+    while (i < end) {
+      var firstByte = buf[i]
+      var codePoint = null
+      var bytesPerSequence = (firstByte > 0xEF) ? 4
+        : (firstByte > 0xDF) ? 3
+        : (firstByte > 0xBF) ? 2
+        : 1
+  
+      if (i + bytesPerSequence <= end) {
+        var secondByte, thirdByte, fourthByte, tempCodePoint
+  
+        switch (bytesPerSequence) {
+          case 1:
+            if (firstByte < 0x80) {
+              codePoint = firstByte
+            }
+            break
+          case 2:
+            secondByte = buf[i + 1]
+            if ((secondByte & 0xC0) === 0x80) {
+              tempCodePoint = (firstByte & 0x1F) << 0x6 | (secondByte & 0x3F)
+              if (tempCodePoint > 0x7F) {
+                codePoint = tempCodePoint
+              }
+            }
+            break
+          case 3:
+            secondByte = buf[i + 1]
+            thirdByte = buf[i + 2]
+            if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80) {
+              tempCodePoint = (firstByte & 0xF) << 0xC | (secondByte & 0x3F) << 0x6 | (thirdByte & 0x3F)
+              if (tempCodePoint > 0x7FF && (tempCodePoint < 0xD800 || tempCodePoint > 0xDFFF)) {
+                codePoint = tempCodePoint
+              }
+            }
+            break
+          case 4:
+            secondByte = buf[i + 1]
+            thirdByte = buf[i + 2]
+            fourthByte = buf[i + 3]
+            if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80 && (fourthByte & 0xC0) === 0x80) {
+              tempCodePoint = (firstByte & 0xF) << 0x12 | (secondByte & 0x3F) << 0xC | (thirdByte & 0x3F) << 0x6 | (fourthByte & 0x3F)
+              if (tempCodePoint > 0xFFFF && tempCodePoint < 0x110000) {
+                codePoint = tempCodePoint
+              }
+            }
+        }
+      }
+  
+      if (codePoint === null) {
+        // we did not generate a valid codePoint so insert a
+        // replacement char (U+FFFD) and advance only 1 byte
+        codePoint = 0xFFFD
+        bytesPerSequence = 1
+      } else if (codePoint > 0xFFFF) {
+        // encode to utf16 (surrogate pair dance)
+        codePoint -= 0x10000
+        res.push(codePoint >>> 10 & 0x3FF | 0xD800)
+        codePoint = 0xDC00 | codePoint & 0x3FF
+      }
+  
+      res.push(codePoint)
+      i += bytesPerSequence
+    }
+  
+    return decodeCodePointsArray(res)
+  }
+  
+  // Based on http://stackoverflow.com/a/22747272/680742, the browser with
+  // the lowest limit is Chrome, with 0x10000 args.
+  // We go 1 magnitude less, for safety
+  var MAX_ARGUMENTS_LENGTH = 0x1000
+  
+  function decodeCodePointsArray (codePoints) {
+    var len = codePoints.length
+    if (len <= MAX_ARGUMENTS_LENGTH) {
+      return String.fromCharCode.apply(String, codePoints) // avoid extra slice()
+    }
+  
+    // Decode in chunks to avoid "call stack size exceeded".
+    var res = ''
+    var i = 0
+    while (i < len) {
+      res += String.fromCharCode.apply(
+        String,
+        codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH)
+      )
+    }
+    return res
+  }
+  
+  function asciiSlice (buf, start, end) {
+    var ret = ''
+    end = Math.min(buf.length, end)
+  
+    for (var i = start; i < end; ++i) {
+      ret += String.fromCharCode(buf[i] & 0x7F)
+    }
+    return ret
+  }
+  
+  function latin1Slice (buf, start, end) {
+    var ret = ''
+    end = Math.min(buf.length, end)
+  
+    for (var i = start; i < end; ++i) {
+      ret += String.fromCharCode(buf[i])
+    }
+    return ret
+  }
+  
+  function hexSlice (buf, start, end) {
+    var len = buf.length
+  
+    if (!start || start < 0) start = 0
+    if (!end || end < 0 || end > len) end = len
+  
+    var out = ''
+    for (var i = start; i < end; ++i) {
+      out += toHex(buf[i])
+    }
+    return out
+  }
+  
+  function utf16leSlice (buf, start, end) {
+    var bytes = buf.slice(start, end)
+    var res = ''
+    for (var i = 0; i < bytes.length; i += 2) {
+      res += String.fromCharCode(bytes[i] + (bytes[i + 1] * 256))
+    }
+    return res
+  }
+  
+  Buffer.prototype.slice = function slice (start, end) {
+    var len = this.length
+    start = ~~start
+    end = end === undefined ? len : ~~end
+  
+    if (start < 0) {
+      start += len
+      if (start < 0) start = 0
+    } else if (start > len) {
+      start = len
+    }
+  
+    if (end < 0) {
+      end += len
+      if (end < 0) end = 0
+    } else if (end > len) {
+      end = len
+    }
+  
+    if (end < start) end = start
+  
+    var newBuf = this.subarray(start, end)
+    // Return an augmented `Uint8Array` instance
+    newBuf.__proto__ = Buffer.prototype
+    return newBuf
+  }
+  
+  /*
+   * Need to make sure that buffer isn't trying to write out of bounds.
+   */
+  function checkOffset (offset, ext, length) {
+    if ((offset % 1) !== 0 || offset < 0) throw new RangeError('offset is not uint')
+    if (offset + ext > length) throw new RangeError('Trying to access beyond buffer length')
+  }
+  
+  Buffer.prototype.readUIntLE = function readUIntLE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+  
+    var val = this[offset]
+    var mul = 1
+    var i = 0
+    while (++i < byteLength && (mul *= 0x100)) {
+      val += this[offset + i] * mul
+    }
+  
+    return val
+  }
+  
+  Buffer.prototype.readUIntBE = function readUIntBE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+      checkOffset(offset, byteLength, this.length)
+    }
+  
+    var val = this[offset + --byteLength]
+    var mul = 1
+    while (byteLength > 0 && (mul *= 0x100)) {
+      val += this[offset + --byteLength] * mul
+    }
+  
+    return val
+  }
+  
+  Buffer.prototype.readUInt8 = function readUInt8 (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 1, this.length)
+    return this[offset]
+  }
+  
+  Buffer.prototype.readUInt16LE = function readUInt16LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    return this[offset] | (this[offset + 1] << 8)
+  }
+  
+  Buffer.prototype.readUInt16BE = function readUInt16BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    return (this[offset] << 8) | this[offset + 1]
+  }
+  
+  Buffer.prototype.readUInt32LE = function readUInt32LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return ((this[offset]) |
+        (this[offset + 1] << 8) |
+        (this[offset + 2] << 16)) +
+        (this[offset + 3] * 0x1000000)
+  }
+  
+  Buffer.prototype.readUInt32BE = function readUInt32BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return (this[offset] * 0x1000000) +
+      ((this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      this[offset + 3])
+  }
+  
+  Buffer.prototype.readIntLE = function readIntLE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+  
+    var val = this[offset]
+    var mul = 1
+    var i = 0
+    while (++i < byteLength && (mul *= 0x100)) {
+      val += this[offset + i] * mul
+    }
+    mul *= 0x80
+  
+    if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+  
+    return val
+  }
+  
+  Buffer.prototype.readIntBE = function readIntBE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+  
+    var i = byteLength
+    var mul = 1
+    var val = this[offset + --i]
+    while (i > 0 && (mul *= 0x100)) {
+      val += this[offset + --i] * mul
+    }
+    mul *= 0x80
+  
+    if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+  
+    return val
+  }
+  
+  Buffer.prototype.readInt8 = function readInt8 (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 1, this.length)
+    if (!(this[offset] & 0x80)) return (this[offset])
+    return ((0xff - this[offset] + 1) * -1)
+  }
+  
+  Buffer.prototype.readInt16LE = function readInt16LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    var val = this[offset] | (this[offset + 1] << 8)
+    return (val & 0x8000) ? val | 0xFFFF0000 : val
+  }
+  
+  Buffer.prototype.readInt16BE = function readInt16BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    var val = this[offset + 1] | (this[offset] << 8)
+    return (val & 0x8000) ? val | 0xFFFF0000 : val
+  }
+  
+  Buffer.prototype.readInt32LE = function readInt32LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return (this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16) |
+      (this[offset + 3] << 24)
+  }
+  
+  Buffer.prototype.readInt32BE = function readInt32BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return (this[offset] << 24) |
+      (this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      (this[offset + 3])
+  }
+  
+  Buffer.prototype.readFloatLE = function readFloatLE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+    return ieee754.read(this, offset, true, 23, 4)
+  }
+  
+  Buffer.prototype.readFloatBE = function readFloatBE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+    return ieee754.read(this, offset, false, 23, 4)
+  }
+  
+  Buffer.prototype.readDoubleLE = function readDoubleLE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 8, this.length)
+    return ieee754.read(this, offset, true, 52, 8)
+  }
+  
+  Buffer.prototype.readDoubleBE = function readDoubleBE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 8, this.length)
+    return ieee754.read(this, offset, false, 52, 8)
+  }
+  
+  function checkInt (buf, value, offset, ext, max, min) {
+    if (!Buffer.isBuffer(buf)) throw new TypeError('"buffer" argument must be a Buffer instance')
+    if (value > max || value < min) throw new RangeError('"value" argument is out of bounds')
+    if (offset + ext > buf.length) throw new RangeError('Index out of range')
+  }
+  
+  Buffer.prototype.writeUIntLE = function writeUIntLE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+      var maxBytes = Math.pow(2, 8 * byteLength) - 1
+      checkInt(this, value, offset, byteLength, maxBytes, 0)
+    }
+  
+    var mul = 1
+    var i = 0
+    this[offset] = value & 0xFF
+    while (++i < byteLength && (mul *= 0x100)) {
+      this[offset + i] = (value / mul) & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeUIntBE = function writeUIntBE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+      var maxBytes = Math.pow(2, 8 * byteLength) - 1
+      checkInt(this, value, offset, byteLength, maxBytes, 0)
+    }
+  
+    var i = byteLength - 1
+    var mul = 1
+    this[offset + i] = value & 0xFF
+    while (--i >= 0 && (mul *= 0x100)) {
+      this[offset + i] = (value / mul) & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeUInt8 = function writeUInt8 (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 1, 0xff, 0)
+    this[offset] = (value & 0xff)
+    return offset + 1
+  }
+  
+  Buffer.prototype.writeUInt16LE = function writeUInt16LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeUInt16BE = function writeUInt16BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeUInt32LE = function writeUInt32LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+    this[offset + 3] = (value >>> 24)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 1] = (value >>> 8)
+    this[offset] = (value & 0xff)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeUInt32BE = function writeUInt32BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeIntLE = function writeIntLE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      var limit = Math.pow(2, (8 * byteLength) - 1)
+  
+      checkInt(this, value, offset, byteLength, limit - 1, -limit)
+    }
+  
+    var i = 0
+    var mul = 1
+    var sub = 0
+    this[offset] = value & 0xFF
+    while (++i < byteLength && (mul *= 0x100)) {
+      if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+        sub = 1
+      }
+      this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeIntBE = function writeIntBE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      var limit = Math.pow(2, (8 * byteLength) - 1)
+  
+      checkInt(this, value, offset, byteLength, limit - 1, -limit)
+    }
+  
+    var i = byteLength - 1
+    var mul = 1
+    var sub = 0
+    this[offset + i] = value & 0xFF
+    while (--i >= 0 && (mul *= 0x100)) {
+      if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+        sub = 1
+      }
+      this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeInt8 = function writeInt8 (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 1, 0x7f, -0x80)
+    if (value < 0) value = 0xff + value + 1
+    this[offset] = (value & 0xff)
+    return offset + 1
+  }
+  
+  Buffer.prototype.writeInt16LE = function writeInt16LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeInt16BE = function writeInt16BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeInt32LE = function writeInt32LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 3] = (value >>> 24)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeInt32BE = function writeInt32BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+    if (value < 0) value = 0xffffffff + value + 1
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+    return offset + 4
+  }
+  
+  function checkIEEE754 (buf, value, offset, ext, max, min) {
+    if (offset + ext > buf.length) throw new RangeError('Index out of range')
+    if (offset < 0) throw new RangeError('Index out of range')
+  }
+  
+  function writeFloat (buf, value, offset, littleEndian, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      checkIEEE754(buf, value, offset, 4, 3.4028234663852886e+38, -3.4028234663852886e+38)
+    }
+    ieee754.write(buf, value, offset, littleEndian, 23, 4)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeFloatLE = function writeFloatLE (value, offset, noAssert) {
+    return writeFloat(this, value, offset, true, noAssert)
+  }
+  
+  Buffer.prototype.writeFloatBE = function writeFloatBE (value, offset, noAssert) {
+    return writeFloat(this, value, offset, false, noAssert)
+  }
+  
+  function writeDouble (buf, value, offset, littleEndian, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      checkIEEE754(buf, value, offset, 8, 1.7976931348623157E+308, -1.7976931348623157E+308)
+    }
+    ieee754.write(buf, value, offset, littleEndian, 52, 8)
+    return offset + 8
+  }
+  
+  Buffer.prototype.writeDoubleLE = function writeDoubleLE (value, offset, noAssert) {
+    return writeDouble(this, value, offset, true, noAssert)
+  }
+  
+  Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert) {
+    return writeDouble(this, value, offset, false, noAssert)
+  }
+  
+  // copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
+  Buffer.prototype.copy = function copy (target, targetStart, start, end) {
+    if (!start) start = 0
+    if (!end && end !== 0) end = this.length
+    if (targetStart >= target.length) targetStart = target.length
+    if (!targetStart) targetStart = 0
+    if (end > 0 && end < start) end = start
+  
+    // Copy 0 bytes; we're done
+    if (end === start) return 0
+    if (target.length === 0 || this.length === 0) return 0
+  
+    // Fatal error conditions
+    if (targetStart < 0) {
+      throw new RangeError('targetStart out of bounds')
+    }
+    if (start < 0 || start >= this.length) throw new RangeError('sourceStart out of bounds')
+    if (end < 0) throw new RangeError('sourceEnd out of bounds')
+  
+    // Are we oob?
+    if (end > this.length) end = this.length
+    if (target.length - targetStart < end - start) {
+      end = target.length - targetStart + start
+    }
+  
+    var len = end - start
+    var i
+  
+    if (this === target && start < targetStart && targetStart < end) {
+      // descending copy from end
+      for (i = len - 1; i >= 0; --i) {
+        target[i + targetStart] = this[i + start]
+      }
+    } else if (len < 1000) {
+      // ascending copy from start
+      for (i = 0; i < len; ++i) {
+        target[i + targetStart] = this[i + start]
+      }
+    } else {
+      Uint8Array.prototype.set.call(
+        target,
+        this.subarray(start, start + len),
+        targetStart
+      )
+    }
+  
+    return len
+  }
+  
+  // Usage:
+  //    buffer.fill(number[, offset[, end]])
+  //    buffer.fill(buffer[, offset[, end]])
+  //    buffer.fill(string[, offset[, end]][, encoding])
+  Buffer.prototype.fill = function fill (val, start, end, encoding) {
+    // Handle string cases:
+    if (typeof val === 'string') {
+      if (typeof start === 'string') {
+        encoding = start
+        start = 0
+        end = this.length
+      } else if (typeof end === 'string') {
+        encoding = end
+        end = this.length
+      }
+      if (val.length === 1) {
+        var code = val.charCodeAt(0)
+        if (code < 256) {
+          val = code
+        }
+      }
+      if (encoding !== undefined && typeof encoding !== 'string') {
+        throw new TypeError('encoding must be a string')
+      }
+      if (typeof encoding === 'string' && !Buffer.isEncoding(encoding)) {
+        throw new TypeError('Unknown encoding: ' + encoding)
+      }
+    } else if (typeof val === 'number') {
+      val = val & 255
+    }
+  
+    // Invalid ranges are not set to a default, so can range check early.
+    if (start < 0 || this.length < start || this.length < end) {
+      throw new RangeError('Out of range index')
+    }
+  
+    if (end <= start) {
+      return this
+    }
+  
+    start = start >>> 0
+    end = end === undefined ? this.length : end >>> 0
+  
+    if (!val) val = 0
+  
+    var i
+    if (typeof val === 'number') {
+      for (i = start; i < end; ++i) {
+        this[i] = val
+      }
+    } else {
+      var bytes = Buffer.isBuffer(val)
+        ? val
+        : new Buffer(val, encoding)
+      var len = bytes.length
+      for (i = 0; i < end - start; ++i) {
+        this[i + start] = bytes[i % len]
+      }
+    }
+  
+    return this
+  }
+  
+  // HELPER FUNCTIONS
+  // ================
+  
+  var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g
+  
+  function base64clean (str) {
+    // Node strips out invalid characters like \n and \t from the string, base64-js does not
+    str = str.trim().replace(INVALID_BASE64_RE, '')
+    // Node converts strings with length < 2 to ''
+    if (str.length < 2) return ''
+    // Node allows for non-padded base64 strings (missing trailing ===), base64-js does not
+    while (str.length % 4 !== 0) {
+      str = str + '='
+    }
+    return str
+  }
+  
+  function toHex (n) {
+    if (n < 16) return '0' + n.toString(16)
+    return n.toString(16)
+  }
+  
+  function utf8ToBytes (string, units) {
+    units = units || Infinity
+    var codePoint
+    var length = string.length
+    var leadSurrogate = null
+    var bytes = []
+  
+    for (var i = 0; i < length; ++i) {
+      codePoint = string.charCodeAt(i)
+  
+      // is surrogate component
+      if (codePoint > 0xD7FF && codePoint < 0xE000) {
+        // last char was a lead
+        if (!leadSurrogate) {
+          // no lead yet
+          if (codePoint > 0xDBFF) {
+            // unexpected trail
+            if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+            continue
+          } else if (i + 1 === length) {
+            // unpaired lead
+            if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+            continue
+          }
+  
+          // valid lead
+          leadSurrogate = codePoint
+  
+          continue
+        }
+  
+        // 2 leads in a row
+        if (codePoint < 0xDC00) {
+          if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+          leadSurrogate = codePoint
+          continue
+        }
+  
+        // valid surrogate pair
+        codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000
+      } else if (leadSurrogate) {
+        // valid bmp char, but last char was a lead
+        if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+      }
+  
+      leadSurrogate = null
+  
+      // encode utf8
+      if (codePoint < 0x80) {
+        if ((units -= 1) < 0) break
+        bytes.push(codePoint)
+      } else if (codePoint < 0x800) {
+        if ((units -= 2) < 0) break
+        bytes.push(
+          codePoint >> 0x6 | 0xC0,
+          codePoint & 0x3F | 0x80
+        )
+      } else if (codePoint < 0x10000) {
+        if ((units -= 3) < 0) break
+        bytes.push(
+          codePoint >> 0xC | 0xE0,
+          codePoint >> 0x6 & 0x3F | 0x80,
+          codePoint & 0x3F | 0x80
+        )
+      } else if (codePoint < 0x110000) {
+        if ((units -= 4) < 0) break
+        bytes.push(
+          codePoint >> 0x12 | 0xF0,
+          codePoint >> 0xC & 0x3F | 0x80,
+          codePoint >> 0x6 & 0x3F | 0x80,
+          codePoint & 0x3F | 0x80
+        )
+      } else {
+        throw new Error('Invalid code point')
+      }
+    }
+  
+    return bytes
+  }
+  
+  function asciiToBytes (str) {
+    var byteArray = []
+    for (var i = 0; i < str.length; ++i) {
+      // Node's code seems to be doing this and not & 0x7F..
+      byteArray.push(str.charCodeAt(i) & 0xFF)
+    }
+    return byteArray
+  }
+  
+  function utf16leToBytes (str, units) {
+    var c, hi, lo
+    var byteArray = []
+    for (var i = 0; i < str.length; ++i) {
+      if ((units -= 2) < 0) break
+  
+      c = str.charCodeAt(i)
+      hi = c >> 8
+      lo = c % 256
+      byteArray.push(lo)
+      byteArray.push(hi)
+    }
+  
+    return byteArray
+  }
+  
+  function base64ToBytes (str) {
+    return base64.toByteArray(base64clean(str))
+  }
+  
+  function blitBuffer (src, dst, offset, length) {
+    for (var i = 0; i < length; ++i) {
+      if ((i + offset >= dst.length) || (i >= src.length)) break
+      dst[i + offset] = src[i]
+    }
+    return i
+  }
+  
+  // ArrayBuffers from another context (i.e. an iframe) do not pass the `instanceof` check
+  // but they should be treated as valid. See: https://github.com/feross/buffer/issues/166
+  function isArrayBuffer (obj) {
+    return obj instanceof ArrayBuffer ||
+      (obj != null && obj.constructor != null && obj.constructor.name === 'ArrayBuffer' &&
+        typeof obj.byteLength === 'number')
+  }
+  
+  // Node 0.10 supports `ArrayBuffer` but lacks `ArrayBuffer.isView`
+  function isArrayBufferView (obj) {
+    return (typeof ArrayBuffer.isView === 'function') && ArrayBuffer.isView(obj)
+  }
+  
+  function numberIsNaN (obj) {
+    return obj !== obj // eslint-disable-line no-self-compare
+  }
+  
+  },{"base64-js":2,"ieee754":20}],9:[function(require,module,exports){
+  /**
+   * @license
+   * https://github.com/bitcoincashjs/cashaddr
+   * Copyright (c) 2017-2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  'use strict';
+  
+  var validate = require('./validation').validate;
+  
+  /**
+   * Base32 encoding and decoding.
+   *
+   * @module base32
+   */
+  
+  /**
+   * Charset containing the 32 symbols used in the base32 encoding.
+   * @private
+   */
+  var CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  
+  /**
+   * Inverted index mapping each symbol into its index within the charset.
+   * @private
+   */
+  var CHARSET_INVERSE_INDEX = {
+    'q': 0, 'p': 1, 'z': 2, 'r': 3, 'y': 4, '9': 5, 'x': 6, '8': 7,
+    'g': 8, 'f': 9, '2': 10, 't': 11, 'v': 12, 'd': 13, 'w': 14, '0': 15,
+    's': 16, '3': 17, 'j': 18, 'n': 19, '5': 20, '4': 21, 'k': 22, 'h': 23,
+    'c': 24, 'e': 25, '6': 26, 'm': 27, 'u': 28, 'a': 29, '7': 30, 'l': 31,
+  };
+  
+  /**
+   * Encodes the given array of 5-bit integers as a base32-encoded string.
+   *
+   * @static
+   * @param {Uint8Array} data Array of integers between 0 and 31 inclusive.
+   * @returns {string}
+   * @throws {ValidationError}
+   */
+  function encode(data) {
+    validate(data instanceof Uint8Array, 'Invalid data: ' + data + '.');
+    var base32 = '';
+    for (var i = 0; i < data.length; ++i) {
+      var value = data[i];
+      validate(0 <= value && value < 32, 'Invalid value: ' + value + '.');
+      base32 += CHARSET[value];
+    }
+    return base32;
+  }
+  
+  /**
+   * Decodes the given base32-encoded string into an array of 5-bit integers.
+   *
+   * @static
+   * @param {string} string
+   * @returns {Uint8Array}
+   * @throws {ValidationError}
+   */
+  function decode(string) {
+    validate(typeof string === 'string', 'Invalid base32-encoded string: ' + string + '.');
+    var data = new Uint8Array(string.length);
+    for (var i = 0; i < string.length; ++i) {
+      var value = string[i];
+      validate(value in CHARSET_INVERSE_INDEX, 'Invalid value: ' + value + '.');
+      data[i] = CHARSET_INVERSE_INDEX[value];
+    }
+    return data;
+  }
+  
+  module.exports = {
+    encode: encode,
+    decode: decode,
+  };
+  
+  },{"./validation":12}],10:[function(require,module,exports){
+  /**
+   * @license
+   * https://github.com/bitcoincashjs/cashaddr
+   * Copyright (c) 2017-2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  'use strict';
+  
+  var base32 = require('./base32');
+  var bigInt = require('big-integer');
+  var convertBits = require('./convertBits');
+  var validation = require('./validation');
+  var validate = validation.validate;
+  
+  /**
+   * Encoding and decoding of the new Cash Address format for Bitcoin Cash. <br />
+   * Compliant with the original cashaddr specification:
+   * {@link https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md}
+   * @module cashaddr
+   */
+  
+  /**
+   * Encodes a hash from a given type into a Bitcoin Cash address with the given prefix.
+   * 
+   * @static
+   * @param {string} prefix Network prefix. E.g.: 'bitcoincash'.
+   * @param {string} type Type of address to generate. Either 'P2PKH' or 'P2SH'.
+   * @param {Uint8Array} hash Hash to encode represented as an array of 8-bit integers.
+   * @returns {string}
+   * @throws {ValidationError}
+   */
+  function encode(prefix, type, hash) {
+    validate(typeof prefix === 'string' && isValidPrefix(prefix), 'Invalid prefix: ' + prefix + '.');
+    validate(typeof type === 'string', 'Invalid type: ' + type + '.');
+    validate(hash instanceof Uint8Array, 'Invalid hash: ' + hash + '.');
+    var prefixData = concat(prefixToUint5Array(prefix), new Uint8Array(1));
+    var versionByte = getTypeBits(type) + getHashSizeBits(hash);
+    var payloadData = toUint5Array(concat(Uint8Array.of(versionByte), hash));
+    var checksumData = concat(concat(prefixData, payloadData), new Uint8Array(8));
+    var payload = concat(payloadData, checksumToUint5Array(polymod(checksumData)));
+    return prefix + ':' + base32.encode(payload);
+  }
+  
+  /**
+   * Decodes the given address into its constituting prefix, type and hash. See [#encode()]{@link encode}.
+   * 
+   * @static
+   * @param {string} address Address to decode. E.g.: 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'.
+   * @returns {object}
+   * @throws {ValidationError}
+   */
+  function decode(address) {
+    validate(typeof address === 'string' && hasSingleCase(address), 'Invalid address: ' + address + '.');
+    var pieces = address.toLowerCase().split(':');
+    validate(pieces.length === 2, 'Missing prefix: ' + address + '.');
+    var prefix = pieces[0];
+    var payload = base32.decode(pieces[1]);
+    validate(validChecksum(prefix, payload), 'Invalid checksum: ' + address + '.');
+    var payloadData = fromUint5Array(payload.slice(0, -8));
+    var versionByte = payloadData[0];
+    var hash = payloadData.slice(1);
+    validate(getHashSize(versionByte) === hash.length * 8, 'Invalid hash size: ' + address + '.');
+    var type = getType(versionByte);
+    return {
+      prefix: prefix,
+      type: type,
+      hash: hash,
+    };
+  }
+  
+  /**
+   * Error thrown when encoding or decoding fail due to invalid input.
+   *
+   * @constructor ValidationError
+   * @param {string} message Error description.
+   */
+  var ValidationError = validation.ValidationError;
+  
+  /**
+   * Valid address prefixes.
+   *
+   * @private
+   */
+  var VALID_PREFIXES = ['bitcoincash', 'bchtest', 'bchreg'];
+  
+  /**
+   * Checks whether a string is a valid prefix; ie., it has a single letter case
+   * and is one of 'bitcoincash', 'bchtest', or 'bchreg'.
+   *
+   * @private
+   * @param {string} prefix 
+   * @returns {boolean}
+   */
+  function isValidPrefix(prefix) {
+    return hasSingleCase(prefix) && VALID_PREFIXES.indexOf(prefix.toLowerCase()) !== -1;
+  }
+  
+  /**
+   * Derives an array from the given prefix to be used in the computation
+   * of the address' checksum.
+   *
+   * @private
+   * @param {string} prefix Network prefix. E.g.: 'bitcoincash'. 
+   * @returns {Uint8Array}
+   */
+  function prefixToUint5Array(prefix) {
+    var result = new Uint8Array(prefix.length);
+    for (var i = 0; i < prefix.length; ++i) {
+      result[i] = prefix[i].charCodeAt(0) & 31;
+    }
+    return result;
+  }
+  
+  /**
+   * Returns an array representation of the given checksum to be encoded
+   * within the address' payload.
+   *
+   * @private
+   * @param {BigInteger} checksum Computed checksum.
+   * @returns {Uint8Array}
+   */
+  function checksumToUint5Array(checksum) {
+    var result = new Uint8Array(8);
+    for (var i = 0; i < 8; ++i) {
+      result[7 - i] = checksum.and(31).toJSNumber();
+      checksum = checksum.shiftRight(5);
+    }
+    return result;
+  }
+  
+  /**
+   * Returns the bit representation of the given type within the version
+   * byte.
+   *
+   * @private
+   * @param {string} type Address type. Either 'P2PKH' or 'P2SH'.
+   * @returns {number}
+   * @throws {ValidationError}
+   */
+  function getTypeBits(type) {
+    switch (type) {
+    case 'P2PKH':
+      return 0;
+    case 'P2SH':
+      return 8;
+    default:
+      throw new ValidationError('Invalid type: ' + type + '.');
+    }
+  }
+  
+  /**
+   * Retrieves the address type from its bit representation within the
+   * version byte.
+   *
+   * @private
+   * @param {number} versionByte
+   * @returns {string}
+   * @throws {ValidationError}
+   */
+  function getType(versionByte) {
+    switch (versionByte & 120) {
+    case 0:
+      return 'P2PKH';
+    case 8:
+      return 'P2SH';
+    default:
+      throw new ValidationError('Invalid address type in version byte: ' + versionByte + '.');
+    }
+  }
+  
+  /**
+   * Returns the bit representation of the length in bits of the given
+   * hash within the version byte.
+   *
+   * @private
+   * @param {Uint8Array} hash Hash to encode represented as an array of 8-bit integers.
+   * @returns {number}
+   * @throws {ValidationError}
+   */
+  function getHashSizeBits(hash) {
+    switch (hash.length * 8) {
+    case 160:
+      return 0;
+    case 192:
+      return 1;
+    case 224:
+      return 2;
+    case 256:
+      return 3;
+    case 320:
+      return 4;
+    case 384:
+      return 5;
+    case 448:
+      return 6;
+    case 512:
+      return 7;
+    default:
+      throw new ValidationError('Invalid hash size: ' + hash.length + '.');
+    }
+  }
+  
+  /**
+   * Retrieves the the length in bits of the encoded hash from its bit
+   * representation within the version byte.
+   *
+   * @private
+   * @param {number} versionByte
+   * @returns {number}
+   */
+  function getHashSize(versionByte) {
+    switch (versionByte & 7) {
+    case 0:
+      return 160;
+    case 1:
+      return 192;
+    case 2:
+      return 224;
+    case 3:
+      return 256;
+    case 4:
+      return 320;
+    case 5:
+      return 384;
+    case 6:
+      return 448;
+    case 7:
+      return 512;
+    }
+  }
+  
+  /**
+   * Converts an array of 8-bit integers into an array of 5-bit integers,
+   * right-padding with zeroes if necessary.
+   *
+   * @private
+   * @param {Uint8Array} data
+   * @returns {Uint8Array}
+   */
+  function toUint5Array(data) {
+    return convertBits(data, 8, 5);
+  }
+  
+  /**
+   * Converts an array of 5-bit integers back into an array of 8-bit integers,
+   * removing extra zeroes left from padding if necessary.
+   * Throws a {@link ValidationError} if input is not a zero-padded array of 8-bit integers.
+   *
+   * @private
+   * @param {Uint8Array} data
+   * @returns {Uint8Array}
+   * @throws {ValidationError}
+   */
+  function fromUint5Array(data) {
+    return convertBits(data, 5, 8, true);
+  }
+  
+  /**
+   * Returns the concatenation a and b.
+   *
+   * @private
+   * @param {Uint8Array} a 
+   * @param {Uint8Array} b 
+   * @returns {Uint8Array}
+   * @throws {ValidationError}
+   */
+  function concat(a, b) {
+    var ab = new Uint8Array(a.length + b.length);
+    ab.set(a);
+    ab.set(b, a.length);
+    return ab;
+  }
+  
+  /**
+   * Computes a checksum from the given input data as specified for the CashAddr
+   * format: https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md.
+   *
+   * @private
+   * @param {Uint8Array} data Array of 5-bit integers over which the checksum is to be computed.
+   * @returns {BigInteger}
+   */
+  function polymod(data) {
+    var GENERATOR = [0x98f2bc8e61, 0x79b76d99e2, 0xf33e5fb3c4, 0xae2eabe2a8, 0x1e4f43e470];
+    var checksum = bigInt(1);
+    for (var i = 0; i < data.length; ++i) {
+      var value = data[i];
+      var topBits = checksum.shiftRight(35);
+      checksum = checksum.and(0x07ffffffff).shiftLeft(5).xor(value);
+      for (var j = 0; j < GENERATOR.length; ++j) {
+        if (topBits.shiftRight(j).and(1).equals(1)) {
+          checksum = checksum.xor(GENERATOR[j]);
+        }
+      }
+    }
+    return checksum.xor(1);
+  }
+  
+  /**
+   * Verify that the payload has not been corrupted by checking that the
+   * checksum is valid.
+   * 
+   * @private
+   * @param {string} prefix Network prefix. E.g.: 'bitcoincash'.
+   * @param {Uint8Array} payload Array of 5-bit integers containing the address' payload.
+   * @returns {boolean}
+   */
+  function validChecksum(prefix, payload) {
+    var prefixData = concat(prefixToUint5Array(prefix), new Uint8Array(1));
+    var checksumData = concat(prefixData, payload);
+    return polymod(checksumData).equals(0);
+  }
+  
+  /**
+   * Returns true if, and only if, the given string contains either uppercase
+   * or lowercase letters, but not both.
+   *
+   * @private
+   * @param {string} string Input string.
+   * @returns {boolean}
+   */
+  function hasSingleCase(string) {
+    return string === string.toLowerCase() || string === string.toUpperCase();
+  }
+  
+  module.exports = {
+    encode: encode,
+    decode: decode,
+    ValidationError: ValidationError,
+  };
+  
+  },{"./base32":9,"./convertBits":11,"./validation":12,"big-integer":3}],11:[function(require,module,exports){
+  // Copyright (c) 2017-2018 Emilio Almansi
+  // Copyright (c) 2017 Pieter Wuille
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a copy
+  // of this software and associated documentation files (the "Software"), to deal
+  // in the Software without restriction, including without limitation the rights
+  // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  // copies of the Software, and to permit persons to whom the Software is
+  // furnished to do so, subject to the following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included in
+  // all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  // THE SOFTWARE.
+  
+  'use strict';
+  
+  var validate = require('./validation').validate;
+  
+  /**
+   * Converts an array of integers made up of 'from' bits into an
+   * array of integers made up of 'to' bits. The output array is
+   * zero-padded if necessary, unless strict mode is true.
+   * Throws a {@link ValidationError} if input is invalid.
+   * Original by Pieter Wuille: https://github.com/sipa/bech32.
+   *
+   * @param {Uint8Array} data Array of integers made up of 'from' bits.
+   * @param {number} from Length in bits of elements in the input array.
+   * @param {number} to Length in bits of elements in the output array.
+   * @param {bool} strictMode Require the conversion to be completed without padding.
+   * @returns {Uint8Array}
+   */
+  module.exports = function(data, from, to, strictMode) {
+    var length = strictMode
+      ? Math.floor(data.length * from / to)
+      : Math.ceil(data.length * from / to);
+    var mask = (1 << to) - 1;
+    var result = new Uint8Array(length);
+    var index = 0;
+    var accumulator = 0;
+    var bits = 0;
+    for (var i = 0; i < data.length; ++i) {
+      var value = data[i];
+      validate(0 <= value && (value >> from) === 0, 'Invalid value: ' + value + '.');
+      accumulator = (accumulator << from) | value;
+      bits += from;
+      while (bits >= to) {
+        bits -= to;
+        result[index] = (accumulator >> bits) & mask;
+        ++index;
+      }
+    }
+    if (!strictMode) {
+      if (bits > 0) {
+        result[index] = (accumulator << (to - bits)) & mask;
+        ++index;
+      }
+    } else {
+      validate(
+        bits < from && ((accumulator << (to - bits)) & mask) === 0,
+        'Input cannot be converted to ' + to + ' bits without padding, but strict mode was used.'
+      );
+    }
+    return result;
+  };
+  
+  },{"./validation":12}],12:[function(require,module,exports){
+  /**
+   * @license
+   * https://github.com/bitcoincashjs/cashaddr
+   * Copyright (c) 2017-2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  'use strict';
+  
+  /**
+   * Validation utility.
+   *
+   * @module validation
+   */
+  
+  /**
+   * Error thrown when encoding or decoding fail due to invalid input.
+   *
+   * @constructor ValidationError
+   * @param {string} message Error description.
+   */
+  function ValidationError(message) {
+    var error = new Error();
+    this.name = error.name = 'ValidationError';
+    this.message = error.message = message;
+    this.stack = error.stack;
+  }
+  
+  ValidationError.prototype = Object.create(Error.prototype);
+  
+  /**
+   * Validates a given condition, throwing a {@link ValidationError} if
+   * the given condition does not hold.
+   *
+   * @static
+   * @param {boolean} condition Condition to validate.
+   * @param {string} message Error message in case the condition does not hold.
+   */
+  function validate(condition, message) {
+    if (!condition) {
+      throw new ValidationError(message);
+    }
+  }
+  
+  module.exports = {
+    ValidationError: ValidationError,
+    validate: validate,
+  };
+  
+  },{}],13:[function(require,module,exports){
+  var Buffer = require('safe-buffer').Buffer
+  var Transform = require('stream').Transform
+  var StringDecoder = require('string_decoder').StringDecoder
+  var inherits = require('inherits')
+  
+  function CipherBase (hashMode) {
+    Transform.call(this)
+    this.hashMode = typeof hashMode === 'string'
+    if (this.hashMode) {
+      this[hashMode] = this._finalOrDigest
+    } else {
+      this.final = this._finalOrDigest
+    }
+    if (this._final) {
+      this.__final = this._final
+      this._final = null
+    }
+    this._decoder = null
+    this._encoding = null
+  }
+  inherits(CipherBase, Transform)
+  
+  CipherBase.prototype.update = function (data, inputEnc, outputEnc) {
+    if (typeof data === 'string') {
+      data = Buffer.from(data, inputEnc)
+    }
+  
+    var outData = this._update(data)
+    if (this.hashMode) return this
+  
+    if (outputEnc) {
+      outData = this._toString(outData, outputEnc)
+    }
+  
+    return outData
+  }
+  
+  CipherBase.prototype.setAutoPadding = function () {}
+  CipherBase.prototype.getAuthTag = function () {
+    throw new Error('trying to get auth tag in unsupported state')
+  }
+  
+  CipherBase.prototype.setAuthTag = function () {
+    throw new Error('trying to set auth tag in unsupported state')
+  }
+  
+  CipherBase.prototype.setAAD = function () {
+    throw new Error('trying to set aad in unsupported state')
+  }
+  
+  CipherBase.prototype._transform = function (data, _, next) {
+    var err
+    try {
+      if (this.hashMode) {
+        this._update(data)
+      } else {
+        this.push(this._update(data))
+      }
+    } catch (e) {
+      err = e
+    } finally {
+      next(err)
+    }
+  }
+  CipherBase.prototype._flush = function (done) {
+    var err
+    try {
+      this.push(this.__final())
+    } catch (e) {
+      err = e
+    }
+  
+    done(err)
+  }
+  CipherBase.prototype._finalOrDigest = function (outputEnc) {
+    var outData = this.__final() || Buffer.alloc(0)
+    if (outputEnc) {
+      outData = this._toString(outData, outputEnc, true)
+    }
+    return outData
+  }
+  
+  CipherBase.prototype._toString = function (value, enc, fin) {
+    if (!this._decoder) {
+      this._decoder = new StringDecoder(enc)
+      this._encoding = enc
+    }
+  
+    if (this._encoding !== enc) throw new Error('can\'t switch encodings')
+  
+    var out = this._decoder.write(value)
+    if (fin) {
+      out += this._decoder.end()
+    }
+  
+    return out
+  }
+  
+  module.exports = CipherBase
+  
+  },{"inherits":21,"safe-buffer":40,"stream":49,"string_decoder":50}],14:[function(require,module,exports){
+  (function (Buffer){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // NOTE: These type checking functions intentionally don't use `instanceof`
+  // because it is fragile and can be easily faked with `Object.create()`.
+  
+  function isArray(arg) {
+    if (Array.isArray) {
+      return Array.isArray(arg);
+    }
+    return objectToString(arg) === '[object Array]';
+  }
+  exports.isArray = isArray;
+  
+  function isBoolean(arg) {
+    return typeof arg === 'boolean';
+  }
+  exports.isBoolean = isBoolean;
+  
+  function isNull(arg) {
+    return arg === null;
+  }
+  exports.isNull = isNull;
+  
+  function isNullOrUndefined(arg) {
+    return arg == null;
+  }
+  exports.isNullOrUndefined = isNullOrUndefined;
+  
+  function isNumber(arg) {
+    return typeof arg === 'number';
+  }
+  exports.isNumber = isNumber;
+  
+  function isString(arg) {
+    return typeof arg === 'string';
+  }
+  exports.isString = isString;
+  
+  function isSymbol(arg) {
+    return typeof arg === 'symbol';
+  }
+  exports.isSymbol = isSymbol;
+  
+  function isUndefined(arg) {
+    return arg === void 0;
+  }
+  exports.isUndefined = isUndefined;
+  
+  function isRegExp(re) {
+    return objectToString(re) === '[object RegExp]';
+  }
+  exports.isRegExp = isRegExp;
+  
+  function isObject(arg) {
+    return typeof arg === 'object' && arg !== null;
+  }
+  exports.isObject = isObject;
+  
+  function isDate(d) {
+    return objectToString(d) === '[object Date]';
+  }
+  exports.isDate = isDate;
+  
+  function isError(e) {
+    return (objectToString(e) === '[object Error]' || e instanceof Error);
+  }
+  exports.isError = isError;
+  
+  function isFunction(arg) {
+    return typeof arg === 'function';
+  }
+  exports.isFunction = isFunction;
+  
+  function isPrimitive(arg) {
+    return arg === null ||
+           typeof arg === 'boolean' ||
+           typeof arg === 'number' ||
+           typeof arg === 'string' ||
+           typeof arg === 'symbol' ||  // ES6 symbol
+           typeof arg === 'undefined';
+  }
+  exports.isPrimitive = isPrimitive;
+  
+  exports.isBuffer = Buffer.isBuffer;
+  
+  function objectToString(o) {
+    return Object.prototype.toString.call(o);
+  }
+  
+  }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
+  },{"../../is-buffer/index.js":22}],15:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var inherits = require('inherits')
+  var md5 = require('./md5')
+  var RIPEMD160 = require('ripemd160')
+  var sha = require('sha.js')
+  
+  var Base = require('cipher-base')
+  
+  function HashNoConstructor (hash) {
+    Base.call(this, 'digest')
+  
+    this._hash = hash
+    this.buffers = []
+  }
+  
+  inherits(HashNoConstructor, Base)
+  
+  HashNoConstructor.prototype._update = function (data) {
+    this.buffers.push(data)
+  }
+  
+  HashNoConstructor.prototype._final = function () {
+    var buf = Buffer.concat(this.buffers)
+    var r = this._hash(buf)
+    this.buffers = null
+  
+    return r
+  }
+  
+  function Hash (hash) {
+    Base.call(this, 'digest')
+  
+    this._hash = hash
+  }
+  
+  inherits(Hash, Base)
+  
+  Hash.prototype._update = function (data) {
+    this._hash.update(data)
+  }
+  
+  Hash.prototype._final = function () {
+    return this._hash.digest()
+  }
+  
+  module.exports = function createHash (alg) {
+    alg = alg.toLowerCase()
+    if (alg === 'md5') return new HashNoConstructor(md5)
+    if (alg === 'rmd160' || alg === 'ripemd160') return new Hash(new RIPEMD160())
+  
+    return new Hash(sha(alg))
+  }
+  
+  }).call(this,require("buffer").Buffer)
+  },{"./md5":17,"buffer":8,"cipher-base":13,"inherits":21,"ripemd160":39,"sha.js":42}],16:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var intSize = 4
+  var zeroBuffer = new Buffer(intSize)
+  zeroBuffer.fill(0)
+  
+  var charSize = 8
+  var hashSize = 16
+  
+  function toArray (buf) {
+    if ((buf.length % intSize) !== 0) {
+      var len = buf.length + (intSize - (buf.length % intSize))
+      buf = Buffer.concat([buf, zeroBuffer], len)
+    }
+  
+    var arr = new Array(buf.length >>> 2)
+    for (var i = 0, j = 0; i < buf.length; i += intSize, j++) {
+      arr[j] = buf.readInt32LE(i)
+    }
+  
+    return arr
+  }
+  
+  module.exports = function hash (buf, fn) {
+    var arr = fn(toArray(buf), buf.length * charSize)
+    buf = new Buffer(hashSize)
+    for (var i = 0; i < arr.length; i++) {
+      buf.writeInt32LE(arr[i], i << 2, true)
+    }
+    return buf
+  }
+  
+  }).call(this,require("buffer").Buffer)
+  },{"buffer":8}],17:[function(require,module,exports){
+  'use strict'
+  /*
+   * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
+   * Digest Algorithm, as defined in RFC 1321.
+   * Version 2.1 Copyright (C) Paul Johnston 1999 - 2002.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   * Distributed under the BSD License
+   * See http://pajhome.org.uk/crypt/md5 for more info.
+   */
+  
+  var makeHash = require('./make-hash')
+  
+  /*
+   * Calculate the MD5 of an array of little-endian words, and a bit length
+   */
+  function core_md5 (x, len) {
+    /* append padding */
+    x[len >> 5] |= 0x80 << ((len) % 32)
+    x[(((len + 64) >>> 9) << 4) + 14] = len
+  
+    var a = 1732584193
+    var b = -271733879
+    var c = -1732584194
+    var d = 271733878
+  
+    for (var i = 0; i < x.length; i += 16) {
+      var olda = a
+      var oldb = b
+      var oldc = c
+      var oldd = d
+  
+      a = md5_ff(a, b, c, d, x[i + 0], 7, -680876936)
+      d = md5_ff(d, a, b, c, x[i + 1], 12, -389564586)
+      c = md5_ff(c, d, a, b, x[i + 2], 17, 606105819)
+      b = md5_ff(b, c, d, a, x[i + 3], 22, -1044525330)
+      a = md5_ff(a, b, c, d, x[i + 4], 7, -176418897)
+      d = md5_ff(d, a, b, c, x[i + 5], 12, 1200080426)
+      c = md5_ff(c, d, a, b, x[i + 6], 17, -1473231341)
+      b = md5_ff(b, c, d, a, x[i + 7], 22, -45705983)
+      a = md5_ff(a, b, c, d, x[i + 8], 7, 1770035416)
+      d = md5_ff(d, a, b, c, x[i + 9], 12, -1958414417)
+      c = md5_ff(c, d, a, b, x[i + 10], 17, -42063)
+      b = md5_ff(b, c, d, a, x[i + 11], 22, -1990404162)
+      a = md5_ff(a, b, c, d, x[i + 12], 7, 1804603682)
+      d = md5_ff(d, a, b, c, x[i + 13], 12, -40341101)
+      c = md5_ff(c, d, a, b, x[i + 14], 17, -1502002290)
+      b = md5_ff(b, c, d, a, x[i + 15], 22, 1236535329)
+  
+      a = md5_gg(a, b, c, d, x[i + 1], 5, -165796510)
+      d = md5_gg(d, a, b, c, x[i + 6], 9, -1069501632)
+      c = md5_gg(c, d, a, b, x[i + 11], 14, 643717713)
+      b = md5_gg(b, c, d, a, x[i + 0], 20, -373897302)
+      a = md5_gg(a, b, c, d, x[i + 5], 5, -701558691)
+      d = md5_gg(d, a, b, c, x[i + 10], 9, 38016083)
+      c = md5_gg(c, d, a, b, x[i + 15], 14, -660478335)
+      b = md5_gg(b, c, d, a, x[i + 4], 20, -405537848)
+      a = md5_gg(a, b, c, d, x[i + 9], 5, 568446438)
+      d = md5_gg(d, a, b, c, x[i + 14], 9, -1019803690)
+      c = md5_gg(c, d, a, b, x[i + 3], 14, -187363961)
+      b = md5_gg(b, c, d, a, x[i + 8], 20, 1163531501)
+      a = md5_gg(a, b, c, d, x[i + 13], 5, -1444681467)
+      d = md5_gg(d, a, b, c, x[i + 2], 9, -51403784)
+      c = md5_gg(c, d, a, b, x[i + 7], 14, 1735328473)
+      b = md5_gg(b, c, d, a, x[i + 12], 20, -1926607734)
+  
+      a = md5_hh(a, b, c, d, x[i + 5], 4, -378558)
+      d = md5_hh(d, a, b, c, x[i + 8], 11, -2022574463)
+      c = md5_hh(c, d, a, b, x[i + 11], 16, 1839030562)
+      b = md5_hh(b, c, d, a, x[i + 14], 23, -35309556)
+      a = md5_hh(a, b, c, d, x[i + 1], 4, -1530992060)
+      d = md5_hh(d, a, b, c, x[i + 4], 11, 1272893353)
+      c = md5_hh(c, d, a, b, x[i + 7], 16, -155497632)
+      b = md5_hh(b, c, d, a, x[i + 10], 23, -1094730640)
+      a = md5_hh(a, b, c, d, x[i + 13], 4, 681279174)
+      d = md5_hh(d, a, b, c, x[i + 0], 11, -358537222)
+      c = md5_hh(c, d, a, b, x[i + 3], 16, -722521979)
+      b = md5_hh(b, c, d, a, x[i + 6], 23, 76029189)
+      a = md5_hh(a, b, c, d, x[i + 9], 4, -640364487)
+      d = md5_hh(d, a, b, c, x[i + 12], 11, -421815835)
+      c = md5_hh(c, d, a, b, x[i + 15], 16, 530742520)
+      b = md5_hh(b, c, d, a, x[i + 2], 23, -995338651)
+  
+      a = md5_ii(a, b, c, d, x[i + 0], 6, -198630844)
+      d = md5_ii(d, a, b, c, x[i + 7], 10, 1126891415)
+      c = md5_ii(c, d, a, b, x[i + 14], 15, -1416354905)
+      b = md5_ii(b, c, d, a, x[i + 5], 21, -57434055)
+      a = md5_ii(a, b, c, d, x[i + 12], 6, 1700485571)
+      d = md5_ii(d, a, b, c, x[i + 3], 10, -1894986606)
+      c = md5_ii(c, d, a, b, x[i + 10], 15, -1051523)
+      b = md5_ii(b, c, d, a, x[i + 1], 21, -2054922799)
+      a = md5_ii(a, b, c, d, x[i + 8], 6, 1873313359)
+      d = md5_ii(d, a, b, c, x[i + 15], 10, -30611744)
+      c = md5_ii(c, d, a, b, x[i + 6], 15, -1560198380)
+      b = md5_ii(b, c, d, a, x[i + 13], 21, 1309151649)
+      a = md5_ii(a, b, c, d, x[i + 4], 6, -145523070)
+      d = md5_ii(d, a, b, c, x[i + 11], 10, -1120210379)
+      c = md5_ii(c, d, a, b, x[i + 2], 15, 718787259)
+      b = md5_ii(b, c, d, a, x[i + 9], 21, -343485551)
+  
+      a = safe_add(a, olda)
+      b = safe_add(b, oldb)
+      c = safe_add(c, oldc)
+      d = safe_add(d, oldd)
+    }
+  
+    return [a, b, c, d]
+  }
+  
+  /*
+   * These functions implement the four basic operations the algorithm uses.
+   */
+  function md5_cmn (q, a, b, x, s, t) {
+    return safe_add(bit_rol(safe_add(safe_add(a, q), safe_add(x, t)), s), b)
+  }
+  
+  function md5_ff (a, b, c, d, x, s, t) {
+    return md5_cmn((b & c) | ((~b) & d), a, b, x, s, t)
+  }
+  
+  function md5_gg (a, b, c, d, x, s, t) {
+    return md5_cmn((b & d) | (c & (~d)), a, b, x, s, t)
+  }
+  
+  function md5_hh (a, b, c, d, x, s, t) {
+    return md5_cmn(b ^ c ^ d, a, b, x, s, t)
+  }
+  
+  function md5_ii (a, b, c, d, x, s, t) {
+    return md5_cmn(c ^ (b | (~d)), a, b, x, s, t)
+  }
+  
+  /*
+   * Add integers, wrapping at 2^32. This uses 16-bit operations internally
+   * to work around bugs in some JS interpreters.
+   */
+  function safe_add (x, y) {
+    var lsw = (x & 0xFFFF) + (y & 0xFFFF)
+    var msw = (x >> 16) + (y >> 16) + (lsw >> 16)
+    return (msw << 16) | (lsw & 0xFFFF)
+  }
+  
+  /*
+   * Bitwise rotate a 32-bit number to the left.
+   */
+  function bit_rol (num, cnt) {
+    return (num << cnt) | (num >>> (32 - cnt))
+  }
+  
+  module.exports = function md5 (buf) {
+    return makeHash(buf, core_md5)
+  }
+  
+  },{"./make-hash":16}],18:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  function EventEmitter() {
+    this._events = this._events || {};
+    this._maxListeners = this._maxListeners || undefined;
+  }
+  module.exports = EventEmitter;
+  
+  // Backwards-compat with node 0.10.x
+  EventEmitter.EventEmitter = EventEmitter;
+  
+  EventEmitter.prototype._events = undefined;
+  EventEmitter.prototype._maxListeners = undefined;
+  
+  // By default EventEmitters will print a warning if more than 10 listeners are
+  // added to it. This is a useful default which helps finding memory leaks.
+  EventEmitter.defaultMaxListeners = 10;
+  
+  // Obviously not all Emitters should be limited to 10. This function allows
+  // that to be increased. Set to zero for unlimited.
+  EventEmitter.prototype.setMaxListeners = function(n) {
+    if (!isNumber(n) || n < 0 || isNaN(n))
+      throw TypeError('n must be a positive number');
+    this._maxListeners = n;
+    return this;
+  };
+  
+  EventEmitter.prototype.emit = function(type) {
+    var er, handler, len, args, i, listeners;
+  
+    if (!this._events)
+      this._events = {};
+  
+    // If there is no 'error' event listener then throw.
+    if (type === 'error') {
+      if (!this._events.error ||
+          (isObject(this._events.error) && !this._events.error.length)) {
+        er = arguments[1];
+        if (er instanceof Error) {
+          throw er; // Unhandled 'error' event
+        } else {
+          // At least give some kind of context to the user
+          var err = new Error('Uncaught, unspecified "error" event. (' + er + ')');
+          err.context = er;
+          throw err;
+        }
+      }
+    }
+  
+    handler = this._events[type];
+  
+    if (isUndefined(handler))
+      return false;
+  
+    if (isFunction(handler)) {
+      switch (arguments.length) {
+        // fast cases
+        case 1:
+          handler.call(this);
+          break;
+        case 2:
+          handler.call(this, arguments[1]);
+          break;
+        case 3:
+          handler.call(this, arguments[1], arguments[2]);
+          break;
+        // slower
+        default:
+          args = Array.prototype.slice.call(arguments, 1);
+          handler.apply(this, args);
+      }
+    } else if (isObject(handler)) {
+      args = Array.prototype.slice.call(arguments, 1);
+      listeners = handler.slice();
+      len = listeners.length;
+      for (i = 0; i < len; i++)
+        listeners[i].apply(this, args);
+    }
+  
+    return true;
+  };
+  
+  EventEmitter.prototype.addListener = function(type, listener) {
+    var m;
+  
+    if (!isFunction(listener))
+      throw TypeError('listener must be a function');
+  
+    if (!this._events)
+      this._events = {};
+  
+    // To avoid recursion in the case that type === "newListener"! Before
+    // adding it to the listeners, first emit "newListener".
+    if (this._events.newListener)
+      this.emit('newListener', type,
+                isFunction(listener.listener) ?
+                listener.listener : listener);
+  
+    if (!this._events[type])
+      // Optimize the case of one listener. Don't need the extra array object.
+      this._events[type] = listener;
+    else if (isObject(this._events[type]))
+      // If we've already got an array, just append.
+      this._events[type].push(listener);
+    else
+      // Adding the second element, need to change to array.
+      this._events[type] = [this._events[type], listener];
+  
+    // Check for listener leak
+    if (isObject(this._events[type]) && !this._events[type].warned) {
+      if (!isUndefined(this._maxListeners)) {
+        m = this._maxListeners;
+      } else {
+        m = EventEmitter.defaultMaxListeners;
+      }
+  
+      if (m && m > 0 && this._events[type].length > m) {
+        this._events[type].warned = true;
+        console.error('(node) warning: possible EventEmitter memory ' +
+                      'leak detected. %d listeners added. ' +
+                      'Use emitter.setMaxListeners() to increase limit.',
+                      this._events[type].length);
+        if (typeof console.trace === 'function') {
+          // not supported in IE 10
+          console.trace();
+        }
+      }
+    }
+  
+    return this;
+  };
+  
+  EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+  
+  EventEmitter.prototype.once = function(type, listener) {
+    if (!isFunction(listener))
+      throw TypeError('listener must be a function');
+  
+    var fired = false;
+  
+    function g() {
+      this.removeListener(type, g);
+  
+      if (!fired) {
+        fired = true;
+        listener.apply(this, arguments);
+      }
+    }
+  
+    g.listener = listener;
+    this.on(type, g);
+  
+    return this;
+  };
+  
+  // emits a 'removeListener' event iff the listener was removed
+  EventEmitter.prototype.removeListener = function(type, listener) {
+    var list, position, length, i;
+  
+    if (!isFunction(listener))
+      throw TypeError('listener must be a function');
+  
+    if (!this._events || !this._events[type])
+      return this;
+  
+    list = this._events[type];
+    length = list.length;
+    position = -1;
+  
+    if (list === listener ||
+        (isFunction(list.listener) && list.listener === listener)) {
+      delete this._events[type];
+      if (this._events.removeListener)
+        this.emit('removeListener', type, listener);
+  
+    } else if (isObject(list)) {
+      for (i = length; i-- > 0;) {
+        if (list[i] === listener ||
+            (list[i].listener && list[i].listener === listener)) {
+          position = i;
+          break;
+        }
+      }
+  
+      if (position < 0)
+        return this;
+  
+      if (list.length === 1) {
+        list.length = 0;
+        delete this._events[type];
+      } else {
+        list.splice(position, 1);
+      }
+  
+      if (this._events.removeListener)
+        this.emit('removeListener', type, listener);
+    }
+  
+    return this;
+  };
+  
+  EventEmitter.prototype.removeAllListeners = function(type) {
+    var key, listeners;
+  
+    if (!this._events)
+      return this;
+  
+    // not listening for removeListener, no need to emit
+    if (!this._events.removeListener) {
+      if (arguments.length === 0)
+        this._events = {};
+      else if (this._events[type])
+        delete this._events[type];
+      return this;
+    }
+  
+    // emit removeListener for all listeners on all events
+    if (arguments.length === 0) {
+      for (key in this._events) {
+        if (key === 'removeListener') continue;
+        this.removeAllListeners(key);
+      }
+      this.removeAllListeners('removeListener');
+      this._events = {};
+      return this;
+    }
+  
+    listeners = this._events[type];
+  
+    if (isFunction(listeners)) {
+      this.removeListener(type, listeners);
+    } else if (listeners) {
+      // LIFO order
+      while (listeners.length)
+        this.removeListener(type, listeners[listeners.length - 1]);
+    }
+    delete this._events[type];
+  
+    return this;
+  };
+  
+  EventEmitter.prototype.listeners = function(type) {
+    var ret;
+    if (!this._events || !this._events[type])
+      ret = [];
+    else if (isFunction(this._events[type]))
+      ret = [this._events[type]];
+    else
+      ret = this._events[type].slice();
+    return ret;
+  };
+  
+  EventEmitter.prototype.listenerCount = function(type) {
+    if (this._events) {
+      var evlistener = this._events[type];
+  
+      if (isFunction(evlistener))
+        return 1;
+      else if (evlistener)
+        return evlistener.length;
+    }
+    return 0;
+  };
+  
+  EventEmitter.listenerCount = function(emitter, type) {
+    return emitter.listenerCount(type);
+  };
+  
+  function isFunction(arg) {
+    return typeof arg === 'function';
+  }
+  
+  function isNumber(arg) {
+    return typeof arg === 'number';
+  }
+  
+  function isObject(arg) {
+    return typeof arg === 'object' && arg !== null;
+  }
+  
+  function isUndefined(arg) {
+    return arg === void 0;
+  }
+  
+  },{}],19:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var Transform = require('stream').Transform
+  var inherits = require('inherits')
+  
+  function HashBase (blockSize) {
+    Transform.call(this)
+  
+    this._block = new Buffer(blockSize)
+    this._blockSize = blockSize
+    this._blockOffset = 0
+    this._length = [0, 0, 0, 0]
+  
+    this._finalized = false
+  }
+  
+  inherits(HashBase, Transform)
+  
+  HashBase.prototype._transform = function (chunk, encoding, callback) {
+    var error = null
+    try {
+      if (encoding !== 'buffer') chunk = new Buffer(chunk, encoding)
+      this.update(chunk)
+    } catch (err) {
+      error = err
+    }
+  
+    callback(error)
+  }
+  
+  HashBase.prototype._flush = function (callback) {
+    var error = null
+    try {
+      this.push(this._digest())
+    } catch (err) {
+      error = err
+    }
+  
+    callback(error)
+  }
+  
+  HashBase.prototype.update = function (data, encoding) {
+    if (!Buffer.isBuffer(data) && typeof data !== 'string') throw new TypeError('Data must be a string or a buffer')
+    if (this._finalized) throw new Error('Digest already called')
+    if (!Buffer.isBuffer(data)) data = new Buffer(data, encoding || 'binary')
+  
+    // consume data
+    var block = this._block
+    var offset = 0
+    while (this._blockOffset + data.length - offset >= this._blockSize) {
+      for (var i = this._blockOffset; i < this._blockSize;) block[i++] = data[offset++]
+      this._update()
+      this._blockOffset = 0
+    }
+    while (offset < data.length) block[this._blockOffset++] = data[offset++]
+  
+    // update length
+    for (var j = 0, carry = data.length * 8; carry > 0; ++j) {
+      this._length[j] += carry
+      carry = (this._length[j] / 0x0100000000) | 0
+      if (carry > 0) this._length[j] -= 0x0100000000 * carry
+    }
+  
+    return this
+  }
+  
+  HashBase.prototype._update = function (data) {
+    throw new Error('_update is not implemented')
+  }
+  
+  HashBase.prototype.digest = function (encoding) {
+    if (this._finalized) throw new Error('Digest already called')
+    this._finalized = true
+  
+    var digest = this._digest()
+    if (encoding !== undefined) digest = digest.toString(encoding)
+    return digest
+  }
+  
+  HashBase.prototype._digest = function () {
+    throw new Error('_digest is not implemented')
+  }
+  
+  module.exports = HashBase
+  
+  }).call(this,require("buffer").Buffer)
+  },{"buffer":8,"inherits":21,"stream":49}],20:[function(require,module,exports){
+  exports.read = function (buffer, offset, isLE, mLen, nBytes) {
+    var e, m
+    var eLen = nBytes * 8 - mLen - 1
+    var eMax = (1 << eLen) - 1
+    var eBias = eMax >> 1
+    var nBits = -7
+    var i = isLE ? (nBytes - 1) : 0
+    var d = isLE ? -1 : 1
+    var s = buffer[offset + i]
+  
+    i += d
+  
+    e = s & ((1 << (-nBits)) - 1)
+    s >>= (-nBits)
+    nBits += eLen
+    for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+  
+    m = e & ((1 << (-nBits)) - 1)
+    e >>= (-nBits)
+    nBits += mLen
+    for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+  
+    if (e === 0) {
+      e = 1 - eBias
+    } else if (e === eMax) {
+      return m ? NaN : ((s ? -1 : 1) * Infinity)
+    } else {
+      m = m + Math.pow(2, mLen)
+      e = e - eBias
+    }
+    return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
+  }
+  
+  exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
+    var e, m, c
+    var eLen = nBytes * 8 - mLen - 1
+    var eMax = (1 << eLen) - 1
+    var eBias = eMax >> 1
+    var rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0)
+    var i = isLE ? 0 : (nBytes - 1)
+    var d = isLE ? 1 : -1
+    var s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0
+  
+    value = Math.abs(value)
+  
+    if (isNaN(value) || value === Infinity) {
+      m = isNaN(value) ? 1 : 0
+      e = eMax
+    } else {
+      e = Math.floor(Math.log(value) / Math.LN2)
+      if (value * (c = Math.pow(2, -e)) < 1) {
+        e--
+        c *= 2
+      }
+      if (e + eBias >= 1) {
+        value += rt / c
+      } else {
+        value += rt * Math.pow(2, 1 - eBias)
+      }
+      if (value * c >= 2) {
+        e++
+        c /= 2
+      }
+  
+      if (e + eBias >= eMax) {
+        m = 0
+        e = eMax
+      } else if (e + eBias >= 1) {
+        m = (value * c - 1) * Math.pow(2, mLen)
+        e = e + eBias
+      } else {
+        m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
+        e = 0
+      }
+    }
+  
+    for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8) {}
+  
+    e = (e << mLen) | m
+    eLen += mLen
+    for (; eLen > 0; buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8) {}
+  
+    buffer[offset + i - d] |= s * 128
+  }
+  
+  },{}],21:[function(require,module,exports){
+  if (typeof Object.create === 'function') {
+    // implementation from standard node.js 'util' module
+    module.exports = function inherits(ctor, superCtor) {
+      ctor.super_ = superCtor
+      ctor.prototype = Object.create(superCtor.prototype, {
+        constructor: {
+          value: ctor,
+          enumerable: false,
+          writable: true,
+          configurable: true
+        }
+      });
+    };
+  } else {
+    // old school shim for old browsers
+    module.exports = function inherits(ctor, superCtor) {
+      ctor.super_ = superCtor
+      var TempCtor = function () {}
+      TempCtor.prototype = superCtor.prototype
+      ctor.prototype = new TempCtor()
+      ctor.prototype.constructor = ctor
+    }
+  }
+  
+  },{}],22:[function(require,module,exports){
+  /*!
+   * Determine if an object is a Buffer
+   *
+   * @author   Feross Aboukhadijeh <https://feross.org>
+   * @license  MIT
+   */
+  
+  // The _isBuffer check is for Safari 5-7 support, because it's missing
+  // Object.prototype.constructor. Remove this eventually
+  module.exports = function (obj) {
+    return obj != null && (isBuffer(obj) || isSlowBuffer(obj) || !!obj._isBuffer)
+  }
+  
+  function isBuffer (obj) {
+    return !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
+  }
+  
+  // For Node v0.10 support. Remove this eventually.
+  function isSlowBuffer (obj) {
+    return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
+  }
+  
+  },{}],23:[function(require,module,exports){
+  var toString = {}.toString;
+  
+  module.exports = Array.isArray || function (arr) {
+    return toString.call(arr) == '[object Array]';
+  };
+  
+  },{}],24:[function(require,module,exports){
+  (function (process){
+  'use strict';
+  
+  if (!process.version ||
+      process.version.indexOf('v0.') === 0 ||
+      process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
+    module.exports = nextTick;
+  } else {
+    module.exports = process.nextTick;
+  }
+  
+  function nextTick(fn, arg1, arg2, arg3) {
+    if (typeof fn !== 'function') {
+      throw new TypeError('"callback" argument must be a function');
+    }
+    var len = arguments.length;
+    var args, i;
+    switch (len) {
+    case 0:
+    case 1:
+      return process.nextTick(fn);
+    case 2:
+      return process.nextTick(function afterTickOne() {
+        fn.call(null, arg1);
+      });
+    case 3:
+      return process.nextTick(function afterTickTwo() {
+        fn.call(null, arg1, arg2);
+      });
+    case 4:
+      return process.nextTick(function afterTickThree() {
+        fn.call(null, arg1, arg2, arg3);
+      });
+    default:
+      args = new Array(len - 1);
+      i = 0;
+      while (i < args.length) {
+        args[i++] = arguments[i];
+      }
+      return process.nextTick(function afterTick() {
+        fn.apply(null, args);
+      });
+    }
+  }
+  
+  }).call(this,require('_process'))
+  },{"_process":25}],25:[function(require,module,exports){
+  // shim for using process in browser
+  var process = module.exports = {};
+  
+  // cached from whatever global is present so that test runners that stub it
+  // don't break things.  But we need to wrap it in a try catch in case it is
+  // wrapped in strict mode code which doesn't define any globals.  It's inside a
+  // function because try/catches deoptimize in certain engines.
+  
+  var cachedSetTimeout;
+  var cachedClearTimeout;
+  
+  function defaultSetTimout() {
+      throw new Error('setTimeout has not been defined');
+  }
+  function defaultClearTimeout () {
+      throw new Error('clearTimeout has not been defined');
+  }
+  (function () {
+      try {
+          if (typeof setTimeout === 'function') {
+              cachedSetTimeout = setTimeout;
+          } else {
+              cachedSetTimeout = defaultSetTimout;
+          }
+      } catch (e) {
+          cachedSetTimeout = defaultSetTimout;
+      }
+      try {
+          if (typeof clearTimeout === 'function') {
+              cachedClearTimeout = clearTimeout;
+          } else {
+              cachedClearTimeout = defaultClearTimeout;
+          }
+      } catch (e) {
+          cachedClearTimeout = defaultClearTimeout;
+      }
+  } ())
+  function runTimeout(fun) {
+      if (cachedSetTimeout === setTimeout) {
+          //normal enviroments in sane situations
+          return setTimeout(fun, 0);
+      }
+      // if setTimeout wasn't available but was latter defined
+      if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+          cachedSetTimeout = setTimeout;
+          return setTimeout(fun, 0);
+      }
+      try {
+          // when when somebody has screwed with setTimeout but no I.E. maddness
+          return cachedSetTimeout(fun, 0);
+      } catch(e){
+          try {
+              // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+              return cachedSetTimeout.call(null, fun, 0);
+          } catch(e){
+              // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+              return cachedSetTimeout.call(this, fun, 0);
+          }
+      }
+  
+  
+  }
+  function runClearTimeout(marker) {
+      if (cachedClearTimeout === clearTimeout) {
+          //normal enviroments in sane situations
+          return clearTimeout(marker);
+      }
+      // if clearTimeout wasn't available but was latter defined
+      if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+          cachedClearTimeout = clearTimeout;
+          return clearTimeout(marker);
+      }
+      try {
+          // when when somebody has screwed with setTimeout but no I.E. maddness
+          return cachedClearTimeout(marker);
+      } catch (e){
+          try {
+              // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+              return cachedClearTimeout.call(null, marker);
+          } catch (e){
+              // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+              // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+              return cachedClearTimeout.call(this, marker);
+          }
+      }
+  
+  
+  
+  }
+  var queue = [];
+  var draining = false;
+  var currentQueue;
+  var queueIndex = -1;
+  
+  function cleanUpNextTick() {
+      if (!draining || !currentQueue) {
+          return;
+      }
+      draining = false;
+      if (currentQueue.length) {
+          queue = currentQueue.concat(queue);
+      } else {
+          queueIndex = -1;
+      }
+      if (queue.length) {
+          drainQueue();
+      }
+  }
+  
+  function drainQueue() {
+      if (draining) {
+          return;
+      }
+      var timeout = runTimeout(cleanUpNextTick);
+      draining = true;
+  
+      var len = queue.length;
+      while(len) {
+          currentQueue = queue;
+          queue = [];
+          while (++queueIndex < len) {
+              if (currentQueue) {
+                  currentQueue[queueIndex].run();
+              }
+          }
+          queueIndex = -1;
+          len = queue.length;
+      }
+      currentQueue = null;
+      draining = false;
+      runClearTimeout(timeout);
+  }
+  
+  process.nextTick = function (fun) {
+      var args = new Array(arguments.length - 1);
+      if (arguments.length > 1) {
+          for (var i = 1; i < arguments.length; i++) {
+              args[i - 1] = arguments[i];
+          }
+      }
+      queue.push(new Item(fun, args));
+      if (queue.length === 1 && !draining) {
+          runTimeout(drainQueue);
+      }
+  };
+  
+  // v8 likes predictible objects
+  function Item(fun, array) {
+      this.fun = fun;
+      this.array = array;
+  }
+  Item.prototype.run = function () {
+      this.fun.apply(null, this.array);
+  };
+  process.title = 'browser';
+  process.browser = true;
+  process.env = {};
+  process.argv = [];
+  process.version = ''; // empty string to avoid regexp issues
+  process.versions = {};
+  
+  function noop() {}
+  
+  process.on = noop;
+  process.addListener = noop;
+  process.once = noop;
+  process.off = noop;
+  process.removeListener = noop;
+  process.removeAllListeners = noop;
+  process.emit = noop;
+  process.prependListener = noop;
+  process.prependOnceListener = noop;
+  
+  process.listeners = function (name) { return [] }
+  
+  process.binding = function (name) {
+      throw new Error('process.binding is not supported');
+  };
+  
+  process.cwd = function () { return '/' };
+  process.chdir = function (dir) {
+      throw new Error('process.chdir is not supported');
+  };
+  process.umask = function() { return 0; };
+  
+  },{}],26:[function(require,module,exports){
+  module.exports = require('./lib/_stream_duplex.js');
+  
+  },{"./lib/_stream_duplex.js":27}],27:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // a duplex stream is just a stream that is both readable and writable.
+  // Since JS doesn't have multiple prototypal inheritance, this class
+  // prototypally inherits from Readable, and then parasitically from
+  // Writable.
+  
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var objectKeys = Object.keys || function (obj) {
+    var keys = [];
+    for (var key in obj) {
+      keys.push(key);
+    }return keys;
+  };
+  /*</replacement>*/
+  
+  module.exports = Duplex;
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  var Readable = require('./_stream_readable');
+  var Writable = require('./_stream_writable');
+  
+  util.inherits(Duplex, Readable);
+  
+  var keys = objectKeys(Writable.prototype);
+  for (var v = 0; v < keys.length; v++) {
+    var method = keys[v];
+    if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
+  }
+  
+  function Duplex(options) {
+    if (!(this instanceof Duplex)) return new Duplex(options);
+  
+    Readable.call(this, options);
+    Writable.call(this, options);
+  
+    if (options && options.readable === false) this.readable = false;
+  
+    if (options && options.writable === false) this.writable = false;
+  
+    this.allowHalfOpen = true;
+    if (options && options.allowHalfOpen === false) this.allowHalfOpen = false;
+  
+    this.once('end', onend);
+  }
+  
+  // the no-half-open enforcer
+  function onend() {
+    // if we allow half-open state, or if the writable side ended,
+    // then we're ok.
+    if (this.allowHalfOpen || this._writableState.ended) return;
+  
+    // no more data can be written.
+    // But allow more writes to happen in this tick.
+    processNextTick(onEndNT, this);
+  }
+  
+  function onEndNT(self) {
+    self.end();
+  }
+  
+  Object.defineProperty(Duplex.prototype, 'destroyed', {
+    get: function () {
+      if (this._readableState === undefined || this._writableState === undefined) {
+        return false;
+      }
+      return this._readableState.destroyed && this._writableState.destroyed;
+    },
+    set: function (value) {
+      // we ignore the value if the stream
+      // has not been initialized yet
+      if (this._readableState === undefined || this._writableState === undefined) {
+        return;
+      }
+  
+      // backward compatibility, the user is explicitly
+      // managing destroyed
+      this._readableState.destroyed = value;
+      this._writableState.destroyed = value;
+    }
+  });
+  
+  Duplex.prototype._destroy = function (err, cb) {
+    this.push(null);
+    this.end();
+  
+    processNextTick(cb, err);
+  };
+  
+  function forEach(xs, f) {
+    for (var i = 0, l = xs.length; i < l; i++) {
+      f(xs[i], i);
+    }
+  }
+  },{"./_stream_readable":29,"./_stream_writable":31,"core-util-is":14,"inherits":21,"process-nextick-args":24}],28:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // a passthrough stream.
+  // basically just the most minimal sort of Transform stream.
+  // Every written chunk gets output as-is.
+  
+  'use strict';
+  
+  module.exports = PassThrough;
+  
+  var Transform = require('./_stream_transform');
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  util.inherits(PassThrough, Transform);
+  
+  function PassThrough(options) {
+    if (!(this instanceof PassThrough)) return new PassThrough(options);
+  
+    Transform.call(this, options);
+  }
+  
+  PassThrough.prototype._transform = function (chunk, encoding, cb) {
+    cb(null, chunk);
+  };
+  },{"./_stream_transform":30,"core-util-is":14,"inherits":21}],29:[function(require,module,exports){
+  (function (process,global){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  module.exports = Readable;
+  
+  /*<replacement>*/
+  var isArray = require('isarray');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Duplex;
+  /*</replacement>*/
+  
+  Readable.ReadableState = ReadableState;
+  
+  /*<replacement>*/
+  var EE = require('events').EventEmitter;
+  
+  var EElistenerCount = function (emitter, type) {
+    return emitter.listeners(type).length;
+  };
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Stream = require('./internal/streams/stream');
+  /*</replacement>*/
+  
+  // TODO(bmeurer): Change this back to const once hole checks are
+  // properly optimized away early in Ignition+TurboFan.
+  /*<replacement>*/
+  var Buffer = require('safe-buffer').Buffer;
+  var OurUint8Array = global.Uint8Array || function () {};
+  function _uint8ArrayToBuffer(chunk) {
+    return Buffer.from(chunk);
+  }
+  function _isUint8Array(obj) {
+    return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
+  }
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var debugUtil = require('util');
+  var debug = void 0;
+  if (debugUtil && debugUtil.debuglog) {
+    debug = debugUtil.debuglog('stream');
+  } else {
+    debug = function () {};
+  }
+  /*</replacement>*/
+  
+  var BufferList = require('./internal/streams/BufferList');
+  var destroyImpl = require('./internal/streams/destroy');
+  var StringDecoder;
+  
+  util.inherits(Readable, Stream);
+  
+  var kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
+  
+  function prependListener(emitter, event, fn) {
+    // Sadly this is not cacheable as some libraries bundle their own
+    // event emitter implementation with them.
+    if (typeof emitter.prependListener === 'function') {
+      return emitter.prependListener(event, fn);
+    } else {
+      // This is a hack to make sure that our error handler is attached before any
+      // userland ones.  NEVER DO THIS. This is here only because this code needs
+      // to continue to work with older versions of Node.js that do not include
+      // the prependListener() method. The goal is to eventually remove this hack.
+      if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
+    }
+  }
+  
+  function ReadableState(options, stream) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    options = options || {};
+  
+    // object stream flag. Used to make read(n) ignore n and to
+    // make all the buffer merging and length checks go away
+    this.objectMode = !!options.objectMode;
+  
+    if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.readableObjectMode;
+  
+    // the point at which it stops calling _read() to fill the buffer
+    // Note: 0 is a valid value, means "don't call _read preemptively ever"
+    var hwm = options.highWaterMark;
+    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+    this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+  
+    // cast to ints.
+    this.highWaterMark = Math.floor(this.highWaterMark);
+  
+    // A linked list is used to store data chunks instead of an array because the
+    // linked list can remove elements from the beginning faster than
+    // array.shift()
+    this.buffer = new BufferList();
+    this.length = 0;
+    this.pipes = null;
+    this.pipesCount = 0;
+    this.flowing = null;
+    this.ended = false;
+    this.endEmitted = false;
+    this.reading = false;
+  
+    // a flag to be able to tell if the event 'readable'/'data' is emitted
+    // immediately, or on a later tick.  We set this to true at first, because
+    // any actions that shouldn't happen until "later" should generally also
+    // not happen before the first read call.
+    this.sync = true;
+  
+    // whenever we return null, then we set a flag to say
+    // that we're awaiting a 'readable' event emission.
+    this.needReadable = false;
+    this.emittedReadable = false;
+    this.readableListening = false;
+    this.resumeScheduled = false;
+  
+    // has it been destroyed
+    this.destroyed = false;
+  
+    // Crypto is kind of old and crusty.  Historically, its default string
+    // encoding is 'binary' so we have to make this configurable.
+    // Everything else in the universe uses 'utf8', though.
+    this.defaultEncoding = options.defaultEncoding || 'utf8';
+  
+    // the number of writers that are awaiting a drain event in .pipe()s
+    this.awaitDrain = 0;
+  
+    // if true, a maybeReadMore has been scheduled
+    this.readingMore = false;
+  
+    this.decoder = null;
+    this.encoding = null;
+    if (options.encoding) {
+      if (!StringDecoder) StringDecoder = require('string_decoder/').StringDecoder;
+      this.decoder = new StringDecoder(options.encoding);
+      this.encoding = options.encoding;
+    }
+  }
+  
+  function Readable(options) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    if (!(this instanceof Readable)) return new Readable(options);
+  
+    this._readableState = new ReadableState(options, this);
+  
+    // legacy
+    this.readable = true;
+  
+    if (options) {
+      if (typeof options.read === 'function') this._read = options.read;
+  
+      if (typeof options.destroy === 'function') this._destroy = options.destroy;
+    }
+  
+    Stream.call(this);
+  }
+  
+  Object.defineProperty(Readable.prototype, 'destroyed', {
+    get: function () {
+      if (this._readableState === undefined) {
+        return false;
+      }
+      return this._readableState.destroyed;
+    },
+    set: function (value) {
+      // we ignore the value if the stream
+      // has not been initialized yet
+      if (!this._readableState) {
+        return;
+      }
+  
+      // backward compatibility, the user is explicitly
+      // managing destroyed
+      this._readableState.destroyed = value;
+    }
+  });
+  
+  Readable.prototype.destroy = destroyImpl.destroy;
+  Readable.prototype._undestroy = destroyImpl.undestroy;
+  Readable.prototype._destroy = function (err, cb) {
+    this.push(null);
+    cb(err);
+  };
+  
+  // Manually shove something into the read() buffer.
+  // This returns true if the highWaterMark has not been hit yet,
+  // similar to how Writable.write() returns true if you should
+  // write() some more.
+  Readable.prototype.push = function (chunk, encoding) {
+    var state = this._readableState;
+    var skipChunkCheck;
+  
+    if (!state.objectMode) {
+      if (typeof chunk === 'string') {
+        encoding = encoding || state.defaultEncoding;
+        if (encoding !== state.encoding) {
+          chunk = Buffer.from(chunk, encoding);
+          encoding = '';
+        }
+        skipChunkCheck = true;
+      }
+    } else {
+      skipChunkCheck = true;
+    }
+  
+    return readableAddChunk(this, chunk, encoding, false, skipChunkCheck);
+  };
+  
+  // Unshift should *always* be something directly out of read()
+  Readable.prototype.unshift = function (chunk) {
+    return readableAddChunk(this, chunk, null, true, false);
+  };
+  
+  function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
+    var state = stream._readableState;
+    if (chunk === null) {
+      state.reading = false;
+      onEofChunk(stream, state);
+    } else {
+      var er;
+      if (!skipChunkCheck) er = chunkInvalid(state, chunk);
+      if (er) {
+        stream.emit('error', er);
+      } else if (state.objectMode || chunk && chunk.length > 0) {
+        if (typeof chunk !== 'string' && !state.objectMode && Object.getPrototypeOf(chunk) !== Buffer.prototype) {
+          chunk = _uint8ArrayToBuffer(chunk);
+        }
+  
+        if (addToFront) {
+          if (state.endEmitted) stream.emit('error', new Error('stream.unshift() after end event'));else addChunk(stream, state, chunk, true);
+        } else if (state.ended) {
+          stream.emit('error', new Error('stream.push() after EOF'));
+        } else {
+          state.reading = false;
+          if (state.decoder && !encoding) {
+            chunk = state.decoder.write(chunk);
+            if (state.objectMode || chunk.length !== 0) addChunk(stream, state, chunk, false);else maybeReadMore(stream, state);
+          } else {
+            addChunk(stream, state, chunk, false);
+          }
+        }
+      } else if (!addToFront) {
+        state.reading = false;
+      }
+    }
+  
+    return needMoreData(state);
+  }
+  
+  function addChunk(stream, state, chunk, addToFront) {
+    if (state.flowing && state.length === 0 && !state.sync) {
+      stream.emit('data', chunk);
+      stream.read(0);
+    } else {
+      // update the buffer info.
+      state.length += state.objectMode ? 1 : chunk.length;
+      if (addToFront) state.buffer.unshift(chunk);else state.buffer.push(chunk);
+  
+      if (state.needReadable) emitReadable(stream);
+    }
+    maybeReadMore(stream, state);
+  }
+  
+  function chunkInvalid(state, chunk) {
+    var er;
+    if (!_isUint8Array(chunk) && typeof chunk !== 'string' && chunk !== undefined && !state.objectMode) {
+      er = new TypeError('Invalid non-string/buffer chunk');
+    }
+    return er;
+  }
+  
+  // if it's past the high water mark, we can push in some more.
+  // Also, if we have no data yet, we can stand some
+  // more bytes.  This is to work around cases where hwm=0,
+  // such as the repl.  Also, if the push() triggered a
+  // readable event, and the user called read(largeNumber) such that
+  // needReadable was set, then we ought to push more, so that another
+  // 'readable' event will be triggered.
+  function needMoreData(state) {
+    return !state.ended && (state.needReadable || state.length < state.highWaterMark || state.length === 0);
+  }
+  
+  Readable.prototype.isPaused = function () {
+    return this._readableState.flowing === false;
+  };
+  
+  // backwards compatibility.
+  Readable.prototype.setEncoding = function (enc) {
+    if (!StringDecoder) StringDecoder = require('string_decoder/').StringDecoder;
+    this._readableState.decoder = new StringDecoder(enc);
+    this._readableState.encoding = enc;
+    return this;
+  };
+  
+  // Don't raise the hwm > 8MB
+  var MAX_HWM = 0x800000;
+  function computeNewHighWaterMark(n) {
+    if (n >= MAX_HWM) {
+      n = MAX_HWM;
+    } else {
+      // Get the next highest power of 2 to prevent increasing hwm excessively in
+      // tiny amounts
+      n--;
+      n |= n >>> 1;
+      n |= n >>> 2;
+      n |= n >>> 4;
+      n |= n >>> 8;
+      n |= n >>> 16;
+      n++;
+    }
+    return n;
+  }
+  
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function howMuchToRead(n, state) {
+    if (n <= 0 || state.length === 0 && state.ended) return 0;
+    if (state.objectMode) return 1;
+    if (n !== n) {
+      // Only flow one buffer at a time
+      if (state.flowing && state.length) return state.buffer.head.data.length;else return state.length;
+    }
+    // If we're asking for more than the current hwm, then raise the hwm.
+    if (n > state.highWaterMark) state.highWaterMark = computeNewHighWaterMark(n);
+    if (n <= state.length) return n;
+    // Don't have enough
+    if (!state.ended) {
+      state.needReadable = true;
+      return 0;
+    }
+    return state.length;
+  }
+  
+  // you can override either this method, or the async _read(n) below.
+  Readable.prototype.read = function (n) {
+    debug('read', n);
+    n = parseInt(n, 10);
+    var state = this._readableState;
+    var nOrig = n;
+  
+    if (n !== 0) state.emittedReadable = false;
+  
+    // if we're doing read(0) to trigger a readable event, but we
+    // already have a bunch of data in the buffer, then just trigger
+    // the 'readable' event and move on.
+    if (n === 0 && state.needReadable && (state.length >= state.highWaterMark || state.ended)) {
+      debug('read: emitReadable', state.length, state.ended);
+      if (state.length === 0 && state.ended) endReadable(this);else emitReadable(this);
+      return null;
+    }
+  
+    n = howMuchToRead(n, state);
+  
+    // if we've ended, and we're now clear, then finish it up.
+    if (n === 0 && state.ended) {
+      if (state.length === 0) endReadable(this);
+      return null;
+    }
+  
+    // All the actual chunk generation logic needs to be
+    // *below* the call to _read.  The reason is that in certain
+    // synthetic stream cases, such as passthrough streams, _read
+    // may be a completely synchronous operation which may change
+    // the state of the read buffer, providing enough data when
+    // before there was *not* enough.
+    //
+    // So, the steps are:
+    // 1. Figure out what the state of things will be after we do
+    // a read from the buffer.
+    //
+    // 2. If that resulting state will trigger a _read, then call _read.
+    // Note that this may be asynchronous, or synchronous.  Yes, it is
+    // deeply ugly to write APIs this way, but that still doesn't mean
+    // that the Readable class should behave improperly, as streams are
+    // designed to be sync/async agnostic.
+    // Take note if the _read call is sync or async (ie, if the read call
+    // has returned yet), so that we know whether or not it's safe to emit
+    // 'readable' etc.
+    //
+    // 3. Actually pull the requested chunks out of the buffer and return.
+  
+    // if we need a readable event, then we need to do some reading.
+    var doRead = state.needReadable;
+    debug('need readable', doRead);
+  
+    // if we currently have less than the highWaterMark, then also read some
+    if (state.length === 0 || state.length - n < state.highWaterMark) {
+      doRead = true;
+      debug('length less than watermark', doRead);
+    }
+  
+    // however, if we've ended, then there's no point, and if we're already
+    // reading, then it's unnecessary.
+    if (state.ended || state.reading) {
+      doRead = false;
+      debug('reading or ended', doRead);
+    } else if (doRead) {
+      debug('do read');
+      state.reading = true;
+      state.sync = true;
+      // if the length is currently zero, then we *need* a readable event.
+      if (state.length === 0) state.needReadable = true;
+      // call internal read method
+      this._read(state.highWaterMark);
+      state.sync = false;
+      // If _read pushed data synchronously, then `reading` will be false,
+      // and we need to re-evaluate how much data we can return to the user.
+      if (!state.reading) n = howMuchToRead(nOrig, state);
+    }
+  
+    var ret;
+    if (n > 0) ret = fromList(n, state);else ret = null;
+  
+    if (ret === null) {
+      state.needReadable = true;
+      n = 0;
+    } else {
+      state.length -= n;
+    }
+  
+    if (state.length === 0) {
+      // If we have nothing in the buffer, then we want to know
+      // as soon as we *do* get something into the buffer.
+      if (!state.ended) state.needReadable = true;
+  
+      // If we tried to read() past the EOF, then emit end on the next tick.
+      if (nOrig !== n && state.ended) endReadable(this);
+    }
+  
+    if (ret !== null) this.emit('data', ret);
+  
+    return ret;
+  };
+  
+  function onEofChunk(stream, state) {
+    if (state.ended) return;
+    if (state.decoder) {
+      var chunk = state.decoder.end();
+      if (chunk && chunk.length) {
+        state.buffer.push(chunk);
+        state.length += state.objectMode ? 1 : chunk.length;
+      }
+    }
+    state.ended = true;
+  
+    // emit 'readable' now to make sure it gets picked up.
+    emitReadable(stream);
+  }
+  
+  // Don't emit readable right away in sync mode, because this can trigger
+  // another read() call => stack overflow.  This way, it might trigger
+  // a nextTick recursion warning, but that's not so bad.
+  function emitReadable(stream) {
+    var state = stream._readableState;
+    state.needReadable = false;
+    if (!state.emittedReadable) {
+      debug('emitReadable', state.flowing);
+      state.emittedReadable = true;
+      if (state.sync) processNextTick(emitReadable_, stream);else emitReadable_(stream);
+    }
+  }
+  
+  function emitReadable_(stream) {
+    debug('emit readable');
+    stream.emit('readable');
+    flow(stream);
+  }
+  
+  // at this point, the user has presumably seen the 'readable' event,
+  // and called read() to consume some data.  that may have triggered
+  // in turn another _read(n) call, in which case reading = true if
+  // it's in progress.
+  // However, if we're not ended, or reading, and the length < hwm,
+  // then go ahead and try to read some more preemptively.
+  function maybeReadMore(stream, state) {
+    if (!state.readingMore) {
+      state.readingMore = true;
+      processNextTick(maybeReadMore_, stream, state);
+    }
+  }
+  
+  function maybeReadMore_(stream, state) {
+    var len = state.length;
+    while (!state.reading && !state.flowing && !state.ended && state.length < state.highWaterMark) {
+      debug('maybeReadMore read 0');
+      stream.read(0);
+      if (len === state.length)
+        // didn't get any data, stop spinning.
+        break;else len = state.length;
+    }
+    state.readingMore = false;
+  }
+  
+  // abstract method.  to be overridden in specific implementation classes.
+  // call cb(er, data) where data is <= n in length.
+  // for virtual (non-string, non-buffer) streams, "length" is somewhat
+  // arbitrary, and perhaps not very meaningful.
+  Readable.prototype._read = function (n) {
+    this.emit('error', new Error('_read() is not implemented'));
+  };
+  
+  Readable.prototype.pipe = function (dest, pipeOpts) {
+    var src = this;
+    var state = this._readableState;
+  
+    switch (state.pipesCount) {
+      case 0:
+        state.pipes = dest;
+        break;
+      case 1:
+        state.pipes = [state.pipes, dest];
+        break;
+      default:
+        state.pipes.push(dest);
+        break;
+    }
+    state.pipesCount += 1;
+    debug('pipe count=%d opts=%j', state.pipesCount, pipeOpts);
+  
+    var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
+  
+    var endFn = doEnd ? onend : unpipe;
+    if (state.endEmitted) processNextTick(endFn);else src.once('end', endFn);
+  
+    dest.on('unpipe', onunpipe);
+    function onunpipe(readable, unpipeInfo) {
+      debug('onunpipe');
+      if (readable === src) {
+        if (unpipeInfo && unpipeInfo.hasUnpiped === false) {
+          unpipeInfo.hasUnpiped = true;
+          cleanup();
+        }
+      }
+    }
+  
+    function onend() {
+      debug('onend');
+      dest.end();
+    }
+  
+    // when the dest drains, it reduces the awaitDrain counter
+    // on the source.  This would be more elegant with a .once()
+    // handler in flow(), but adding and removing repeatedly is
+    // too slow.
+    var ondrain = pipeOnDrain(src);
+    dest.on('drain', ondrain);
+  
+    var cleanedUp = false;
+    function cleanup() {
+      debug('cleanup');
+      // cleanup event handlers once the pipe is broken
+      dest.removeListener('close', onclose);
+      dest.removeListener('finish', onfinish);
+      dest.removeListener('drain', ondrain);
+      dest.removeListener('error', onerror);
+      dest.removeListener('unpipe', onunpipe);
+      src.removeListener('end', onend);
+      src.removeListener('end', unpipe);
+      src.removeListener('data', ondata);
+  
+      cleanedUp = true;
+  
+      // if the reader is waiting for a drain event from this
+      // specific writer, then it would cause it to never start
+      // flowing again.
+      // So, if this is awaiting a drain, then we just call it now.
+      // If we don't know, then assume that we are waiting for one.
+      if (state.awaitDrain && (!dest._writableState || dest._writableState.needDrain)) ondrain();
+    }
+  
+    // If the user pushes more data while we're writing to dest then we'll end up
+    // in ondata again. However, we only want to increase awaitDrain once because
+    // dest will only emit one 'drain' event for the multiple writes.
+    // => Introduce a guard on increasing awaitDrain.
+    var increasedAwaitDrain = false;
+    src.on('data', ondata);
+    function ondata(chunk) {
+      debug('ondata');
+      increasedAwaitDrain = false;
+      var ret = dest.write(chunk);
+      if (false === ret && !increasedAwaitDrain) {
+        // If the user unpiped during `dest.write()`, it is possible
+        // to get stuck in a permanently paused state if that write
+        // also returned false.
+        // => Check whether `dest` is still a piping destination.
+        if ((state.pipesCount === 1 && state.pipes === dest || state.pipesCount > 1 && indexOf(state.pipes, dest) !== -1) && !cleanedUp) {
+          debug('false write response, pause', src._readableState.awaitDrain);
+          src._readableState.awaitDrain++;
+          increasedAwaitDrain = true;
+        }
+        src.pause();
+      }
+    }
+  
+    // if the dest has an error, then stop piping into it.
+    // however, don't suppress the throwing behavior for this.
+    function onerror(er) {
+      debug('onerror', er);
+      unpipe();
+      dest.removeListener('error', onerror);
+      if (EElistenerCount(dest, 'error') === 0) dest.emit('error', er);
+    }
+  
+    // Make sure our error handler is attached before userland ones.
+    prependListener(dest, 'error', onerror);
+  
+    // Both close and finish should trigger unpipe, but only once.
+    function onclose() {
+      dest.removeListener('finish', onfinish);
+      unpipe();
+    }
+    dest.once('close', onclose);
+    function onfinish() {
+      debug('onfinish');
+      dest.removeListener('close', onclose);
+      unpipe();
+    }
+    dest.once('finish', onfinish);
+  
+    function unpipe() {
+      debug('unpipe');
+      src.unpipe(dest);
+    }
+  
+    // tell the dest that it's being piped to
+    dest.emit('pipe', src);
+  
+    // start the flow if it hasn't been started already.
+    if (!state.flowing) {
+      debug('pipe resume');
+      src.resume();
+    }
+  
+    return dest;
+  };
+  
+  function pipeOnDrain(src) {
+    return function () {
+      var state = src._readableState;
+      debug('pipeOnDrain', state.awaitDrain);
+      if (state.awaitDrain) state.awaitDrain--;
+      if (state.awaitDrain === 0 && EElistenerCount(src, 'data')) {
+        state.flowing = true;
+        flow(src);
+      }
+    };
+  }
+  
+  Readable.prototype.unpipe = function (dest) {
+    var state = this._readableState;
+    var unpipeInfo = { hasUnpiped: false };
+  
+    // if we're not piping anywhere, then do nothing.
+    if (state.pipesCount === 0) return this;
+  
+    // just one destination.  most common case.
+    if (state.pipesCount === 1) {
+      // passed in one, but it's not the right one.
+      if (dest && dest !== state.pipes) return this;
+  
+      if (!dest) dest = state.pipes;
+  
+      // got a match.
+      state.pipes = null;
+      state.pipesCount = 0;
+      state.flowing = false;
+      if (dest) dest.emit('unpipe', this, unpipeInfo);
+      return this;
+    }
+  
+    // slow case. multiple pipe destinations.
+  
+    if (!dest) {
+      // remove all.
+      var dests = state.pipes;
+      var len = state.pipesCount;
+      state.pipes = null;
+      state.pipesCount = 0;
+      state.flowing = false;
+  
+      for (var i = 0; i < len; i++) {
+        dests[i].emit('unpipe', this, unpipeInfo);
+      }return this;
+    }
+  
+    // try to find the right one.
+    var index = indexOf(state.pipes, dest);
+    if (index === -1) return this;
+  
+    state.pipes.splice(index, 1);
+    state.pipesCount -= 1;
+    if (state.pipesCount === 1) state.pipes = state.pipes[0];
+  
+    dest.emit('unpipe', this, unpipeInfo);
+  
+    return this;
+  };
+  
+  // set up data events if they are asked for
+  // Ensure readable listeners eventually get something
+  Readable.prototype.on = function (ev, fn) {
+    var res = Stream.prototype.on.call(this, ev, fn);
+  
+    if (ev === 'data') {
+      // Start flowing on next tick if stream isn't explicitly paused
+      if (this._readableState.flowing !== false) this.resume();
+    } else if (ev === 'readable') {
+      var state = this._readableState;
+      if (!state.endEmitted && !state.readableListening) {
+        state.readableListening = state.needReadable = true;
+        state.emittedReadable = false;
+        if (!state.reading) {
+          processNextTick(nReadingNextTick, this);
+        } else if (state.length) {
+          emitReadable(this);
+        }
+      }
+    }
+  
+    return res;
+  };
+  Readable.prototype.addListener = Readable.prototype.on;
+  
+  function nReadingNextTick(self) {
+    debug('readable nexttick read 0');
+    self.read(0);
+  }
+  
+  // pause() and resume() are remnants of the legacy readable stream API
+  // If the user uses them, then switch into old mode.
+  Readable.prototype.resume = function () {
+    var state = this._readableState;
+    if (!state.flowing) {
+      debug('resume');
+      state.flowing = true;
+      resume(this, state);
+    }
+    return this;
+  };
+  
+  function resume(stream, state) {
+    if (!state.resumeScheduled) {
+      state.resumeScheduled = true;
+      processNextTick(resume_, stream, state);
+    }
+  }
+  
+  function resume_(stream, state) {
+    if (!state.reading) {
+      debug('resume read 0');
+      stream.read(0);
+    }
+  
+    state.resumeScheduled = false;
+    state.awaitDrain = 0;
+    stream.emit('resume');
+    flow(stream);
+    if (state.flowing && !state.reading) stream.read(0);
+  }
+  
+  Readable.prototype.pause = function () {
+    debug('call pause flowing=%j', this._readableState.flowing);
+    if (false !== this._readableState.flowing) {
+      debug('pause');
+      this._readableState.flowing = false;
+      this.emit('pause');
+    }
+    return this;
+  };
+  
+  function flow(stream) {
+    var state = stream._readableState;
+    debug('flow', state.flowing);
+    while (state.flowing && stream.read() !== null) {}
+  }
+  
+  // wrap an old-style stream as the async data source.
+  // This is *not* part of the readable stream interface.
+  // It is an ugly unfortunate mess of history.
+  Readable.prototype.wrap = function (stream) {
+    var state = this._readableState;
+    var paused = false;
+  
+    var self = this;
+    stream.on('end', function () {
+      debug('wrapped end');
+      if (state.decoder && !state.ended) {
+        var chunk = state.decoder.end();
+        if (chunk && chunk.length) self.push(chunk);
+      }
+  
+      self.push(null);
+    });
+  
+    stream.on('data', function (chunk) {
+      debug('wrapped data');
+      if (state.decoder) chunk = state.decoder.write(chunk);
+  
+      // don't skip over falsy values in objectMode
+      if (state.objectMode && (chunk === null || chunk === undefined)) return;else if (!state.objectMode && (!chunk || !chunk.length)) return;
+  
+      var ret = self.push(chunk);
+      if (!ret) {
+        paused = true;
+        stream.pause();
+      }
+    });
+  
+    // proxy all the other methods.
+    // important when wrapping filters and duplexes.
+    for (var i in stream) {
+      if (this[i] === undefined && typeof stream[i] === 'function') {
+        this[i] = function (method) {
+          return function () {
+            return stream[method].apply(stream, arguments);
+          };
+        }(i);
+      }
+    }
+  
+    // proxy certain important events.
+    for (var n = 0; n < kProxyEvents.length; n++) {
+      stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+    }
+  
+    // when we try to consume some more bytes, simply unpause the
+    // underlying stream.
+    self._read = function (n) {
+      debug('wrapped _read', n);
+      if (paused) {
+        paused = false;
+        stream.resume();
+      }
+    };
+  
+    return self;
+  };
+  
+  // exposed for testing purposes only.
+  Readable._fromList = fromList;
+  
+  // Pluck off n bytes from an array of buffers.
+  // Length is the combined lengths of all the buffers in the list.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function fromList(n, state) {
+    // nothing buffered
+    if (state.length === 0) return null;
+  
+    var ret;
+    if (state.objectMode) ret = state.buffer.shift();else if (!n || n >= state.length) {
+      // read it all, truncate the list
+      if (state.decoder) ret = state.buffer.join('');else if (state.buffer.length === 1) ret = state.buffer.head.data;else ret = state.buffer.concat(state.length);
+      state.buffer.clear();
+    } else {
+      // read part of list
+      ret = fromListPartial(n, state.buffer, state.decoder);
+    }
+  
+    return ret;
+  }
+  
+  // Extracts only enough buffered data to satisfy the amount requested.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function fromListPartial(n, list, hasStrings) {
+    var ret;
+    if (n < list.head.data.length) {
+      // slice is the same for buffers and strings
+      ret = list.head.data.slice(0, n);
+      list.head.data = list.head.data.slice(n);
+    } else if (n === list.head.data.length) {
+      // first chunk is a perfect match
+      ret = list.shift();
+    } else {
+      // result spans more than one buffer
+      ret = hasStrings ? copyFromBufferString(n, list) : copyFromBuffer(n, list);
+    }
+    return ret;
+  }
+  
+  // Copies a specified amount of characters from the list of buffered data
+  // chunks.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function copyFromBufferString(n, list) {
+    var p = list.head;
+    var c = 1;
+    var ret = p.data;
+    n -= ret.length;
+    while (p = p.next) {
+      var str = p.data;
+      var nb = n > str.length ? str.length : n;
+      if (nb === str.length) ret += str;else ret += str.slice(0, n);
+      n -= nb;
+      if (n === 0) {
+        if (nb === str.length) {
+          ++c;
+          if (p.next) list.head = p.next;else list.head = list.tail = null;
+        } else {
+          list.head = p;
+          p.data = str.slice(nb);
+        }
+        break;
+      }
+      ++c;
+    }
+    list.length -= c;
+    return ret;
+  }
+  
+  // Copies a specified amount of bytes from the list of buffered data chunks.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function copyFromBuffer(n, list) {
+    var ret = Buffer.allocUnsafe(n);
+    var p = list.head;
+    var c = 1;
+    p.data.copy(ret);
+    n -= p.data.length;
+    while (p = p.next) {
+      var buf = p.data;
+      var nb = n > buf.length ? buf.length : n;
+      buf.copy(ret, ret.length - n, 0, nb);
+      n -= nb;
+      if (n === 0) {
+        if (nb === buf.length) {
+          ++c;
+          if (p.next) list.head = p.next;else list.head = list.tail = null;
+        } else {
+          list.head = p;
+          p.data = buf.slice(nb);
+        }
+        break;
+      }
+      ++c;
+    }
+    list.length -= c;
+    return ret;
+  }
+  
+  function endReadable(stream) {
+    var state = stream._readableState;
+  
+    // If we get here before consuming all the bytes, then that is a
+    // bug in node.  Should never happen.
+    if (state.length > 0) throw new Error('"endReadable()" called on non-empty stream');
+  
+    if (!state.endEmitted) {
+      state.ended = true;
+      processNextTick(endReadableNT, state, stream);
+    }
+  }
+  
+  function endReadableNT(state, stream) {
+    // Check that we didn't get one last unshift.
+    if (!state.endEmitted && state.length === 0) {
+      state.endEmitted = true;
+      stream.readable = false;
+      stream.emit('end');
+    }
+  }
+  
+  function forEach(xs, f) {
+    for (var i = 0, l = xs.length; i < l; i++) {
+      f(xs[i], i);
+    }
+  }
+  
+  function indexOf(xs, x) {
+    for (var i = 0, l = xs.length; i < l; i++) {
+      if (xs[i] === x) return i;
+    }
+    return -1;
+  }
+  }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+  },{"./_stream_duplex":27,"./internal/streams/BufferList":32,"./internal/streams/destroy":33,"./internal/streams/stream":34,"_process":25,"core-util-is":14,"events":18,"inherits":21,"isarray":23,"process-nextick-args":24,"safe-buffer":40,"string_decoder/":50,"util":4}],30:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // a transform stream is a readable/writable stream where you do
+  // something with the data.  Sometimes it's called a "filter",
+  // but that's not a great name for it, since that implies a thing where
+  // some bits pass through, and others are simply ignored.  (That would
+  // be a valid example of a transform, of course.)
+  //
+  // While the output is causally related to the input, it's not a
+  // necessarily symmetric or synchronous transformation.  For example,
+  // a zlib stream might take multiple plain-text writes(), and then
+  // emit a single compressed chunk some time in the future.
+  //
+  // Here's how this works:
+  //
+  // The Transform stream has all the aspects of the readable and writable
+  // stream classes.  When you write(chunk), that calls _write(chunk,cb)
+  // internally, and returns false if there's a lot of pending writes
+  // buffered up.  When you call read(), that calls _read(n) until
+  // there's enough pending readable data buffered up.
+  //
+  // In a transform stream, the written data is placed in a buffer.  When
+  // _read(n) is called, it transforms the queued up data, calling the
+  // buffered _write cb's as it consumes chunks.  If consuming a single
+  // written chunk would result in multiple output chunks, then the first
+  // outputted bit calls the readcb, and subsequent chunks just go into
+  // the read buffer, and will cause it to emit 'readable' if necessary.
+  //
+  // This way, back-pressure is actually determined by the reading side,
+  // since _read has to be called to start processing a new chunk.  However,
+  // a pathological inflate type of transform can cause excessive buffering
+  // here.  For example, imagine a stream where every byte of input is
+  // interpreted as an integer from 0-255, and then results in that many
+  // bytes of output.  Writing the 4 bytes {ff,ff,ff,ff} would result in
+  // 1kb of data being output.  In this case, you could write a very small
+  // amount of input, and end up with a very large amount of output.  In
+  // such a pathological inflating mechanism, there'd be no way to tell
+  // the system to stop doing the transform.  A single 4MB write could
+  // cause the system to run out of memory.
+  //
+  // However, even in such a pathological case, only a single written chunk
+  // would be consumed, and then the rest would wait (un-transformed) until
+  // the results of the previous transformed chunk were consumed.
+  
+  'use strict';
+  
+  module.exports = Transform;
+  
+  var Duplex = require('./_stream_duplex');
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  util.inherits(Transform, Duplex);
+  
+  function TransformState(stream) {
+    this.afterTransform = function (er, data) {
+      return afterTransform(stream, er, data);
+    };
+  
+    this.needTransform = false;
+    this.transforming = false;
+    this.writecb = null;
+    this.writechunk = null;
+    this.writeencoding = null;
+  }
+  
+  function afterTransform(stream, er, data) {
+    var ts = stream._transformState;
+    ts.transforming = false;
+  
+    var cb = ts.writecb;
+  
+    if (!cb) {
+      return stream.emit('error', new Error('write callback called multiple times'));
+    }
+  
+    ts.writechunk = null;
+    ts.writecb = null;
+  
+    if (data !== null && data !== undefined) stream.push(data);
+  
+    cb(er);
+  
+    var rs = stream._readableState;
+    rs.reading = false;
+    if (rs.needReadable || rs.length < rs.highWaterMark) {
+      stream._read(rs.highWaterMark);
+    }
+  }
+  
+  function Transform(options) {
+    if (!(this instanceof Transform)) return new Transform(options);
+  
+    Duplex.call(this, options);
+  
+    this._transformState = new TransformState(this);
+  
+    var stream = this;
+  
+    // start out asking for a readable event once data is transformed.
+    this._readableState.needReadable = true;
+  
+    // we have implemented the _read method, and done the other things
+    // that Readable wants before the first _read call, so unset the
+    // sync guard flag.
+    this._readableState.sync = false;
+  
+    if (options) {
+      if (typeof options.transform === 'function') this._transform = options.transform;
+  
+      if (typeof options.flush === 'function') this._flush = options.flush;
+    }
+  
+    // When the writable side finishes, then flush out anything remaining.
+    this.once('prefinish', function () {
+      if (typeof this._flush === 'function') this._flush(function (er, data) {
+        done(stream, er, data);
+      });else done(stream);
+    });
+  }
+  
+  Transform.prototype.push = function (chunk, encoding) {
+    this._transformState.needTransform = false;
+    return Duplex.prototype.push.call(this, chunk, encoding);
+  };
+  
+  // This is the part where you do stuff!
+  // override this function in implementation classes.
+  // 'chunk' is an input chunk.
+  //
+  // Call `push(newChunk)` to pass along transformed output
+  // to the readable side.  You may call 'push' zero or more times.
+  //
+  // Call `cb(err)` when you are done with this chunk.  If you pass
+  // an error, then that'll put the hurt on the whole operation.  If you
+  // never call cb(), then you'll never get another chunk.
+  Transform.prototype._transform = function (chunk, encoding, cb) {
+    throw new Error('_transform() is not implemented');
+  };
+  
+  Transform.prototype._write = function (chunk, encoding, cb) {
+    var ts = this._transformState;
+    ts.writecb = cb;
+    ts.writechunk = chunk;
+    ts.writeencoding = encoding;
+    if (!ts.transforming) {
+      var rs = this._readableState;
+      if (ts.needTransform || rs.needReadable || rs.length < rs.highWaterMark) this._read(rs.highWaterMark);
+    }
+  };
+  
+  // Doesn't matter what the args are here.
+  // _transform does all the work.
+  // That we got here means that the readable side wants more data.
+  Transform.prototype._read = function (n) {
+    var ts = this._transformState;
+  
+    if (ts.writechunk !== null && ts.writecb && !ts.transforming) {
+      ts.transforming = true;
+      this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
+    } else {
+      // mark that we need a transform, so that any data that comes in
+      // will get processed, now that we've asked for it.
+      ts.needTransform = true;
+    }
+  };
+  
+  Transform.prototype._destroy = function (err, cb) {
+    var _this = this;
+  
+    Duplex.prototype._destroy.call(this, err, function (err2) {
+      cb(err2);
+      _this.emit('close');
+    });
+  };
+  
+  function done(stream, er, data) {
+    if (er) return stream.emit('error', er);
+  
+    if (data !== null && data !== undefined) stream.push(data);
+  
+    // if there's nothing in the write buffer, then that means
+    // that nothing more will ever be provided
+    var ws = stream._writableState;
+    var ts = stream._transformState;
+  
+    if (ws.length) throw new Error('Calling transform done when ws.length != 0');
+  
+    if (ts.transforming) throw new Error('Calling transform done when still transforming');
+  
+    return stream.push(null);
+  }
+  },{"./_stream_duplex":27,"core-util-is":14,"inherits":21}],31:[function(require,module,exports){
+  (function (process,global){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // A bit simpler than readable streams.
+  // Implement an async ._write(chunk, encoding, cb), and it'll handle all
+  // the drain event emission and buffering.
+  
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  module.exports = Writable;
+  
+  /* <replacement> */
+  function WriteReq(chunk, encoding, cb) {
+    this.chunk = chunk;
+    this.encoding = encoding;
+    this.callback = cb;
+    this.next = null;
+  }
+  
+  // It seems a linked list but it is not
+  // there will be only 2 of these for each stream
+  function CorkedRequest(state) {
+    var _this = this;
+  
+    this.next = null;
+    this.entry = null;
+    this.finish = function () {
+      onCorkedFinish(_this, state);
+    };
+  }
+  /* </replacement> */
+  
+  /*<replacement>*/
+  var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : processNextTick;
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Duplex;
+  /*</replacement>*/
+  
+  Writable.WritableState = WritableState;
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var internalUtil = {
+    deprecate: require('util-deprecate')
+  };
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Stream = require('./internal/streams/stream');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Buffer = require('safe-buffer').Buffer;
+  var OurUint8Array = global.Uint8Array || function () {};
+  function _uint8ArrayToBuffer(chunk) {
+    return Buffer.from(chunk);
+  }
+  function _isUint8Array(obj) {
+    return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
+  }
+  /*</replacement>*/
+  
+  var destroyImpl = require('./internal/streams/destroy');
+  
+  util.inherits(Writable, Stream);
+  
+  function nop() {}
+  
+  function WritableState(options, stream) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    options = options || {};
+  
+    // object stream flag to indicate whether or not this stream
+    // contains buffers or objects.
+    this.objectMode = !!options.objectMode;
+  
+    if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.writableObjectMode;
+  
+    // the point at which write() starts returning false
+    // Note: 0 is a valid value, means that we always return false if
+    // the entire buffer is not flushed immediately on write()
+    var hwm = options.highWaterMark;
+    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+    this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+  
+    // cast to ints.
+    this.highWaterMark = Math.floor(this.highWaterMark);
+  
+    // if _final has been called
+    this.finalCalled = false;
+  
+    // drain event flag.
+    this.needDrain = false;
+    // at the start of calling end()
+    this.ending = false;
+    // when end() has been called, and returned
+    this.ended = false;
+    // when 'finish' is emitted
+    this.finished = false;
+  
+    // has it been destroyed
+    this.destroyed = false;
+  
+    // should we decode strings into buffers before passing to _write?
+    // this is here so that some node-core streams can optimize string
+    // handling at a lower level.
+    var noDecode = options.decodeStrings === false;
+    this.decodeStrings = !noDecode;
+  
+    // Crypto is kind of old and crusty.  Historically, its default string
+    // encoding is 'binary' so we have to make this configurable.
+    // Everything else in the universe uses 'utf8', though.
+    this.defaultEncoding = options.defaultEncoding || 'utf8';
+  
+    // not an actual buffer we keep track of, but a measurement
+    // of how much we're waiting to get pushed to some underlying
+    // socket or file.
+    this.length = 0;
+  
+    // a flag to see when we're in the middle of a write.
+    this.writing = false;
+  
+    // when true all writes will be buffered until .uncork() call
+    this.corked = 0;
+  
+    // a flag to be able to tell if the onwrite cb is called immediately,
+    // or on a later tick.  We set this to true at first, because any
+    // actions that shouldn't happen until "later" should generally also
+    // not happen before the first write call.
+    this.sync = true;
+  
+    // a flag to know if we're processing previously buffered items, which
+    // may call the _write() callback in the same tick, so that we don't
+    // end up in an overlapped onwrite situation.
+    this.bufferProcessing = false;
+  
+    // the callback that's passed to _write(chunk,cb)
+    this.onwrite = function (er) {
+      onwrite(stream, er);
+    };
+  
+    // the callback that the user supplies to write(chunk,encoding,cb)
+    this.writecb = null;
+  
+    // the amount that is being written when _write is called.
+    this.writelen = 0;
+  
+    this.bufferedRequest = null;
+    this.lastBufferedRequest = null;
+  
+    // number of pending user-supplied write callbacks
+    // this must be 0 before 'finish' can be emitted
+    this.pendingcb = 0;
+  
+    // emit prefinish if the only thing we're waiting for is _write cbs
+    // This is relevant for synchronous Transform streams
+    this.prefinished = false;
+  
+    // True if the error was already emitted and should not be thrown again
+    this.errorEmitted = false;
+  
+    // count buffered requests
+    this.bufferedRequestCount = 0;
+  
+    // allocate the first CorkedRequest, there is always
+    // one allocated and free to use, and we maintain at most two
+    this.corkedRequestsFree = new CorkedRequest(this);
+  }
+  
+  WritableState.prototype.getBuffer = function getBuffer() {
+    var current = this.bufferedRequest;
+    var out = [];
+    while (current) {
+      out.push(current);
+      current = current.next;
+    }
+    return out;
+  };
+  
+  (function () {
+    try {
+      Object.defineProperty(WritableState.prototype, 'buffer', {
+        get: internalUtil.deprecate(function () {
+          return this.getBuffer();
+        }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' + 'instead.', 'DEP0003')
+      });
+    } catch (_) {}
+  })();
+  
+  // Test _writableState for inheritance to account for Duplex streams,
+  // whose prototype chain only points to Readable.
+  var realHasInstance;
+  if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.prototype[Symbol.hasInstance] === 'function') {
+    realHasInstance = Function.prototype[Symbol.hasInstance];
+    Object.defineProperty(Writable, Symbol.hasInstance, {
+      value: function (object) {
+        if (realHasInstance.call(this, object)) return true;
+  
+        return object && object._writableState instanceof WritableState;
+      }
+    });
+  } else {
+    realHasInstance = function (object) {
+      return object instanceof this;
+    };
+  }
+  
+  function Writable(options) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    // Writable ctor is applied to Duplexes, too.
+    // `realHasInstance` is necessary because using plain `instanceof`
+    // would return false, as no `_writableState` property is attached.
+  
+    // Trying to use the custom `instanceof` for Writable here will also break the
+    // Node.js LazyTransform implementation, which has a non-trivial getter for
+    // `_writableState` that would lead to infinite recursion.
+    if (!realHasInstance.call(Writable, this) && !(this instanceof Duplex)) {
+      return new Writable(options);
+    }
+  
+    this._writableState = new WritableState(options, this);
+  
+    // legacy.
+    this.writable = true;
+  
+    if (options) {
+      if (typeof options.write === 'function') this._write = options.write;
+  
+      if (typeof options.writev === 'function') this._writev = options.writev;
+  
+      if (typeof options.destroy === 'function') this._destroy = options.destroy;
+  
+      if (typeof options.final === 'function') this._final = options.final;
+    }
+  
+    Stream.call(this);
+  }
+  
+  // Otherwise people can pipe Writable streams, which is just wrong.
+  Writable.prototype.pipe = function () {
+    this.emit('error', new Error('Cannot pipe, not readable'));
+  };
+  
+  function writeAfterEnd(stream, cb) {
+    var er = new Error('write after end');
+    // TODO: defer error events consistently everywhere, not just the cb
+    stream.emit('error', er);
+    processNextTick(cb, er);
+  }
+  
+  // Checks that a user-supplied chunk is valid, especially for the particular
+  // mode the stream is in. Currently this means that `null` is never accepted
+  // and undefined/non-string values are only allowed in object mode.
+  function validChunk(stream, state, chunk, cb) {
+    var valid = true;
+    var er = false;
+  
+    if (chunk === null) {
+      er = new TypeError('May not write null values to stream');
+    } else if (typeof chunk !== 'string' && chunk !== undefined && !state.objectMode) {
+      er = new TypeError('Invalid non-string/buffer chunk');
+    }
+    if (er) {
+      stream.emit('error', er);
+      processNextTick(cb, er);
+      valid = false;
+    }
+    return valid;
+  }
+  
+  Writable.prototype.write = function (chunk, encoding, cb) {
+    var state = this._writableState;
+    var ret = false;
+    var isBuf = _isUint8Array(chunk) && !state.objectMode;
+  
+    if (isBuf && !Buffer.isBuffer(chunk)) {
+      chunk = _uint8ArrayToBuffer(chunk);
+    }
+  
+    if (typeof encoding === 'function') {
+      cb = encoding;
+      encoding = null;
+    }
+  
+    if (isBuf) encoding = 'buffer';else if (!encoding) encoding = state.defaultEncoding;
+  
+    if (typeof cb !== 'function') cb = nop;
+  
+    if (state.ended) writeAfterEnd(this, cb);else if (isBuf || validChunk(this, state, chunk, cb)) {
+      state.pendingcb++;
+      ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
+    }
+  
+    return ret;
+  };
+  
+  Writable.prototype.cork = function () {
+    var state = this._writableState;
+  
+    state.corked++;
+  };
+  
+  Writable.prototype.uncork = function () {
+    var state = this._writableState;
+  
+    if (state.corked) {
+      state.corked--;
+  
+      if (!state.writing && !state.corked && !state.finished && !state.bufferProcessing && state.bufferedRequest) clearBuffer(this, state);
+    }
+  };
+  
+  Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
+    // node::ParseEncoding() requires lower case.
+    if (typeof encoding === 'string') encoding = encoding.toLowerCase();
+    if (!(['hex', 'utf8', 'utf-8', 'ascii', 'binary', 'base64', 'ucs2', 'ucs-2', 'utf16le', 'utf-16le', 'raw'].indexOf((encoding + '').toLowerCase()) > -1)) throw new TypeError('Unknown encoding: ' + encoding);
+    this._writableState.defaultEncoding = encoding;
+    return this;
+  };
+  
+  function decodeChunk(state, chunk, encoding) {
+    if (!state.objectMode && state.decodeStrings !== false && typeof chunk === 'string') {
+      chunk = Buffer.from(chunk, encoding);
+    }
+    return chunk;
+  }
+  
+  // if we're already writing something, then just put this
+  // in the queue, and wait our turn.  Otherwise, call _write
+  // If we return false, then we need a drain event, so set that flag.
+  function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
+    if (!isBuf) {
+      var newChunk = decodeChunk(state, chunk, encoding);
+      if (chunk !== newChunk) {
+        isBuf = true;
+        encoding = 'buffer';
+        chunk = newChunk;
+      }
+    }
+    var len = state.objectMode ? 1 : chunk.length;
+  
+    state.length += len;
+  
+    var ret = state.length < state.highWaterMark;
+    // we must ensure that previous needDrain will not be reset to false.
+    if (!ret) state.needDrain = true;
+  
+    if (state.writing || state.corked) {
+      var last = state.lastBufferedRequest;
+      state.lastBufferedRequest = {
+        chunk: chunk,
+        encoding: encoding,
+        isBuf: isBuf,
+        callback: cb,
+        next: null
+      };
+      if (last) {
+        last.next = state.lastBufferedRequest;
+      } else {
+        state.bufferedRequest = state.lastBufferedRequest;
+      }
+      state.bufferedRequestCount += 1;
+    } else {
+      doWrite(stream, state, false, len, chunk, encoding, cb);
+    }
+  
+    return ret;
+  }
+  
+  function doWrite(stream, state, writev, len, chunk, encoding, cb) {
+    state.writelen = len;
+    state.writecb = cb;
+    state.writing = true;
+    state.sync = true;
+    if (writev) stream._writev(chunk, state.onwrite);else stream._write(chunk, encoding, state.onwrite);
+    state.sync = false;
+  }
+  
+  function onwriteError(stream, state, sync, er, cb) {
+    --state.pendingcb;
+  
+    if (sync) {
+      // defer the callback if we are being called synchronously
+      // to avoid piling up things on the stack
+      processNextTick(cb, er);
+      // this can emit finish, and it will always happen
+      // after error
+      processNextTick(finishMaybe, stream, state);
+      stream._writableState.errorEmitted = true;
+      stream.emit('error', er);
+    } else {
+      // the caller expect this to happen before if
+      // it is async
+      cb(er);
+      stream._writableState.errorEmitted = true;
+      stream.emit('error', er);
+      // this can emit finish, but finish must
+      // always follow error
+      finishMaybe(stream, state);
+    }
+  }
+  
+  function onwriteStateUpdate(state) {
+    state.writing = false;
+    state.writecb = null;
+    state.length -= state.writelen;
+    state.writelen = 0;
+  }
+  
+  function onwrite(stream, er) {
+    var state = stream._writableState;
+    var sync = state.sync;
+    var cb = state.writecb;
+  
+    onwriteStateUpdate(state);
+  
+    if (er) onwriteError(stream, state, sync, er, cb);else {
+      // Check if we're actually ready to finish, but don't emit yet
+      var finished = needFinish(state);
+  
+      if (!finished && !state.corked && !state.bufferProcessing && state.bufferedRequest) {
+        clearBuffer(stream, state);
+      }
+  
+      if (sync) {
+        /*<replacement>*/
+        asyncWrite(afterWrite, stream, state, finished, cb);
+        /*</replacement>*/
+      } else {
+        afterWrite(stream, state, finished, cb);
+      }
+    }
+  }
+  
+  function afterWrite(stream, state, finished, cb) {
+    if (!finished) onwriteDrain(stream, state);
+    state.pendingcb--;
+    cb();
+    finishMaybe(stream, state);
+  }
+  
+  // Must force callback to be called on nextTick, so that we don't
+  // emit 'drain' before the write() consumer gets the 'false' return
+  // value, and has a chance to attach a 'drain' listener.
+  function onwriteDrain(stream, state) {
+    if (state.length === 0 && state.needDrain) {
+      state.needDrain = false;
+      stream.emit('drain');
+    }
+  }
+  
+  // if there's something in the buffer waiting, then process it
+  function clearBuffer(stream, state) {
+    state.bufferProcessing = true;
+    var entry = state.bufferedRequest;
+  
+    if (stream._writev && entry && entry.next) {
+      // Fast case, write everything using _writev()
+      var l = state.bufferedRequestCount;
+      var buffer = new Array(l);
+      var holder = state.corkedRequestsFree;
+      holder.entry = entry;
+  
+      var count = 0;
+      var allBuffers = true;
+      while (entry) {
+        buffer[count] = entry;
+        if (!entry.isBuf) allBuffers = false;
+        entry = entry.next;
+        count += 1;
+      }
+      buffer.allBuffers = allBuffers;
+  
+      doWrite(stream, state, true, state.length, buffer, '', holder.finish);
+  
+      // doWrite is almost always async, defer these to save a bit of time
+      // as the hot path ends with doWrite
+      state.pendingcb++;
+      state.lastBufferedRequest = null;
+      if (holder.next) {
+        state.corkedRequestsFree = holder.next;
+        holder.next = null;
+      } else {
+        state.corkedRequestsFree = new CorkedRequest(state);
+      }
+    } else {
+      // Slow case, write chunks one-by-one
+      while (entry) {
+        var chunk = entry.chunk;
+        var encoding = entry.encoding;
+        var cb = entry.callback;
+        var len = state.objectMode ? 1 : chunk.length;
+  
+        doWrite(stream, state, false, len, chunk, encoding, cb);
+        entry = entry.next;
+        // if we didn't call the onwrite immediately, then
+        // it means that we need to wait until it does.
+        // also, that means that the chunk and cb are currently
+        // being processed, so move the buffer counter past them.
+        if (state.writing) {
+          break;
+        }
+      }
+  
+      if (entry === null) state.lastBufferedRequest = null;
+    }
+  
+    state.bufferedRequestCount = 0;
+    state.bufferedRequest = entry;
+    state.bufferProcessing = false;
+  }
+  
+  Writable.prototype._write = function (chunk, encoding, cb) {
+    cb(new Error('_write() is not implemented'));
+  };
+  
+  Writable.prototype._writev = null;
+  
+  Writable.prototype.end = function (chunk, encoding, cb) {
+    var state = this._writableState;
+  
+    if (typeof chunk === 'function') {
+      cb = chunk;
+      chunk = null;
+      encoding = null;
+    } else if (typeof encoding === 'function') {
+      cb = encoding;
+      encoding = null;
+    }
+  
+    if (chunk !== null && chunk !== undefined) this.write(chunk, encoding);
+  
+    // .end() fully uncorks
+    if (state.corked) {
+      state.corked = 1;
+      this.uncork();
+    }
+  
+    // ignore unnecessary end() calls.
+    if (!state.ending && !state.finished) endWritable(this, state, cb);
+  };
+  
+  function needFinish(state) {
+    return state.ending && state.length === 0 && state.bufferedRequest === null && !state.finished && !state.writing;
+  }
+  function callFinal(stream, state) {
+    stream._final(function (err) {
+      state.pendingcb--;
+      if (err) {
+        stream.emit('error', err);
+      }
+      state.prefinished = true;
+      stream.emit('prefinish');
+      finishMaybe(stream, state);
+    });
+  }
+  function prefinish(stream, state) {
+    if (!state.prefinished && !state.finalCalled) {
+      if (typeof stream._final === 'function') {
+        state.pendingcb++;
+        state.finalCalled = true;
+        processNextTick(callFinal, stream, state);
+      } else {
+        state.prefinished = true;
+        stream.emit('prefinish');
+      }
+    }
+  }
+  
+  function finishMaybe(stream, state) {
+    var need = needFinish(state);
+    if (need) {
+      prefinish(stream, state);
+      if (state.pendingcb === 0) {
+        state.finished = true;
+        stream.emit('finish');
+      }
+    }
+    return need;
+  }
+  
+  function endWritable(stream, state, cb) {
+    state.ending = true;
+    finishMaybe(stream, state);
+    if (cb) {
+      if (state.finished) processNextTick(cb);else stream.once('finish', cb);
+    }
+    state.ended = true;
+    stream.writable = false;
+  }
+  
+  function onCorkedFinish(corkReq, state, err) {
+    var entry = corkReq.entry;
+    corkReq.entry = null;
+    while (entry) {
+      var cb = entry.callback;
+      state.pendingcb--;
+      cb(err);
+      entry = entry.next;
+    }
+    if (state.corkedRequestsFree) {
+      state.corkedRequestsFree.next = corkReq;
+    } else {
+      state.corkedRequestsFree = corkReq;
+    }
+  }
+  
+  Object.defineProperty(Writable.prototype, 'destroyed', {
+    get: function () {
+      if (this._writableState === undefined) {
+        return false;
+      }
+      return this._writableState.destroyed;
+    },
+    set: function (value) {
+      // we ignore the value if the stream
+      // has not been initialized yet
+      if (!this._writableState) {
+        return;
+      }
+  
+      // backward compatibility, the user is explicitly
+      // managing destroyed
+      this._writableState.destroyed = value;
+    }
+  });
+  
+  Writable.prototype.destroy = destroyImpl.destroy;
+  Writable.prototype._undestroy = destroyImpl.undestroy;
+  Writable.prototype._destroy = function (err, cb) {
+    this.end();
+    cb(err);
+  };
+  }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+  },{"./_stream_duplex":27,"./internal/streams/destroy":33,"./internal/streams/stream":34,"_process":25,"core-util-is":14,"inherits":21,"process-nextick-args":24,"safe-buffer":40,"util-deprecate":51}],32:[function(require,module,exports){
+  'use strict';
+  
+  /*<replacement>*/
+  
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+  
+  var Buffer = require('safe-buffer').Buffer;
+  /*</replacement>*/
+  
+  function copyBuffer(src, target, offset) {
+    src.copy(target, offset);
+  }
+  
+  module.exports = function () {
+    function BufferList() {
+      _classCallCheck(this, BufferList);
+  
+      this.head = null;
+      this.tail = null;
+      this.length = 0;
+    }
+  
+    BufferList.prototype.push = function push(v) {
+      var entry = { data: v, next: null };
+      if (this.length > 0) this.tail.next = entry;else this.head = entry;
+      this.tail = entry;
+      ++this.length;
+    };
+  
+    BufferList.prototype.unshift = function unshift(v) {
+      var entry = { data: v, next: this.head };
+      if (this.length === 0) this.tail = entry;
+      this.head = entry;
+      ++this.length;
+    };
+  
+    BufferList.prototype.shift = function shift() {
+      if (this.length === 0) return;
+      var ret = this.head.data;
+      if (this.length === 1) this.head = this.tail = null;else this.head = this.head.next;
+      --this.length;
+      return ret;
+    };
+  
+    BufferList.prototype.clear = function clear() {
+      this.head = this.tail = null;
+      this.length = 0;
+    };
+  
+    BufferList.prototype.join = function join(s) {
+      if (this.length === 0) return '';
+      var p = this.head;
+      var ret = '' + p.data;
+      while (p = p.next) {
+        ret += s + p.data;
+      }return ret;
+    };
+  
+    BufferList.prototype.concat = function concat(n) {
+      if (this.length === 0) return Buffer.alloc(0);
+      if (this.length === 1) return this.head.data;
+      var ret = Buffer.allocUnsafe(n >>> 0);
+      var p = this.head;
+      var i = 0;
+      while (p) {
+        copyBuffer(p.data, ret, i);
+        i += p.data.length;
+        p = p.next;
+      }
+      return ret;
+    };
+  
+    return BufferList;
+  }();
+  },{"safe-buffer":40}],33:[function(require,module,exports){
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  // undocumented cb() API, needed for core, not for public API
+  function destroy(err, cb) {
+    var _this = this;
+  
+    var readableDestroyed = this._readableState && this._readableState.destroyed;
+    var writableDestroyed = this._writableState && this._writableState.destroyed;
+  
+    if (readableDestroyed || writableDestroyed) {
+      if (cb) {
+        cb(err);
+      } else if (err && (!this._writableState || !this._writableState.errorEmitted)) {
+        processNextTick(emitErrorNT, this, err);
+      }
+      return;
+    }
+  
+    // we set destroyed to true before firing error callbacks in order
+    // to make it re-entrance safe in case destroy() is called within callbacks
+  
+    if (this._readableState) {
+      this._readableState.destroyed = true;
+    }
+  
+    // if this is a duplex stream mark the writable part as destroyed as well
+    if (this._writableState) {
+      this._writableState.destroyed = true;
+    }
+  
+    this._destroy(err || null, function (err) {
+      if (!cb && err) {
+        processNextTick(emitErrorNT, _this, err);
+        if (_this._writableState) {
+          _this._writableState.errorEmitted = true;
+        }
+      } else if (cb) {
+        cb(err);
+      }
+    });
+  }
+  
+  function undestroy() {
+    if (this._readableState) {
+      this._readableState.destroyed = false;
+      this._readableState.reading = false;
+      this._readableState.ended = false;
+      this._readableState.endEmitted = false;
+    }
+  
+    if (this._writableState) {
+      this._writableState.destroyed = false;
+      this._writableState.ended = false;
+      this._writableState.ending = false;
+      this._writableState.finished = false;
+      this._writableState.errorEmitted = false;
+    }
+  }
+  
+  function emitErrorNT(self, err) {
+    self.emit('error', err);
+  }
+  
+  module.exports = {
+    destroy: destroy,
+    undestroy: undestroy
+  };
+  },{"process-nextick-args":24}],34:[function(require,module,exports){
+  module.exports = require('events').EventEmitter;
+  
+  },{"events":18}],35:[function(require,module,exports){
+  module.exports = require('./readable').PassThrough
+  
+  },{"./readable":36}],36:[function(require,module,exports){
+  exports = module.exports = require('./lib/_stream_readable.js');
+  exports.Stream = exports;
+  exports.Readable = exports;
+  exports.Writable = require('./lib/_stream_writable.js');
+  exports.Duplex = require('./lib/_stream_duplex.js');
+  exports.Transform = require('./lib/_stream_transform.js');
+  exports.PassThrough = require('./lib/_stream_passthrough.js');
+  
+  },{"./lib/_stream_duplex.js":27,"./lib/_stream_passthrough.js":28,"./lib/_stream_readable.js":29,"./lib/_stream_transform.js":30,"./lib/_stream_writable.js":31}],37:[function(require,module,exports){
+  module.exports = require('./readable').Transform
+  
+  },{"./readable":36}],38:[function(require,module,exports){
+  module.exports = require('./lib/_stream_writable.js');
+  
+  },{"./lib/_stream_writable.js":31}],39:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var inherits = require('inherits')
+  var HashBase = require('hash-base')
+  
+  function RIPEMD160 () {
+    HashBase.call(this, 64)
+  
+    // state
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
+  }
+  
+  inherits(RIPEMD160, HashBase)
+  
+  RIPEMD160.prototype._update = function () {
+    var m = new Array(16)
+    for (var i = 0; i < 16; ++i) m[i] = this._block.readInt32LE(i * 4)
+  
+    var al = this._a
+    var bl = this._b
+    var cl = this._c
+    var dl = this._d
+    var el = this._e
+  
+    // Mj = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    // K = 0x00000000
+    // Sj = 11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8
+    al = fn1(al, bl, cl, dl, el, m[0], 0x00000000, 11); cl = rotl(cl, 10)
+    el = fn1(el, al, bl, cl, dl, m[1], 0x00000000, 14); bl = rotl(bl, 10)
+    dl = fn1(dl, el, al, bl, cl, m[2], 0x00000000, 15); al = rotl(al, 10)
+    cl = fn1(cl, dl, el, al, bl, m[3], 0x00000000, 12); el = rotl(el, 10)
+    bl = fn1(bl, cl, dl, el, al, m[4], 0x00000000, 5); dl = rotl(dl, 10)
+    al = fn1(al, bl, cl, dl, el, m[5], 0x00000000, 8); cl = rotl(cl, 10)
+    el = fn1(el, al, bl, cl, dl, m[6], 0x00000000, 7); bl = rotl(bl, 10)
+    dl = fn1(dl, el, al, bl, cl, m[7], 0x00000000, 9); al = rotl(al, 10)
+    cl = fn1(cl, dl, el, al, bl, m[8], 0x00000000, 11); el = rotl(el, 10)
+    bl = fn1(bl, cl, dl, el, al, m[9], 0x00000000, 13); dl = rotl(dl, 10)
+    al = fn1(al, bl, cl, dl, el, m[10], 0x00000000, 14); cl = rotl(cl, 10)
+    el = fn1(el, al, bl, cl, dl, m[11], 0x00000000, 15); bl = rotl(bl, 10)
+    dl = fn1(dl, el, al, bl, cl, m[12], 0x00000000, 6); al = rotl(al, 10)
+    cl = fn1(cl, dl, el, al, bl, m[13], 0x00000000, 7); el = rotl(el, 10)
+    bl = fn1(bl, cl, dl, el, al, m[14], 0x00000000, 9); dl = rotl(dl, 10)
+    al = fn1(al, bl, cl, dl, el, m[15], 0x00000000, 8); cl = rotl(cl, 10)
+  
+    // Mj = 7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8
+    // K = 0x5a827999
+    // Sj = 7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12
+    el = fn2(el, al, bl, cl, dl, m[7], 0x5a827999, 7); bl = rotl(bl, 10)
+    dl = fn2(dl, el, al, bl, cl, m[4], 0x5a827999, 6); al = rotl(al, 10)
+    cl = fn2(cl, dl, el, al, bl, m[13], 0x5a827999, 8); el = rotl(el, 10)
+    bl = fn2(bl, cl, dl, el, al, m[1], 0x5a827999, 13); dl = rotl(dl, 10)
+    al = fn2(al, bl, cl, dl, el, m[10], 0x5a827999, 11); cl = rotl(cl, 10)
+    el = fn2(el, al, bl, cl, dl, m[6], 0x5a827999, 9); bl = rotl(bl, 10)
+    dl = fn2(dl, el, al, bl, cl, m[15], 0x5a827999, 7); al = rotl(al, 10)
+    cl = fn2(cl, dl, el, al, bl, m[3], 0x5a827999, 15); el = rotl(el, 10)
+    bl = fn2(bl, cl, dl, el, al, m[12], 0x5a827999, 7); dl = rotl(dl, 10)
+    al = fn2(al, bl, cl, dl, el, m[0], 0x5a827999, 12); cl = rotl(cl, 10)
+    el = fn2(el, al, bl, cl, dl, m[9], 0x5a827999, 15); bl = rotl(bl, 10)
+    dl = fn2(dl, el, al, bl, cl, m[5], 0x5a827999, 9); al = rotl(al, 10)
+    cl = fn2(cl, dl, el, al, bl, m[2], 0x5a827999, 11); el = rotl(el, 10)
+    bl = fn2(bl, cl, dl, el, al, m[14], 0x5a827999, 7); dl = rotl(dl, 10)
+    al = fn2(al, bl, cl, dl, el, m[11], 0x5a827999, 13); cl = rotl(cl, 10)
+    el = fn2(el, al, bl, cl, dl, m[8], 0x5a827999, 12); bl = rotl(bl, 10)
+  
+    // Mj = 3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12
+    // K = 0x6ed9eba1
+    // Sj = 11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5
+    dl = fn3(dl, el, al, bl, cl, m[3], 0x6ed9eba1, 11); al = rotl(al, 10)
+    cl = fn3(cl, dl, el, al, bl, m[10], 0x6ed9eba1, 13); el = rotl(el, 10)
+    bl = fn3(bl, cl, dl, el, al, m[14], 0x6ed9eba1, 6); dl = rotl(dl, 10)
+    al = fn3(al, bl, cl, dl, el, m[4], 0x6ed9eba1, 7); cl = rotl(cl, 10)
+    el = fn3(el, al, bl, cl, dl, m[9], 0x6ed9eba1, 14); bl = rotl(bl, 10)
+    dl = fn3(dl, el, al, bl, cl, m[15], 0x6ed9eba1, 9); al = rotl(al, 10)
+    cl = fn3(cl, dl, el, al, bl, m[8], 0x6ed9eba1, 13); el = rotl(el, 10)
+    bl = fn3(bl, cl, dl, el, al, m[1], 0x6ed9eba1, 15); dl = rotl(dl, 10)
+    al = fn3(al, bl, cl, dl, el, m[2], 0x6ed9eba1, 14); cl = rotl(cl, 10)
+    el = fn3(el, al, bl, cl, dl, m[7], 0x6ed9eba1, 8); bl = rotl(bl, 10)
+    dl = fn3(dl, el, al, bl, cl, m[0], 0x6ed9eba1, 13); al = rotl(al, 10)
+    cl = fn3(cl, dl, el, al, bl, m[6], 0x6ed9eba1, 6); el = rotl(el, 10)
+    bl = fn3(bl, cl, dl, el, al, m[13], 0x6ed9eba1, 5); dl = rotl(dl, 10)
+    al = fn3(al, bl, cl, dl, el, m[11], 0x6ed9eba1, 12); cl = rotl(cl, 10)
+    el = fn3(el, al, bl, cl, dl, m[5], 0x6ed9eba1, 7); bl = rotl(bl, 10)
+    dl = fn3(dl, el, al, bl, cl, m[12], 0x6ed9eba1, 5); al = rotl(al, 10)
+  
+    // Mj = 1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2
+    // K = 0x8f1bbcdc
+    // Sj = 11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12
+    cl = fn4(cl, dl, el, al, bl, m[1], 0x8f1bbcdc, 11); el = rotl(el, 10)
+    bl = fn4(bl, cl, dl, el, al, m[9], 0x8f1bbcdc, 12); dl = rotl(dl, 10)
+    al = fn4(al, bl, cl, dl, el, m[11], 0x8f1bbcdc, 14); cl = rotl(cl, 10)
+    el = fn4(el, al, bl, cl, dl, m[10], 0x8f1bbcdc, 15); bl = rotl(bl, 10)
+    dl = fn4(dl, el, al, bl, cl, m[0], 0x8f1bbcdc, 14); al = rotl(al, 10)
+    cl = fn4(cl, dl, el, al, bl, m[8], 0x8f1bbcdc, 15); el = rotl(el, 10)
+    bl = fn4(bl, cl, dl, el, al, m[12], 0x8f1bbcdc, 9); dl = rotl(dl, 10)
+    al = fn4(al, bl, cl, dl, el, m[4], 0x8f1bbcdc, 8); cl = rotl(cl, 10)
+    el = fn4(el, al, bl, cl, dl, m[13], 0x8f1bbcdc, 9); bl = rotl(bl, 10)
+    dl = fn4(dl, el, al, bl, cl, m[3], 0x8f1bbcdc, 14); al = rotl(al, 10)
+    cl = fn4(cl, dl, el, al, bl, m[7], 0x8f1bbcdc, 5); el = rotl(el, 10)
+    bl = fn4(bl, cl, dl, el, al, m[15], 0x8f1bbcdc, 6); dl = rotl(dl, 10)
+    al = fn4(al, bl, cl, dl, el, m[14], 0x8f1bbcdc, 8); cl = rotl(cl, 10)
+    el = fn4(el, al, bl, cl, dl, m[5], 0x8f1bbcdc, 6); bl = rotl(bl, 10)
+    dl = fn4(dl, el, al, bl, cl, m[6], 0x8f1bbcdc, 5); al = rotl(al, 10)
+    cl = fn4(cl, dl, el, al, bl, m[2], 0x8f1bbcdc, 12); el = rotl(el, 10)
+  
+    // Mj = 4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15, 13
+    // K = 0xa953fd4e
+    // Sj = 9, 15, 5, 11, 6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6
+    bl = fn5(bl, cl, dl, el, al, m[4], 0xa953fd4e, 9); dl = rotl(dl, 10)
+    al = fn5(al, bl, cl, dl, el, m[0], 0xa953fd4e, 15); cl = rotl(cl, 10)
+    el = fn5(el, al, bl, cl, dl, m[5], 0xa953fd4e, 5); bl = rotl(bl, 10)
+    dl = fn5(dl, el, al, bl, cl, m[9], 0xa953fd4e, 11); al = rotl(al, 10)
+    cl = fn5(cl, dl, el, al, bl, m[7], 0xa953fd4e, 6); el = rotl(el, 10)
+    bl = fn5(bl, cl, dl, el, al, m[12], 0xa953fd4e, 8); dl = rotl(dl, 10)
+    al = fn5(al, bl, cl, dl, el, m[2], 0xa953fd4e, 13); cl = rotl(cl, 10)
+    el = fn5(el, al, bl, cl, dl, m[10], 0xa953fd4e, 12); bl = rotl(bl, 10)
+    dl = fn5(dl, el, al, bl, cl, m[14], 0xa953fd4e, 5); al = rotl(al, 10)
+    cl = fn5(cl, dl, el, al, bl, m[1], 0xa953fd4e, 12); el = rotl(el, 10)
+    bl = fn5(bl, cl, dl, el, al, m[3], 0xa953fd4e, 13); dl = rotl(dl, 10)
+    al = fn5(al, bl, cl, dl, el, m[8], 0xa953fd4e, 14); cl = rotl(cl, 10)
+    el = fn5(el, al, bl, cl, dl, m[11], 0xa953fd4e, 11); bl = rotl(bl, 10)
+    dl = fn5(dl, el, al, bl, cl, m[6], 0xa953fd4e, 8); al = rotl(al, 10)
+    cl = fn5(cl, dl, el, al, bl, m[15], 0xa953fd4e, 5); el = rotl(el, 10)
+    bl = fn5(bl, cl, dl, el, al, m[13], 0xa953fd4e, 6); dl = rotl(dl, 10)
+  
+    var ar = this._a
+    var br = this._b
+    var cr = this._c
+    var dr = this._d
+    var er = this._e
+  
+    // M'j = 5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12
+    // K' = 0x50a28be6
+    // S'j = 8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6
+    ar = fn5(ar, br, cr, dr, er, m[5], 0x50a28be6, 8); cr = rotl(cr, 10)
+    er = fn5(er, ar, br, cr, dr, m[14], 0x50a28be6, 9); br = rotl(br, 10)
+    dr = fn5(dr, er, ar, br, cr, m[7], 0x50a28be6, 9); ar = rotl(ar, 10)
+    cr = fn5(cr, dr, er, ar, br, m[0], 0x50a28be6, 11); er = rotl(er, 10)
+    br = fn5(br, cr, dr, er, ar, m[9], 0x50a28be6, 13); dr = rotl(dr, 10)
+    ar = fn5(ar, br, cr, dr, er, m[2], 0x50a28be6, 15); cr = rotl(cr, 10)
+    er = fn5(er, ar, br, cr, dr, m[11], 0x50a28be6, 15); br = rotl(br, 10)
+    dr = fn5(dr, er, ar, br, cr, m[4], 0x50a28be6, 5); ar = rotl(ar, 10)
+    cr = fn5(cr, dr, er, ar, br, m[13], 0x50a28be6, 7); er = rotl(er, 10)
+    br = fn5(br, cr, dr, er, ar, m[6], 0x50a28be6, 7); dr = rotl(dr, 10)
+    ar = fn5(ar, br, cr, dr, er, m[15], 0x50a28be6, 8); cr = rotl(cr, 10)
+    er = fn5(er, ar, br, cr, dr, m[8], 0x50a28be6, 11); br = rotl(br, 10)
+    dr = fn5(dr, er, ar, br, cr, m[1], 0x50a28be6, 14); ar = rotl(ar, 10)
+    cr = fn5(cr, dr, er, ar, br, m[10], 0x50a28be6, 14); er = rotl(er, 10)
+    br = fn5(br, cr, dr, er, ar, m[3], 0x50a28be6, 12); dr = rotl(dr, 10)
+    ar = fn5(ar, br, cr, dr, er, m[12], 0x50a28be6, 6); cr = rotl(cr, 10)
+  
+    // M'j = 6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2
+    // K' = 0x5c4dd124
+    // S'j = 9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11
+    er = fn4(er, ar, br, cr, dr, m[6], 0x5c4dd124, 9); br = rotl(br, 10)
+    dr = fn4(dr, er, ar, br, cr, m[11], 0x5c4dd124, 13); ar = rotl(ar, 10)
+    cr = fn4(cr, dr, er, ar, br, m[3], 0x5c4dd124, 15); er = rotl(er, 10)
+    br = fn4(br, cr, dr, er, ar, m[7], 0x5c4dd124, 7); dr = rotl(dr, 10)
+    ar = fn4(ar, br, cr, dr, er, m[0], 0x5c4dd124, 12); cr = rotl(cr, 10)
+    er = fn4(er, ar, br, cr, dr, m[13], 0x5c4dd124, 8); br = rotl(br, 10)
+    dr = fn4(dr, er, ar, br, cr, m[5], 0x5c4dd124, 9); ar = rotl(ar, 10)
+    cr = fn4(cr, dr, er, ar, br, m[10], 0x5c4dd124, 11); er = rotl(er, 10)
+    br = fn4(br, cr, dr, er, ar, m[14], 0x5c4dd124, 7); dr = rotl(dr, 10)
+    ar = fn4(ar, br, cr, dr, er, m[15], 0x5c4dd124, 7); cr = rotl(cr, 10)
+    er = fn4(er, ar, br, cr, dr, m[8], 0x5c4dd124, 12); br = rotl(br, 10)
+    dr = fn4(dr, er, ar, br, cr, m[12], 0x5c4dd124, 7); ar = rotl(ar, 10)
+    cr = fn4(cr, dr, er, ar, br, m[4], 0x5c4dd124, 6); er = rotl(er, 10)
+    br = fn4(br, cr, dr, er, ar, m[9], 0x5c4dd124, 15); dr = rotl(dr, 10)
+    ar = fn4(ar, br, cr, dr, er, m[1], 0x5c4dd124, 13); cr = rotl(cr, 10)
+    er = fn4(er, ar, br, cr, dr, m[2], 0x5c4dd124, 11); br = rotl(br, 10)
+  
+    // M'j = 15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13
+    // K' = 0x6d703ef3
+    // S'j = 9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5
+    dr = fn3(dr, er, ar, br, cr, m[15], 0x6d703ef3, 9); ar = rotl(ar, 10)
+    cr = fn3(cr, dr, er, ar, br, m[5], 0x6d703ef3, 7); er = rotl(er, 10)
+    br = fn3(br, cr, dr, er, ar, m[1], 0x6d703ef3, 15); dr = rotl(dr, 10)
+    ar = fn3(ar, br, cr, dr, er, m[3], 0x6d703ef3, 11); cr = rotl(cr, 10)
+    er = fn3(er, ar, br, cr, dr, m[7], 0x6d703ef3, 8); br = rotl(br, 10)
+    dr = fn3(dr, er, ar, br, cr, m[14], 0x6d703ef3, 6); ar = rotl(ar, 10)
+    cr = fn3(cr, dr, er, ar, br, m[6], 0x6d703ef3, 6); er = rotl(er, 10)
+    br = fn3(br, cr, dr, er, ar, m[9], 0x6d703ef3, 14); dr = rotl(dr, 10)
+    ar = fn3(ar, br, cr, dr, er, m[11], 0x6d703ef3, 12); cr = rotl(cr, 10)
+    er = fn3(er, ar, br, cr, dr, m[8], 0x6d703ef3, 13); br = rotl(br, 10)
+    dr = fn3(dr, er, ar, br, cr, m[12], 0x6d703ef3, 5); ar = rotl(ar, 10)
+    cr = fn3(cr, dr, er, ar, br, m[2], 0x6d703ef3, 14); er = rotl(er, 10)
+    br = fn3(br, cr, dr, er, ar, m[10], 0x6d703ef3, 13); dr = rotl(dr, 10)
+    ar = fn3(ar, br, cr, dr, er, m[0], 0x6d703ef3, 13); cr = rotl(cr, 10)
+    er = fn3(er, ar, br, cr, dr, m[4], 0x6d703ef3, 7); br = rotl(br, 10)
+    dr = fn3(dr, er, ar, br, cr, m[13], 0x6d703ef3, 5); ar = rotl(ar, 10)
+  
+    // M'j = 8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14
+    // K' = 0x7a6d76e9
+    // S'j = 15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8
+    cr = fn2(cr, dr, er, ar, br, m[8], 0x7a6d76e9, 15); er = rotl(er, 10)
+    br = fn2(br, cr, dr, er, ar, m[6], 0x7a6d76e9, 5); dr = rotl(dr, 10)
+    ar = fn2(ar, br, cr, dr, er, m[4], 0x7a6d76e9, 8); cr = rotl(cr, 10)
+    er = fn2(er, ar, br, cr, dr, m[1], 0x7a6d76e9, 11); br = rotl(br, 10)
+    dr = fn2(dr, er, ar, br, cr, m[3], 0x7a6d76e9, 14); ar = rotl(ar, 10)
+    cr = fn2(cr, dr, er, ar, br, m[11], 0x7a6d76e9, 14); er = rotl(er, 10)
+    br = fn2(br, cr, dr, er, ar, m[15], 0x7a6d76e9, 6); dr = rotl(dr, 10)
+    ar = fn2(ar, br, cr, dr, er, m[0], 0x7a6d76e9, 14); cr = rotl(cr, 10)
+    er = fn2(er, ar, br, cr, dr, m[5], 0x7a6d76e9, 6); br = rotl(br, 10)
+    dr = fn2(dr, er, ar, br, cr, m[12], 0x7a6d76e9, 9); ar = rotl(ar, 10)
+    cr = fn2(cr, dr, er, ar, br, m[2], 0x7a6d76e9, 12); er = rotl(er, 10)
+    br = fn2(br, cr, dr, er, ar, m[13], 0x7a6d76e9, 9); dr = rotl(dr, 10)
+    ar = fn2(ar, br, cr, dr, er, m[9], 0x7a6d76e9, 12); cr = rotl(cr, 10)
+    er = fn2(er, ar, br, cr, dr, m[7], 0x7a6d76e9, 5); br = rotl(br, 10)
+    dr = fn2(dr, er, ar, br, cr, m[10], 0x7a6d76e9, 15); ar = rotl(ar, 10)
+    cr = fn2(cr, dr, er, ar, br, m[14], 0x7a6d76e9, 8); er = rotl(er, 10)
+  
+    // M'j = 12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14, 0, 3, 9, 11
+    // K' = 0x00000000
+    // S'j = 8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11
+    br = fn1(br, cr, dr, er, ar, m[12], 0x00000000, 8); dr = rotl(dr, 10)
+    ar = fn1(ar, br, cr, dr, er, m[15], 0x00000000, 5); cr = rotl(cr, 10)
+    er = fn1(er, ar, br, cr, dr, m[10], 0x00000000, 12); br = rotl(br, 10)
+    dr = fn1(dr, er, ar, br, cr, m[4], 0x00000000, 9); ar = rotl(ar, 10)
+    cr = fn1(cr, dr, er, ar, br, m[1], 0x00000000, 12); er = rotl(er, 10)
+    br = fn1(br, cr, dr, er, ar, m[5], 0x00000000, 5); dr = rotl(dr, 10)
+    ar = fn1(ar, br, cr, dr, er, m[8], 0x00000000, 14); cr = rotl(cr, 10)
+    er = fn1(er, ar, br, cr, dr, m[7], 0x00000000, 6); br = rotl(br, 10)
+    dr = fn1(dr, er, ar, br, cr, m[6], 0x00000000, 8); ar = rotl(ar, 10)
+    cr = fn1(cr, dr, er, ar, br, m[2], 0x00000000, 13); er = rotl(er, 10)
+    br = fn1(br, cr, dr, er, ar, m[13], 0x00000000, 6); dr = rotl(dr, 10)
+    ar = fn1(ar, br, cr, dr, er, m[14], 0x00000000, 5); cr = rotl(cr, 10)
+    er = fn1(er, ar, br, cr, dr, m[0], 0x00000000, 15); br = rotl(br, 10)
+    dr = fn1(dr, er, ar, br, cr, m[3], 0x00000000, 13); ar = rotl(ar, 10)
+    cr = fn1(cr, dr, er, ar, br, m[9], 0x00000000, 11); er = rotl(er, 10)
+    br = fn1(br, cr, dr, er, ar, m[11], 0x00000000, 11); dr = rotl(dr, 10)
+  
+    // change state
+    var t = (this._b + cl + dr) | 0
+    this._b = (this._c + dl + er) | 0
+    this._c = (this._d + el + ar) | 0
+    this._d = (this._e + al + br) | 0
+    this._e = (this._a + bl + cr) | 0
+    this._a = t
+  }
+  
+  RIPEMD160.prototype._digest = function () {
+    // create padding and handle blocks
+    this._block[this._blockOffset++] = 0x80
+    if (this._blockOffset > 56) {
+      this._block.fill(0, this._blockOffset, 64)
+      this._update()
+      this._blockOffset = 0
+    }
+  
+    this._block.fill(0, this._blockOffset, 56)
+    this._block.writeUInt32LE(this._length[0], 56)
+    this._block.writeUInt32LE(this._length[1], 60)
+    this._update()
+  
+    // produce result
+    var buffer = new Buffer(20)
+    buffer.writeInt32LE(this._a, 0)
+    buffer.writeInt32LE(this._b, 4)
+    buffer.writeInt32LE(this._c, 8)
+    buffer.writeInt32LE(this._d, 12)
+    buffer.writeInt32LE(this._e, 16)
+    return buffer
+  }
+  
+  function rotl (x, n) {
+    return (x << n) | (x >>> (32 - n))
+  }
+  
+  function fn1 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + (b ^ c ^ d) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn2 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + ((b & c) | ((~b) & d)) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn3 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + ((b | (~c)) ^ d) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn4 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + ((b & d) | (c & (~d))) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn5 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + (b ^ (c | (~d))) + m + k) | 0, s) + e) | 0
+  }
+  
+  module.exports = RIPEMD160
+  
+  }).call(this,require("buffer").Buffer)
+  },{"buffer":8,"hash-base":19,"inherits":21}],40:[function(require,module,exports){
+  /* eslint-disable node/no-deprecated-api */
+  var buffer = require('buffer')
+  var Buffer = buffer.Buffer
+  
+  // alternative to using Object.keys for old browsers
+  function copyProps (src, dst) {
+    for (var key in src) {
+      dst[key] = src[key]
+    }
+  }
+  if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+    module.exports = buffer
+  } else {
+    // Copy properties from require('buffer')
+    copyProps(buffer, exports)
+    exports.Buffer = SafeBuffer
+  }
+  
+  function SafeBuffer (arg, encodingOrOffset, length) {
+    return Buffer(arg, encodingOrOffset, length)
+  }
+  
+  // Copy static methods from Buffer
+  copyProps(Buffer, SafeBuffer)
+  
+  SafeBuffer.from = function (arg, encodingOrOffset, length) {
+    if (typeof arg === 'number') {
+      throw new TypeError('Argument must not be a number')
+    }
+    return Buffer(arg, encodingOrOffset, length)
+  }
+  
+  SafeBuffer.alloc = function (size, fill, encoding) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Argument must be a number')
+    }
+    var buf = Buffer(size)
+    if (fill !== undefined) {
+      if (typeof encoding === 'string') {
+        buf.fill(fill, encoding)
+      } else {
+        buf.fill(fill)
+      }
+    } else {
+      buf.fill(0)
+    }
+    return buf
+  }
+  
+  SafeBuffer.allocUnsafe = function (size) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Argument must be a number')
+    }
+    return Buffer(size)
+  }
+  
+  SafeBuffer.allocUnsafeSlow = function (size) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Argument must be a number')
+    }
+    return buffer.SlowBuffer(size)
+  }
+  
+  },{"buffer":8}],41:[function(require,module,exports){
+  var Buffer = require('safe-buffer').Buffer
+  
+  // prototype class for hash functions
+  function Hash (blockSize, finalSize) {
+    this._block = Buffer.alloc(blockSize)
+    this._finalSize = finalSize
+    this._blockSize = blockSize
+    this._len = 0
+  }
+  
+  Hash.prototype.update = function (data, enc) {
+    if (typeof data === 'string') {
+      enc = enc || 'utf8'
+      data = Buffer.from(data, enc)
+    }
+  
+    var block = this._block
+    var blockSize = this._blockSize
+    var length = data.length
+    var accum = this._len
+  
+    for (var offset = 0; offset < length;) {
+      var assigned = accum % blockSize
+      var remainder = Math.min(length - offset, blockSize - assigned)
+  
+      for (var i = 0; i < remainder; i++) {
+        block[assigned + i] = data[offset + i]
+      }
+  
+      accum += remainder
+      offset += remainder
+  
+      if ((accum % blockSize) === 0) {
+        this._update(block)
+      }
+    }
+  
+    this._len += length
+    return this
+  }
+  
+  Hash.prototype.digest = function (enc) {
+    var rem = this._len % this._blockSize
+  
+    this._block[rem] = 0x80
+  
+    // zero (rem + 1) trailing bits, where (rem + 1) is the smallest
+    // non-negative solution to the equation (length + 1 + (rem + 1)) === finalSize mod blockSize
+    this._block.fill(0, rem + 1)
+  
+    if (rem >= this._finalSize) {
+      this._update(this._block)
+      this._block.fill(0)
+    }
+  
+    var bits = this._len * 8
+  
+    // uint32
+    if (bits <= 0xffffffff) {
+      this._block.writeUInt32BE(bits, this._blockSize - 4)
+  
+    // uint64
+    } else {
+      var lowBits = bits & 0xffffffff
+      var highBits = (bits - lowBits) / 0x100000000
+  
+      this._block.writeUInt32BE(highBits, this._blockSize - 8)
+      this._block.writeUInt32BE(lowBits, this._blockSize - 4)
+    }
+  
+    this._update(this._block)
+    var hash = this._hash()
+  
+    return enc ? hash.toString(enc) : hash
+  }
+  
+  Hash.prototype._update = function () {
+    throw new Error('_update must be implemented by subclass')
+  }
+  
+  module.exports = Hash
+  
+  },{"safe-buffer":40}],42:[function(require,module,exports){
+  var exports = module.exports = function SHA (algorithm) {
+    algorithm = algorithm.toLowerCase()
+  
+    var Algorithm = exports[algorithm]
+    if (!Algorithm) throw new Error(algorithm + ' is not supported (we accept pull requests)')
+  
+    return new Algorithm()
+  }
+  
+  exports.sha = require('./sha')
+  exports.sha1 = require('./sha1')
+  exports.sha224 = require('./sha224')
+  exports.sha256 = require('./sha256')
+  exports.sha384 = require('./sha384')
+  exports.sha512 = require('./sha512')
+  
+  },{"./sha":43,"./sha1":44,"./sha224":45,"./sha256":46,"./sha384":47,"./sha512":48}],43:[function(require,module,exports){
+  /*
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-0, as defined
+   * in FIPS PUB 180-1
+   * This source code is derived from sha1.js of the same repository.
+   * The difference between SHA-0 and SHA-1 is just a bitwise rotate left
+   * operation was added.
+   */
+  
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0
+  ]
+  
+  var W = new Array(80)
+  
+  function Sha () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha, Hash)
+  
+  Sha.prototype.init = function () {
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
+  
+    return this
+  }
+  
+  function rotl5 (num) {
+    return (num << 5) | (num >>> 27)
+  }
+  
+  function rotl30 (num) {
+    return (num << 30) | (num >>> 2)
+  }
+  
+  function ft (s, b, c, d) {
+    if (s === 0) return (b & c) | ((~b) & d)
+    if (s === 2) return (b & c) | (b & d) | (c & d)
+    return b ^ c ^ d
+  }
+  
+  Sha.prototype._update = function (M) {
+    var W = this._w
+  
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
+  
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+    for (; i < 80; ++i) W[i] = W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16]
+  
+    for (var j = 0; j < 80; ++j) {
+      var s = ~~(j / 20)
+      var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
+  
+      e = d
+      d = c
+      c = rotl30(b)
+      b = a
+      a = t
+    }
+  
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
+  }
+  
+  Sha.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(20)
+  
+    H.writeInt32BE(this._a | 0, 0)
+    H.writeInt32BE(this._b | 0, 4)
+    H.writeInt32BE(this._c | 0, 8)
+    H.writeInt32BE(this._d | 0, 12)
+    H.writeInt32BE(this._e | 0, 16)
+  
+    return H
+  }
+  
+  module.exports = Sha
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],44:[function(require,module,exports){
+  /*
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
+   * in FIPS PUB 180-1
+   * Version 2.1a Copyright Paul Johnston 2000 - 2002.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   * Distributed under the BSD License
+   * See http://pajhome.org.uk/crypt/md5 for details.
+   */
+  
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0
+  ]
+  
+  var W = new Array(80)
+  
+  function Sha1 () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha1, Hash)
+  
+  Sha1.prototype.init = function () {
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
+  
+    return this
+  }
+  
+  function rotl1 (num) {
+    return (num << 1) | (num >>> 31)
+  }
+  
+  function rotl5 (num) {
+    return (num << 5) | (num >>> 27)
+  }
+  
+  function rotl30 (num) {
+    return (num << 30) | (num >>> 2)
+  }
+  
+  function ft (s, b, c, d) {
+    if (s === 0) return (b & c) | ((~b) & d)
+    if (s === 2) return (b & c) | (b & d) | (c & d)
+    return b ^ c ^ d
+  }
+  
+  Sha1.prototype._update = function (M) {
+    var W = this._w
+  
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
+  
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+    for (; i < 80; ++i) W[i] = rotl1(W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16])
+  
+    for (var j = 0; j < 80; ++j) {
+      var s = ~~(j / 20)
+      var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
+  
+      e = d
+      d = c
+      c = rotl30(b)
+      b = a
+      a = t
+    }
+  
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
+  }
+  
+  Sha1.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(20)
+  
+    H.writeInt32BE(this._a | 0, 0)
+    H.writeInt32BE(this._b | 0, 4)
+    H.writeInt32BE(this._c | 0, 8)
+    H.writeInt32BE(this._d | 0, 12)
+    H.writeInt32BE(this._e | 0, 16)
+  
+    return H
+  }
+  
+  module.exports = Sha1
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],45:[function(require,module,exports){
+  /**
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
+   * in FIPS 180-2
+   * Version 2.2-beta Copyright Angel Marin, Paul Johnston 2000 - 2009.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   *
+   */
+  
+  var inherits = require('inherits')
+  var Sha256 = require('./sha256')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var W = new Array(64)
+  
+  function Sha224 () {
+    this.init()
+  
+    this._w = W // new Array(64)
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha224, Sha256)
+  
+  Sha224.prototype.init = function () {
+    this._a = 0xc1059ed8
+    this._b = 0x367cd507
+    this._c = 0x3070dd17
+    this._d = 0xf70e5939
+    this._e = 0xffc00b31
+    this._f = 0x68581511
+    this._g = 0x64f98fa7
+    this._h = 0xbefa4fa4
+  
+    return this
+  }
+  
+  Sha224.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(28)
+  
+    H.writeInt32BE(this._a, 0)
+    H.writeInt32BE(this._b, 4)
+    H.writeInt32BE(this._c, 8)
+    H.writeInt32BE(this._d, 12)
+    H.writeInt32BE(this._e, 16)
+    H.writeInt32BE(this._f, 20)
+    H.writeInt32BE(this._g, 24)
+  
+    return H
+  }
+  
+  module.exports = Sha224
+  
+  },{"./hash":41,"./sha256":46,"inherits":21,"safe-buffer":40}],46:[function(require,module,exports){
+  /**
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
+   * in FIPS 180-2
+   * Version 2.2-beta Copyright Angel Marin, Paul Johnston 2000 - 2009.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   *
+   */
+  
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+  ]
+  
+  var W = new Array(64)
+  
+  function Sha256 () {
+    this.init()
+  
+    this._w = W // new Array(64)
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha256, Hash)
+  
+  Sha256.prototype.init = function () {
+    this._a = 0x6a09e667
+    this._b = 0xbb67ae85
+    this._c = 0x3c6ef372
+    this._d = 0xa54ff53a
+    this._e = 0x510e527f
+    this._f = 0x9b05688c
+    this._g = 0x1f83d9ab
+    this._h = 0x5be0cd19
+  
+    return this
+  }
+  
+  function ch (x, y, z) {
+    return z ^ (x & (y ^ z))
+  }
+  
+  function maj (x, y, z) {
+    return (x & y) | (z & (x | y))
+  }
+  
+  function sigma0 (x) {
+    return (x >>> 2 | x << 30) ^ (x >>> 13 | x << 19) ^ (x >>> 22 | x << 10)
+  }
+  
+  function sigma1 (x) {
+    return (x >>> 6 | x << 26) ^ (x >>> 11 | x << 21) ^ (x >>> 25 | x << 7)
+  }
+  
+  function gamma0 (x) {
+    return (x >>> 7 | x << 25) ^ (x >>> 18 | x << 14) ^ (x >>> 3)
+  }
+  
+  function gamma1 (x) {
+    return (x >>> 17 | x << 15) ^ (x >>> 19 | x << 13) ^ (x >>> 10)
+  }
+  
+  Sha256.prototype._update = function (M) {
+    var W = this._w
+  
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
+    var f = this._f | 0
+    var g = this._g | 0
+    var h = this._h | 0
+  
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+    for (; i < 64; ++i) W[i] = (gamma1(W[i - 2]) + W[i - 7] + gamma0(W[i - 15]) + W[i - 16]) | 0
+  
+    for (var j = 0; j < 64; ++j) {
+      var T1 = (h + sigma1(e) + ch(e, f, g) + K[j] + W[j]) | 0
+      var T2 = (sigma0(a) + maj(a, b, c)) | 0
+  
+      h = g
+      g = f
+      f = e
+      e = (d + T1) | 0
+      d = c
+      c = b
+      b = a
+      a = (T1 + T2) | 0
+    }
+  
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
+    this._f = (f + this._f) | 0
+    this._g = (g + this._g) | 0
+    this._h = (h + this._h) | 0
+  }
+  
+  Sha256.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(32)
+  
+    H.writeInt32BE(this._a, 0)
+    H.writeInt32BE(this._b, 4)
+    H.writeInt32BE(this._c, 8)
+    H.writeInt32BE(this._d, 12)
+    H.writeInt32BE(this._e, 16)
+    H.writeInt32BE(this._f, 20)
+    H.writeInt32BE(this._g, 24)
+    H.writeInt32BE(this._h, 28)
+  
+    return H
+  }
+  
+  module.exports = Sha256
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],47:[function(require,module,exports){
+  var inherits = require('inherits')
+  var SHA512 = require('./sha512')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var W = new Array(160)
+  
+  function Sha384 () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 128, 112)
+  }
+  
+  inherits(Sha384, SHA512)
+  
+  Sha384.prototype.init = function () {
+    this._ah = 0xcbbb9d5d
+    this._bh = 0x629a292a
+    this._ch = 0x9159015a
+    this._dh = 0x152fecd8
+    this._eh = 0x67332667
+    this._fh = 0x8eb44a87
+    this._gh = 0xdb0c2e0d
+    this._hh = 0x47b5481d
+  
+    this._al = 0xc1059ed8
+    this._bl = 0x367cd507
+    this._cl = 0x3070dd17
+    this._dl = 0xf70e5939
+    this._el = 0xffc00b31
+    this._fl = 0x68581511
+    this._gl = 0x64f98fa7
+    this._hl = 0xbefa4fa4
+  
+    return this
+  }
+  
+  Sha384.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(48)
+  
+    function writeInt64BE (h, l, offset) {
+      H.writeInt32BE(h, offset)
+      H.writeInt32BE(l, offset + 4)
+    }
+  
+    writeInt64BE(this._ah, this._al, 0)
+    writeInt64BE(this._bh, this._bl, 8)
+    writeInt64BE(this._ch, this._cl, 16)
+    writeInt64BE(this._dh, this._dl, 24)
+    writeInt64BE(this._eh, this._el, 32)
+    writeInt64BE(this._fh, this._fl, 40)
+  
+    return H
+  }
+  
+  module.exports = Sha384
+  
+  },{"./hash":41,"./sha512":48,"inherits":21,"safe-buffer":40}],48:[function(require,module,exports){
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x428a2f98, 0xd728ae22, 0x71374491, 0x23ef65cd,
+    0xb5c0fbcf, 0xec4d3b2f, 0xe9b5dba5, 0x8189dbbc,
+    0x3956c25b, 0xf348b538, 0x59f111f1, 0xb605d019,
+    0x923f82a4, 0xaf194f9b, 0xab1c5ed5, 0xda6d8118,
+    0xd807aa98, 0xa3030242, 0x12835b01, 0x45706fbe,
+    0x243185be, 0x4ee4b28c, 0x550c7dc3, 0xd5ffb4e2,
+    0x72be5d74, 0xf27b896f, 0x80deb1fe, 0x3b1696b1,
+    0x9bdc06a7, 0x25c71235, 0xc19bf174, 0xcf692694,
+    0xe49b69c1, 0x9ef14ad2, 0xefbe4786, 0x384f25e3,
+    0x0fc19dc6, 0x8b8cd5b5, 0x240ca1cc, 0x77ac9c65,
+    0x2de92c6f, 0x592b0275, 0x4a7484aa, 0x6ea6e483,
+    0x5cb0a9dc, 0xbd41fbd4, 0x76f988da, 0x831153b5,
+    0x983e5152, 0xee66dfab, 0xa831c66d, 0x2db43210,
+    0xb00327c8, 0x98fb213f, 0xbf597fc7, 0xbeef0ee4,
+    0xc6e00bf3, 0x3da88fc2, 0xd5a79147, 0x930aa725,
+    0x06ca6351, 0xe003826f, 0x14292967, 0x0a0e6e70,
+    0x27b70a85, 0x46d22ffc, 0x2e1b2138, 0x5c26c926,
+    0x4d2c6dfc, 0x5ac42aed, 0x53380d13, 0x9d95b3df,
+    0x650a7354, 0x8baf63de, 0x766a0abb, 0x3c77b2a8,
+    0x81c2c92e, 0x47edaee6, 0x92722c85, 0x1482353b,
+    0xa2bfe8a1, 0x4cf10364, 0xa81a664b, 0xbc423001,
+    0xc24b8b70, 0xd0f89791, 0xc76c51a3, 0x0654be30,
+    0xd192e819, 0xd6ef5218, 0xd6990624, 0x5565a910,
+    0xf40e3585, 0x5771202a, 0x106aa070, 0x32bbd1b8,
+    0x19a4c116, 0xb8d2d0c8, 0x1e376c08, 0x5141ab53,
+    0x2748774c, 0xdf8eeb99, 0x34b0bcb5, 0xe19b48a8,
+    0x391c0cb3, 0xc5c95a63, 0x4ed8aa4a, 0xe3418acb,
+    0x5b9cca4f, 0x7763e373, 0x682e6ff3, 0xd6b2b8a3,
+    0x748f82ee, 0x5defb2fc, 0x78a5636f, 0x43172f60,
+    0x84c87814, 0xa1f0ab72, 0x8cc70208, 0x1a6439ec,
+    0x90befffa, 0x23631e28, 0xa4506ceb, 0xde82bde9,
+    0xbef9a3f7, 0xb2c67915, 0xc67178f2, 0xe372532b,
+    0xca273ece, 0xea26619c, 0xd186b8c7, 0x21c0c207,
+    0xeada7dd6, 0xcde0eb1e, 0xf57d4f7f, 0xee6ed178,
+    0x06f067aa, 0x72176fba, 0x0a637dc5, 0xa2c898a6,
+    0x113f9804, 0xbef90dae, 0x1b710b35, 0x131c471b,
+    0x28db77f5, 0x23047d84, 0x32caab7b, 0x40c72493,
+    0x3c9ebe0a, 0x15c9bebc, 0x431d67c4, 0x9c100d4c,
+    0x4cc5d4be, 0xcb3e42b6, 0x597f299c, 0xfc657e2a,
+    0x5fcb6fab, 0x3ad6faec, 0x6c44198c, 0x4a475817
+  ]
+  
+  var W = new Array(160)
+  
+  function Sha512 () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 128, 112)
+  }
+  
+  inherits(Sha512, Hash)
+  
+  Sha512.prototype.init = function () {
+    this._ah = 0x6a09e667
+    this._bh = 0xbb67ae85
+    this._ch = 0x3c6ef372
+    this._dh = 0xa54ff53a
+    this._eh = 0x510e527f
+    this._fh = 0x9b05688c
+    this._gh = 0x1f83d9ab
+    this._hh = 0x5be0cd19
+  
+    this._al = 0xf3bcc908
+    this._bl = 0x84caa73b
+    this._cl = 0xfe94f82b
+    this._dl = 0x5f1d36f1
+    this._el = 0xade682d1
+    this._fl = 0x2b3e6c1f
+    this._gl = 0xfb41bd6b
+    this._hl = 0x137e2179
+  
+    return this
+  }
+  
+  function Ch (x, y, z) {
+    return z ^ (x & (y ^ z))
+  }
+  
+  function maj (x, y, z) {
+    return (x & y) | (z & (x | y))
+  }
+  
+  function sigma0 (x, xl) {
+    return (x >>> 28 | xl << 4) ^ (xl >>> 2 | x << 30) ^ (xl >>> 7 | x << 25)
+  }
+  
+  function sigma1 (x, xl) {
+    return (x >>> 14 | xl << 18) ^ (x >>> 18 | xl << 14) ^ (xl >>> 9 | x << 23)
+  }
+  
+  function Gamma0 (x, xl) {
+    return (x >>> 1 | xl << 31) ^ (x >>> 8 | xl << 24) ^ (x >>> 7)
+  }
+  
+  function Gamma0l (x, xl) {
+    return (x >>> 1 | xl << 31) ^ (x >>> 8 | xl << 24) ^ (x >>> 7 | xl << 25)
+  }
+  
+  function Gamma1 (x, xl) {
+    return (x >>> 19 | xl << 13) ^ (xl >>> 29 | x << 3) ^ (x >>> 6)
+  }
+  
+  function Gamma1l (x, xl) {
+    return (x >>> 19 | xl << 13) ^ (xl >>> 29 | x << 3) ^ (x >>> 6 | xl << 26)
+  }
+  
+  function getCarry (a, b) {
+    return (a >>> 0) < (b >>> 0) ? 1 : 0
+  }
+  
+  Sha512.prototype._update = function (M) {
+    var W = this._w
+  
+    var ah = this._ah | 0
+    var bh = this._bh | 0
+    var ch = this._ch | 0
+    var dh = this._dh | 0
+    var eh = this._eh | 0
+    var fh = this._fh | 0
+    var gh = this._gh | 0
+    var hh = this._hh | 0
+  
+    var al = this._al | 0
+    var bl = this._bl | 0
+    var cl = this._cl | 0
+    var dl = this._dl | 0
+    var el = this._el | 0
+    var fl = this._fl | 0
+    var gl = this._gl | 0
+    var hl = this._hl | 0
+  
+    for (var i = 0; i < 32; i += 2) {
+      W[i] = M.readInt32BE(i * 4)
+      W[i + 1] = M.readInt32BE(i * 4 + 4)
+    }
+    for (; i < 160; i += 2) {
+      var xh = W[i - 15 * 2]
+      var xl = W[i - 15 * 2 + 1]
+      var gamma0 = Gamma0(xh, xl)
+      var gamma0l = Gamma0l(xl, xh)
+  
+      xh = W[i - 2 * 2]
+      xl = W[i - 2 * 2 + 1]
+      var gamma1 = Gamma1(xh, xl)
+      var gamma1l = Gamma1l(xl, xh)
+  
+      // W[i] = gamma0 + W[i - 7] + gamma1 + W[i - 16]
+      var Wi7h = W[i - 7 * 2]
+      var Wi7l = W[i - 7 * 2 + 1]
+  
+      var Wi16h = W[i - 16 * 2]
+      var Wi16l = W[i - 16 * 2 + 1]
+  
+      var Wil = (gamma0l + Wi7l) | 0
+      var Wih = (gamma0 + Wi7h + getCarry(Wil, gamma0l)) | 0
+      Wil = (Wil + gamma1l) | 0
+      Wih = (Wih + gamma1 + getCarry(Wil, gamma1l)) | 0
+      Wil = (Wil + Wi16l) | 0
+      Wih = (Wih + Wi16h + getCarry(Wil, Wi16l)) | 0
+  
+      W[i] = Wih
+      W[i + 1] = Wil
+    }
+  
+    for (var j = 0; j < 160; j += 2) {
+      Wih = W[j]
+      Wil = W[j + 1]
+  
+      var majh = maj(ah, bh, ch)
+      var majl = maj(al, bl, cl)
+  
+      var sigma0h = sigma0(ah, al)
+      var sigma0l = sigma0(al, ah)
+      var sigma1h = sigma1(eh, el)
+      var sigma1l = sigma1(el, eh)
+  
+      // t1 = h + sigma1 + ch + K[j] + W[j]
+      var Kih = K[j]
+      var Kil = K[j + 1]
+  
+      var chh = Ch(eh, fh, gh)
+      var chl = Ch(el, fl, gl)
+  
+      var t1l = (hl + sigma1l) | 0
+      var t1h = (hh + sigma1h + getCarry(t1l, hl)) | 0
+      t1l = (t1l + chl) | 0
+      t1h = (t1h + chh + getCarry(t1l, chl)) | 0
+      t1l = (t1l + Kil) | 0
+      t1h = (t1h + Kih + getCarry(t1l, Kil)) | 0
+      t1l = (t1l + Wil) | 0
+      t1h = (t1h + Wih + getCarry(t1l, Wil)) | 0
+  
+      // t2 = sigma0 + maj
+      var t2l = (sigma0l + majl) | 0
+      var t2h = (sigma0h + majh + getCarry(t2l, sigma0l)) | 0
+  
+      hh = gh
+      hl = gl
+      gh = fh
+      gl = fl
+      fh = eh
+      fl = el
+      el = (dl + t1l) | 0
+      eh = (dh + t1h + getCarry(el, dl)) | 0
+      dh = ch
+      dl = cl
+      ch = bh
+      cl = bl
+      bh = ah
+      bl = al
+      al = (t1l + t2l) | 0
+      ah = (t1h + t2h + getCarry(al, t1l)) | 0
+    }
+  
+    this._al = (this._al + al) | 0
+    this._bl = (this._bl + bl) | 0
+    this._cl = (this._cl + cl) | 0
+    this._dl = (this._dl + dl) | 0
+    this._el = (this._el + el) | 0
+    this._fl = (this._fl + fl) | 0
+    this._gl = (this._gl + gl) | 0
+    this._hl = (this._hl + hl) | 0
+  
+    this._ah = (this._ah + ah + getCarry(this._al, al)) | 0
+    this._bh = (this._bh + bh + getCarry(this._bl, bl)) | 0
+    this._ch = (this._ch + ch + getCarry(this._cl, cl)) | 0
+    this._dh = (this._dh + dh + getCarry(this._dl, dl)) | 0
+    this._eh = (this._eh + eh + getCarry(this._el, el)) | 0
+    this._fh = (this._fh + fh + getCarry(this._fl, fl)) | 0
+    this._gh = (this._gh + gh + getCarry(this._gl, gl)) | 0
+    this._hh = (this._hh + hh + getCarry(this._hl, hl)) | 0
+  }
+  
+  Sha512.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(64)
+  
+    function writeInt64BE (h, l, offset) {
+      H.writeInt32BE(h, offset)
+      H.writeInt32BE(l, offset + 4)
+    }
+  
+    writeInt64BE(this._ah, this._al, 0)
+    writeInt64BE(this._bh, this._bl, 8)
+    writeInt64BE(this._ch, this._cl, 16)
+    writeInt64BE(this._dh, this._dl, 24)
+    writeInt64BE(this._eh, this._el, 32)
+    writeInt64BE(this._fh, this._fl, 40)
+    writeInt64BE(this._gh, this._gl, 48)
+    writeInt64BE(this._hh, this._hl, 56)
+  
+    return H
+  }
+  
+  module.exports = Sha512
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],49:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  module.exports = Stream;
+  
+  var EE = require('events').EventEmitter;
+  var inherits = require('inherits');
+  
+  inherits(Stream, EE);
+  Stream.Readable = require('readable-stream/readable.js');
+  Stream.Writable = require('readable-stream/writable.js');
+  Stream.Duplex = require('readable-stream/duplex.js');
+  Stream.Transform = require('readable-stream/transform.js');
+  Stream.PassThrough = require('readable-stream/passthrough.js');
+  
+  // Backwards-compat with node 0.4.x
+  Stream.Stream = Stream;
+  
+  
+  
+  // old-style streams.  Note that the pipe method (the only relevant
+  // part of this class) is overridden in the Readable class.
+  
+  function Stream() {
+    EE.call(this);
+  }
+  
+  Stream.prototype.pipe = function(dest, options) {
+    var source = this;
+  
+    function ondata(chunk) {
+      if (dest.writable) {
+        if (false === dest.write(chunk) && source.pause) {
+          source.pause();
+        }
+      }
+    }
+  
+    source.on('data', ondata);
+  
+    function ondrain() {
+      if (source.readable && source.resume) {
+        source.resume();
+      }
+    }
+  
+    dest.on('drain', ondrain);
+  
+    // If the 'end' option is not supplied, dest.end() will be called when
+    // source gets the 'end' or 'close' events.  Only dest.end() once.
+    if (!dest._isStdio && (!options || options.end !== false)) {
+      source.on('end', onend);
+      source.on('close', onclose);
+    }
+  
+    var didOnEnd = false;
+    function onend() {
+      if (didOnEnd) return;
+      didOnEnd = true;
+  
+      dest.end();
+    }
+  
+  
+    function onclose() {
+      if (didOnEnd) return;
+      didOnEnd = true;
+  
+      if (typeof dest.destroy === 'function') dest.destroy();
+    }
+  
+    // don't leave dangling pipes when there are errors.
+    function onerror(er) {
+      cleanup();
+      if (EE.listenerCount(this, 'error') === 0) {
+        throw er; // Unhandled stream error in pipe.
+      }
+    }
+  
+    source.on('error', onerror);
+    dest.on('error', onerror);
+  
+    // remove all the event listeners that were added.
+    function cleanup() {
+      source.removeListener('data', ondata);
+      dest.removeListener('drain', ondrain);
+  
+      source.removeListener('end', onend);
+      source.removeListener('close', onclose);
+  
+      source.removeListener('error', onerror);
+      dest.removeListener('error', onerror);
+  
+      source.removeListener('end', cleanup);
+      source.removeListener('close', cleanup);
+  
+      dest.removeListener('close', cleanup);
+    }
+  
+    source.on('end', cleanup);
+    source.on('close', cleanup);
+  
+    dest.on('close', cleanup);
+  
+    dest.emit('pipe', source);
+  
+    // Allow for unix-like usage: A.pipe(B).pipe(C)
+    return dest;
+  };
+  
+  },{"events":18,"inherits":21,"readable-stream/duplex.js":26,"readable-stream/passthrough.js":35,"readable-stream/readable.js":36,"readable-stream/transform.js":37,"readable-stream/writable.js":38}],50:[function(require,module,exports){
+  'use strict';
+  
+  var Buffer = require('safe-buffer').Buffer;
+  
+  var isEncoding = Buffer.isEncoding || function (encoding) {
+    encoding = '' + encoding;
+    switch (encoding && encoding.toLowerCase()) {
+      case 'hex':case 'utf8':case 'utf-8':case 'ascii':case 'binary':case 'base64':case 'ucs2':case 'ucs-2':case 'utf16le':case 'utf-16le':case 'raw':
+        return true;
+      default:
+        return false;
+    }
+  };
+  
+  function _normalizeEncoding(enc) {
+    if (!enc) return 'utf8';
+    var retried;
+    while (true) {
+      switch (enc) {
+        case 'utf8':
+        case 'utf-8':
+          return 'utf8';
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return 'utf16le';
+        case 'latin1':
+        case 'binary':
+          return 'latin1';
+        case 'base64':
+        case 'ascii':
+        case 'hex':
+          return enc;
+        default:
+          if (retried) return; // undefined
+          enc = ('' + enc).toLowerCase();
+          retried = true;
+      }
+    }
+  };
+  
+  // Do not cache `Buffer.isEncoding` when checking encoding names as some
+  // modules monkey-patch it to support additional encodings
+  function normalizeEncoding(enc) {
+    var nenc = _normalizeEncoding(enc);
+    if (typeof nenc !== 'string' && (Buffer.isEncoding === isEncoding || !isEncoding(enc))) throw new Error('Unknown encoding: ' + enc);
+    return nenc || enc;
+  }
+  
+  // StringDecoder provides an interface for efficiently splitting a series of
+  // buffers into a series of JS strings without breaking apart multi-byte
+  // characters.
+  exports.StringDecoder = StringDecoder;
+  function StringDecoder(encoding) {
+    this.encoding = normalizeEncoding(encoding);
+    var nb;
+    switch (this.encoding) {
+      case 'utf16le':
+        this.text = utf16Text;
+        this.end = utf16End;
+        nb = 4;
+        break;
+      case 'utf8':
+        this.fillLast = utf8FillLast;
+        nb = 4;
+        break;
+      case 'base64':
+        this.text = base64Text;
+        this.end = base64End;
+        nb = 3;
+        break;
+      default:
+        this.write = simpleWrite;
+        this.end = simpleEnd;
+        return;
+    }
+    this.lastNeed = 0;
+    this.lastTotal = 0;
+    this.lastChar = Buffer.allocUnsafe(nb);
+  }
+  
+  StringDecoder.prototype.write = function (buf) {
+    if (buf.length === 0) return '';
+    var r;
+    var i;
+    if (this.lastNeed) {
+      r = this.fillLast(buf);
+      if (r === undefined) return '';
+      i = this.lastNeed;
+      this.lastNeed = 0;
+    } else {
+      i = 0;
+    }
+    if (i < buf.length) return r ? r + this.text(buf, i) : this.text(buf, i);
+    return r || '';
+  };
+  
+  StringDecoder.prototype.end = utf8End;
+  
+  // Returns only complete characters in a Buffer
+  StringDecoder.prototype.text = utf8Text;
+  
+  // Attempts to complete a partial non-UTF-8 character using bytes from a Buffer
+  StringDecoder.prototype.fillLast = function (buf) {
+    if (this.lastNeed <= buf.length) {
+      buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, this.lastNeed);
+      return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+    }
+    buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, buf.length);
+    this.lastNeed -= buf.length;
+  };
+  
+  // Checks the type of a UTF-8 byte, whether it's ASCII, a leading byte, or a
+  // continuation byte.
+  function utf8CheckByte(byte) {
+    if (byte <= 0x7F) return 0;else if (byte >> 5 === 0x06) return 2;else if (byte >> 4 === 0x0E) return 3;else if (byte >> 3 === 0x1E) return 4;
+    return -1;
+  }
+  
+  // Checks at most 3 bytes at the end of a Buffer in order to detect an
+  // incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
+  // needed to complete the UTF-8 character (if applicable) are returned.
+  function utf8CheckIncomplete(self, buf, i) {
+    var j = buf.length - 1;
+    if (j < i) return 0;
+    var nb = utf8CheckByte(buf[j]);
+    if (nb >= 0) {
+      if (nb > 0) self.lastNeed = nb - 1;
+      return nb;
+    }
+    if (--j < i) return 0;
+    nb = utf8CheckByte(buf[j]);
+    if (nb >= 0) {
+      if (nb > 0) self.lastNeed = nb - 2;
+      return nb;
+    }
+    if (--j < i) return 0;
+    nb = utf8CheckByte(buf[j]);
+    if (nb >= 0) {
+      if (nb > 0) {
+        if (nb === 2) nb = 0;else self.lastNeed = nb - 3;
+      }
+      return nb;
+    }
+    return 0;
+  }
+  
+  // Validates as many continuation bytes for a multi-byte UTF-8 character as
+  // needed or are available. If we see a non-continuation byte where we expect
+  // one, we "replace" the validated continuation bytes we've seen so far with
+  // UTF-8 replacement characters ('\ufffd'), to match v8's UTF-8 decoding
+  // behavior. The continuation byte check is included three times in the case
+  // where all of the continuation bytes for a character exist in the same buffer.
+  // It is also done this way as a slight performance increase instead of using a
+  // loop.
+  function utf8CheckExtraBytes(self, buf, p) {
+    if ((buf[0] & 0xC0) !== 0x80) {
+      self.lastNeed = 0;
+      return '\ufffd'.repeat(p);
+    }
+    if (self.lastNeed > 1 && buf.length > 1) {
+      if ((buf[1] & 0xC0) !== 0x80) {
+        self.lastNeed = 1;
+        return '\ufffd'.repeat(p + 1);
+      }
+      if (self.lastNeed > 2 && buf.length > 2) {
+        if ((buf[2] & 0xC0) !== 0x80) {
+          self.lastNeed = 2;
+          return '\ufffd'.repeat(p + 2);
+        }
+      }
+    }
+  }
+  
+  // Attempts to complete a multi-byte UTF-8 character using bytes from a Buffer.
+  function utf8FillLast(buf) {
+    var p = this.lastTotal - this.lastNeed;
+    var r = utf8CheckExtraBytes(this, buf, p);
+    if (r !== undefined) return r;
+    if (this.lastNeed <= buf.length) {
+      buf.copy(this.lastChar, p, 0, this.lastNeed);
+      return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+    }
+    buf.copy(this.lastChar, p, 0, buf.length);
+    this.lastNeed -= buf.length;
+  }
+  
+  // Returns all complete UTF-8 characters in a Buffer. If the Buffer ended on a
+  // partial character, the character's bytes are buffered until the required
+  // number of bytes are available.
+  function utf8Text(buf, i) {
+    var total = utf8CheckIncomplete(this, buf, i);
+    if (!this.lastNeed) return buf.toString('utf8', i);
+    this.lastTotal = total;
+    var end = buf.length - (total - this.lastNeed);
+    buf.copy(this.lastChar, 0, end);
+    return buf.toString('utf8', i, end);
+  }
+  
+  // For UTF-8, a replacement character for each buffered byte of a (partial)
+  // character needs to be added to the output.
+  function utf8End(buf) {
+    var r = buf && buf.length ? this.write(buf) : '';
+    if (this.lastNeed) return r + '\ufffd'.repeat(this.lastTotal - this.lastNeed);
+    return r;
+  }
+  
+  // UTF-16LE typically needs two bytes per character, but even if we have an even
+  // number of bytes available, we need to check if we end on a leading/high
+  // surrogate. In that case, we need to wait for the next two bytes in order to
+  // decode the last character properly.
+  function utf16Text(buf, i) {
+    if ((buf.length - i) % 2 === 0) {
+      var r = buf.toString('utf16le', i);
+      if (r) {
+        var c = r.charCodeAt(r.length - 1);
+        if (c >= 0xD800 && c <= 0xDBFF) {
+          this.lastNeed = 2;
+          this.lastTotal = 4;
+          this.lastChar[0] = buf[buf.length - 2];
+          this.lastChar[1] = buf[buf.length - 1];
+          return r.slice(0, -1);
+        }
+      }
+      return r;
+    }
+    this.lastNeed = 1;
+    this.lastTotal = 2;
+    this.lastChar[0] = buf[buf.length - 1];
+    return buf.toString('utf16le', i, buf.length - 1);
+  }
+  
+  // For UTF-16LE we do not explicitly append special replacement characters if we
+  // end on a partial character, we simply let v8 handle that.
+  function utf16End(buf) {
+    var r = buf && buf.length ? this.write(buf) : '';
+    if (this.lastNeed) {
+      var end = this.lastTotal - this.lastNeed;
+      return r + this.lastChar.toString('utf16le', 0, end);
+    }
+    return r;
+  }
+  
+  function base64Text(buf, i) {
+    var n = (buf.length - i) % 3;
+    if (n === 0) return buf.toString('base64', i);
+    this.lastNeed = 3 - n;
+    this.lastTotal = 3;
+    if (n === 1) {
+      this.lastChar[0] = buf[buf.length - 1];
+    } else {
+      this.lastChar[0] = buf[buf.length - 2];
+      this.lastChar[1] = buf[buf.length - 1];
+    }
+    return buf.toString('base64', i, buf.length - n);
+  }
+  
+  function base64End(buf) {
+    var r = buf && buf.length ? this.write(buf) : '';
+    if (this.lastNeed) return r + this.lastChar.toString('base64', 0, 3 - this.lastNeed);
+    return r;
+  }
+  
+  // Pass bytes on through for single-byte encodings (e.g. ascii, latin1, hex)
+  function simpleWrite(buf) {
+    return buf.toString(this.encoding);
+  }
+  
+  function simpleEnd(buf) {
+    return buf && buf.length ? this.write(buf) : '';
+  }
+  },{"safe-buffer":40}],51:[function(require,module,exports){
+  (function (global){
+  
+  /**
+   * Module exports.
+   */
+  
+  module.exports = deprecate;
+  
+  /**
+   * Mark that a method should not be used.
+   * Returns a modified function which warns once by default.
+   *
+   * If `localStorage.noDeprecation = true` is set, then it is a no-op.
+   *
+   * If `localStorage.throwDeprecation = true` is set, then deprecated functions
+   * will throw an Error when invoked.
+   *
+   * If `localStorage.traceDeprecation = true` is set, then deprecated functions
+   * will invoke `console.trace()` instead of `console.error()`.
+   *
+   * @param {Function} fn - the function to deprecate
+   * @param {String} msg - the string to print to the console when `fn` is invoked
+   * @returns {Function} a new "deprecated" version of `fn`
+   * @api public
+   */
+  
+  function deprecate (fn, msg) {
+    if (config('noDeprecation')) {
+      return fn;
+    }
+  
+    var warned = false;
+    function deprecated() {
+      if (!warned) {
+        if (config('throwDeprecation')) {
+          throw new Error(msg);
+        } else if (config('traceDeprecation')) {
+          console.trace(msg);
+        } else {
+          console.warn(msg);
+        }
+        warned = true;
+      }
+      return fn.apply(this, arguments);
+    }
+  
+    return deprecated;
+  }
+  
+  /**
+   * Checks `localStorage` for boolean values for the given `name`.
+   *
+   * @param {String} name
+   * @returns {Boolean}
+   * @api private
+   */
+  
+  function config (name) {
+    // accessing global.localStorage can trigger a DOMException in sandboxed iframes
+    try {
+      if (!global.localStorage) return false;
+    } catch (_) {
+      return false;
+    }
+    var val = global.localStorage[name];
+    if (null == val) return false;
+    return String(val).toLowerCase() === 'true';
+  }
+  
+  }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+  },{}],52:[function(require,module,exports){
+  (function (Buffer){
+  /***
+   * @license
+   * https://github.com/bitcoincashjs/bchaddr
+   * Copyright (c) 2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  var bs58check = require('bs58check')
+  var cashaddr = require('cashaddrjs')
+  
+  /**
+   * General purpose Bitcoin Cash address detection and translation.<br />
+   * Supports all major Bitcoin Cash address formats.<br />
+   * Currently:
+   * <ul>
+   *    <li> Legacy format </li>
+   *    <li> Bitpay format </li>
+   *    <li> Cashaddr format </li>
+   * </ul>
+   * @module bchaddr
+   */
+  
+  /**
+   * @static
+   * Supported Bitcoin Cash address formats.
+   */
+  var Format = {}
+  Format.Legacy = 'legacy'
+  Format.Bitpay = 'bitpay'
+  Format.Cashaddr = 'cashaddr'
+  
+  /**
+   * @static
+   * Supported networks.
+   */
+  var Network = {}
+  Network.Mainnet = 'mainnet'
+  Network.Testnet = 'testnet'
+  
+  /**
+   * @static
+   * Supported address types.
+   */
+  var Type = {}
+  Type.P2PKH = 'p2pkh'
+  Type.P2SH = 'p2sh'
+  
+  /**
+   * Detects what is the given address' format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function detectAddressFormat (address) {
+    return decodeAddress(address).format
+  }
+  
+  /**
+   * Detects what is the given address' network.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function detectAddressNetwork (address) {
+    return decodeAddress(address).network
+  }
+  
+  /**
+   * Detects what is the given address' type.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function detectAddressType (address) {
+    return decodeAddress(address).type
+  }
+  
+  /**
+   * Translates the given address into legacy format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function toLegacyAddress (address) {
+    var decoded = decodeAddress(address)
+    if (decoded.format === Format.Legacy) {
+      return address
+    }
+    return encodeAsLegacy(decoded)
+  }
+  
+  /**
+   * Translates the given address into bitpay format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function toBitpayAddress (address) {
+    var decoded = decodeAddress(address)
+    if (decoded.format === Format.Bitpay) {
+      return address
+    }
+    return encodeAsBitpay(decoded)
+  }
+  
+  /**
+   * Translates the given address into cashaddr format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function toCashAddress (address) {
+    var decoded = decodeAddress(address)
+    if (decoded.format === Format.Cashaddr) {
+      return address
+    }
+    return encodeAsCashaddr(decoded)
+  }
+  
+  /**
+   * Version byte table for base58 formats.
+   * @private
+   */
+  var VERSION_BYTE = {}
+  VERSION_BYTE[Format.Legacy] = {}
+  VERSION_BYTE[Format.Legacy][Network.Mainnet] = {}
+  VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2PKH] = 0
+  VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2SH] = 5
+  VERSION_BYTE[Format.Legacy][Network.Testnet] = {}
+  VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2PKH] = 111
+  VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2SH] = 196
+  VERSION_BYTE[Format.Bitpay] = {}
+  VERSION_BYTE[Format.Bitpay][Network.Mainnet] = {}
+  VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2PKH] = 28
+  VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2SH] = 40
+  VERSION_BYTE[Format.Bitpay][Network.Testnet] = {}
+  VERSION_BYTE[Format.Bitpay][Network.Testnet][Type.P2PKH] = 111
+  VERSION_BYTE[Format.Bitpay][Network.Testnet][Type.P2SH] = 196
+  
+  /**
+   * Decodes the given address into its constituting hash, format, network and type.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeAddress (address) {
+    try {
+      return decodeBase58Address(address)
+    } catch (error) {
+    }
+    try {
+      return decodeCashAddress(address)
+    } catch (error) {
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Attempts to decode the given address assuming it is a base58 address.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeBase58Address (address) {
+    try {
+      var payload = bs58check.decode(address)
+      var versionByte = payload[0]
+      var hash = Array.prototype.slice.call(payload, 1)
+      switch (versionByte) {
+        case VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2PKH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Mainnet,
+            type: Type.P2PKH
+          }
+        case VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2SH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Mainnet,
+            type: Type.P2SH
+          }
+        case VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2PKH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Testnet,
+            type: Type.P2PKH
+          }
+        case VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2SH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Testnet,
+            type: Type.P2SH
+          }
+        case VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2PKH]:
+          return {
+            hash: hash,
+            format: Format.Bitpay,
+            network: Network.Mainnet,
+            type: Type.P2PKH
+          }
+        case VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2SH]:
+          return {
+            hash: hash,
+            format: Format.Bitpay,
+            network: Network.Mainnet,
+            type: Type.P2SH
+          }
+      }
+    } catch (error) {
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Attempts to decode the given address assuming it is a cashaddr address.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeCashAddress (address) {
+    if (address.indexOf(':') !== -1) {
+      try {
+        return decodeCashAddressWithPrefix(address)
+      } catch (error) {
+      }
+    } else {
+      var prefixes = ['bitcoincash', 'bchtest', 'regtest']
+      for (var i = 0; i < prefixes.length; ++i) {
+        try {
+          var prefix = prefixes[i]
+          return decodeCashAddressWithPrefix(prefix + ':' + address)
+        } catch (error) {
+        }
+      }
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Attempts to decode the given address assuming it is a cashaddr address with explicit prefix.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeCashAddressWithPrefix (address) {
+    try {
+      var decoded = cashaddr.decode(address)
+      var hash = Array.prototype.slice.call(decoded.hash, 0)
+      var type = decoded.type === 'P2PKH' ? Type.P2PKH : Type.P2SH
+      switch (decoded.prefix) {
+        case 'bitcoincash':
+          return {
+            hash: hash,
+            format: Format.Cashaddr,
+            network: Network.Mainnet,
+            type: type
+          }
+        case 'bchtest':
+        case 'regtest':
+          return {
+            hash: hash,
+            format: Format.Cashaddr,
+            network: Network.Testnet,
+            type: type
+          }
+      }
+    } catch (error) {
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Encodes the given decoded address into legacy format.
+   * @private
+   * @param {object} decoded
+   * @returns {string}
+   */
+  function encodeAsLegacy (decoded) {
+    var versionByte = VERSION_BYTE[Format.Legacy][decoded.network][decoded.type]
+    var buffer = Buffer.alloc(1 + decoded.hash.length)
+    buffer[0] = versionByte
+    buffer.set(decoded.hash, 1)
+    return bs58check.encode(buffer)
+  }
+  
+  /**
+   * Encodes the given decoded address into bitpay format.
+   * @private
+   * @param {object} decoded
+   * @returns {string}
+   */
+  function encodeAsBitpay (decoded) {
+    var versionByte = VERSION_BYTE[Format.Bitpay][decoded.network][decoded.type]
+    var buffer = Buffer.alloc(1 + decoded.hash.length)
+    buffer[0] = versionByte
+    buffer.set(decoded.hash, 1)
+    return bs58check.encode(buffer)
+  }
+  
+  /**
+   * Encodes the given decoded address into cashaddr format.
+   * @private
+   * @param {object} decoded
+   * @returns {string}
+   */
+  function encodeAsCashaddr (decoded) {
+    var prefix = decoded.network === Network.Mainnet ? 'bitcoincash' : 'bchtest'
+    var type = decoded.type === Type.P2PKH ? 'P2PKH' : 'P2SH'
+    var hash = Uint8Array.from(decoded.hash)
+    return cashaddr.encode(prefix, type, hash)
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is in legacy format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isLegacyAddress (address) {
+    return detectAddressFormat(address) === Format.Legacy
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is in bitpay format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isBitpayAddress (address) {
+    return detectAddressFormat(address) === Format.Bitpay
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is in cashaddr format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isCashAddress (address) {
+    return detectAddressFormat(address) === Format.Cashaddr
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a mainnet address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isMainnetAddress (address) {
+    return detectAddressNetwork(address) === Network.Mainnet
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a testnet address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isTestnetAddress (address) {
+    return detectAddressNetwork(address) === Network.Testnet
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a p2pkh address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isP2PKHAddress (address) {
+    return detectAddressType(address) === Type.P2PKH
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a p2sh address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isP2SHAddress (address) {
+    return detectAddressType(address) === Type.P2SH
+  }
+  
+  /**
+   * Error thrown when the address given as input is not a valid Bitcoin Cash address.
+   * @constructor
+   * InvalidAddressError
+   */
+  function InvalidAddressError () {
+    var error = new Error()
+    this.name = error.name = 'InvalidAddressError'
+    this.message = error.message = 'Received an invalid Bitcoin Cash address as input.'
+    this.stack = error.stack
+  }
+  
+  InvalidAddressError.prototype = Object.create(Error.prototype)
+  
+  module.exports = {
+    Format: Format,
+    Network: Network,
+    Type: Type,
+    detectAddressFormat: detectAddressFormat,
+    detectAddressNetwork: detectAddressNetwork,
+    detectAddressType: detectAddressType,
+    toLegacyAddress: toLegacyAddress,
+    toBitpayAddress: toBitpayAddress,
+    toCashAddress: toCashAddress,
+    isLegacyAddress: isLegacyAddress,
+    isBitpayAddress: isBitpayAddress,
+    isCashAddress: isCashAddress,
+    isMainnetAddress: isMainnetAddress,
+    isTestnetAddress: isTestnetAddress,
+    isP2PKHAddress: isP2PKHAddress,
+    isP2SHAddress: isP2SHAddress,
+    InvalidAddressError: InvalidAddressError
+  }
+  
+  }).call(this,require("buffer").Buffer)
+  },{"bs58check":7,"buffer":8,"cashaddrjs":10}]},{},[52])(52)
+  });	
+	</script>
+	<script type="text/javascript">
 /*!
 * Crypto-JS v2.5.4	Crypto.js
 * http://code.google.com/p/crypto-js/
@@ -6366,7 +15699,8 @@ a { position: relative; z-index: 20; }
 .right { text-align: right; }
 .walletarea, #paperarea { display: none; }
 hr { margin: 20px 0; border-top: 2px dashed #008000; }
-.keyarea { height: 110px; text-align: left; position: relative; padding: 5px; }
+#paperkeyarea .keyarea { height: 110px; }
+.keyarea { text-align: left; position: relative; padding: 5px; }
 .keyarea .public { float: left; }
 .keyarea .pubaddress { display: inline-block; height: 40px; padding: 0 0 0 10px; float: left; }
 .keyarea .privwif { margin: 0;  float: right; text-align: right; padding: 0 20px 0 0; position: relative; }
@@ -6394,7 +15728,6 @@ input[type=checkbox] { position: relative; z-index: 20; }
 #generate { font-family: monospace; font-size: 1.25em; height: 305px; text-align: left; position: relative; padding: 20px 10px; clear: both; }
 #generate span { padding: 5px 5px 0 5px; }
 #generatekeyinput { position: relative; z-index: 20; display: block; width: 620px; margin-top: 5px; }
-#keyarea { height: 250px; }
 #keyarea .pubaddress { float: none; display: block; padding: 0; height: auto; }
 #keyarea .label { text-decoration: none; }
 #keyarea .privwif { float: none; text-align: right; position: relative; padding: 0; }
@@ -6420,7 +15753,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
                                         padding: 5px 5px 2px 5px; }
 #paperarea .artwallet .btcaddress  
 {
-    position: absolute; top: 240px; left: 139px; z-index: 100; font-size: 10px; background-color: transparent;
+    position: absolute; top: 225px; left: 142px; z-index: 100; font-size: 8px; background-color: transparent;
     font-weight:bold; color: #000000; margin: 0;
         -webkit-transform-origin:top left; -webkit-transform:rotate(-90deg);
         -moz-transform-origin:top left;    -moz-transform:rotate(-90deg);
@@ -6450,7 +15783,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 }
 #bulkarea .body { padding: 5px 0 0 0; }
 #bulkarea .format { font-style: italic; font-size: 90%; }
-#bulktextarea { font-size: 90%; width: 98%; margin: 4px 0 0 0; }
+#bulktextarea { font-size: 85%; width: 98%; margin: 4px 0 0 0; }
 #detailkeyarea { padding: 10px; }
 #detailarea { margin: 0; text-align: left; }
 #detailarea .notes { text-align: left; font-size: 80%; padding: 0 0 20px 0; }
@@ -6567,7 +15900,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 
     .footer { font-size: 90%; clear: both; padding: 10px 0 10px 0; margin: 0; border-top: 2px solid #4cca47; }
     .footer div span.item { padding: 10px; }
-    .footer .authorbtc { float: left; width: 450px; }
+    .footer .authorbtc { float: left; width: 500px; }
     .footer .authorbtc span.item { text-align: left; display: block; padding: 0 20px; }
     .footer .authorbtc div { position: relative; z-index: 100; }
     .footer .github { position: relative; }
@@ -6980,7 +16313,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 						<span class="statusicon" id="statusunittests" onclick="ninja.status.showUnitTests();">...</span>
 						<span class="statusicon" id="statuskeypool" onclick="ninja.status.showKeyPool();">&#8803;</span>
 					</span>
-					<span class="item"><span id="footerlabeldonations">Bitcoin Cash Donations for hosting (Do not send BTC):</span> 1AqBBnvDqhaXvzaLnZxSwxBVQ7JnEMBihS</span>
+					<span class="item"><span id="footerlabeldonations">Bitcoin Cash Donations:</span> bitcoincash:qp4atx0z6h6atuzchuaqssnkdqag95ecdqtt5nx8z8</span>
 					<span class="item" id="footerlabeltranslatedby"></span>
 				</div>
 			</div>
@@ -7529,7 +16862,9 @@ ninja.publicKey = {
 			for (var key in keyValuePair) {
 				var value = keyValuePair[key];
 				origValueSize = value.length;
-				value = ninja.qrCode.scheme() + value;
+				if (!value.startsWith(ninja.qrCode.scheme())) {
+					value = ninja.qrCode.scheme() + value;
+				}
 				valueSize = value.length;
 				adjustment = 0;
 				// Tweak adjustment for addresses and regular
@@ -7538,6 +16873,8 @@ ninja.publicKey = {
 					adjustment = 0.065;
 				} else if (value.length == 64) {
 					adjustment = 0.1;
+				} else if (valueSize == 54) {
+					adjustment = -0.2;
 				}
 				multiplier = sizeMultiplier * ((origValueSize/valueSize) + adjustment);
 				try {
@@ -7755,7 +17092,7 @@ ninja.foreachSerialized = function (collection, whatToDo, onComplete) {
 			"en": {
 				// javascript alerts or messages
 				"testneteditionactivated": "TESTNET EDITION ACTIVATED",
-				"paperlabelbitcoinaddress": "Bitcoin Address:",
+				"paperlabelbitcoinaddress": "Bitcoin Cash Address:",
 				"paperlabelprivatekey": "Private Key:",
 				"paperlabelencryptedkey": "Encrypted Private Key (Password required)",
 				"bulkgeneratingaddresses": "Generating addresses... ",
@@ -8185,7 +17522,7 @@ ninja.foreachSerialized = function (collection, whatToDo, onComplete) {
 
 		// footer html
 		"footerlabeldonations": "Δωρεές:",
-		"footerlabeltranslatedby": "Μετάφραση: <a href='http://BitcoinX.gr/'><b>BitcoinX.gr</b></a>BTC 1BitcoiNxkUPcTFxwMqxhRiPEiQRzYskf6",
+		"footerlabeltranslatedby": "Μετάφραση: <a href='http://BitcoinX.gr/'><b>BitcoinX.gr</b></a> BTC 1BitcoiNxkUPcTFxwMqxhRiPEiQRzYskf6",
 		"footerlabelpgp": "PGP",
 		"footerlabelversion": "ιστορικό εκδόσεων",
 		"footerlabelgithub": "Αποθετήριο GitHub",
@@ -8340,7 +17677,7 @@ ninja.foreachSerialized = function (collection, whatToDo, onComplete) {
 
 		// footer html
 		"footerlabeldonations": "Donaciones:",
-		"footerlabeltranslatedby": "Traducción: <b>Francisco Salvado</b> 34asTQaYjY1wViisS7ydueY3Kx3Cw5dVLW",
+		"footerlabeltranslatedby": "Traducción: <b>Francisco Salvado</b> bitcoincash:pq0ma5q7rtmyty47qr5s54hys0uqu472nu37ge98q9",
 		"footerlabelpgp": "PGP",
 		"footerlabelversion": "Histórico de versiones",
 		"footerlabelgithub": "Repositorio GitHub",
@@ -8497,7 +17834,7 @@ ninja.foreachSerialized = function (collection, whatToDo, onComplete) {
 
 		// footer html
 		"footerlabeldonations": "Don:",
-		"footerlabeltranslatedby": "Traduction: <b>checksum0</b> 1EsQy5Ry8guF6BuUgWCgBCQt11PCQhXqHA",
+		"footerlabeltranslatedby": "Traduction: <b>checksum0</b> bitcoincash:qzvzyuy4kshwfqcuavcmrx00s04uze2dgvj3gh0qhl",
 		"footerlabelpgp": "PGP",
 		"footerlabelversion": "Historique des versions",
 		"footerlabelgithub": "Dépôt Github",
@@ -9574,7 +18911,7 @@ ninja.foreachSerialized = function (collection, whatToDo, onComplete) {
 			try {
 				var key = new Bitcoin.ECKey(false);
 				key.setCompressed(true);
-				var bitcoinAddress = key.getBitcoinAddress();
+				var bitcoinAddress = bchaddr.toCashAddress(key.getBitcoinAddress());
 				var privateKeyWif = key.getBitcoinWalletImportFormat();
 				document.getElementById("btcaddress").innerHTML = bitcoinAddress;
 				document.getElementById("btcprivwif").innerHTML = privateKeyWif;
@@ -9703,10 +19040,10 @@ ninja.wallets.paperwallet = {
 			ninja.privateKey.BIP38GenerateECAddressAsync(ninja.wallets.paperwallet.intermediatePoint, compressed, function (address, encryptedKey) {
 				Bitcoin.KeyPool.push(new Bitcoin.Bip38Key(address, encryptedKey));
 				if (ninja.wallets.paperwallet.useArtisticWallet) {
-					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, address, encryptedKey);
+					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
 				}
 				else {
-					ninja.wallets.paperwallet.showWallet(idPostFix, address, encryptedKey);
+					ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
 				}
 			});
 		}
@@ -9716,10 +19053,10 @@ ninja.wallets.paperwallet = {
 			var bitcoinAddress = key.getBitcoinAddress();
 			var privateKeyWif = key.getBitcoinWalletImportFormat();
 			if (ninja.wallets.paperwallet.useArtisticWallet) {
-				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bitcoinAddress, privateKeyWif);
+				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);
 			}
 			else {
-				ninja.wallets.paperwallet.showWallet(idPostFix, bitcoinAddress, privateKeyWif);
+				ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);
 			}
 		}
 	},
@@ -9782,10 +19119,10 @@ ninja.wallets.paperwallet = {
 
 	showArtisticWallet: function (idPostFix, bitcoinAddress, privateKey) {
 		var keyValuePair = {};
-		keyValuePair["qrcode_public" + idPostFix] = bitcoinAddress;
+		keyValuePair["qrcode_public" + idPostFix] = bchaddr.toCashAddress(bitcoinAddress);
 		keyValuePair["qrcode_private" + idPostFix] = privateKey;
 		ninja.qrCode.showQrCode(keyValuePair, 2.5);
-		document.getElementById("btcaddress" + idPostFix).innerHTML = bitcoinAddress;
+		document.getElementById("btcaddress" + idPostFix).innerHTML = bchaddr.toCashAddress(bitcoinAddress).replace(/^bitcoincash:/, '');
 
 		if (ninja.wallets.paperwallet.encrypt) {
 			var half = privateKey.length / 2;
@@ -9827,7 +19164,7 @@ ninja.wallets.paperwallet = {
 		var limit;
 		var limitperpage;
 
-		document.getElementById("paperkeyarea").style.fontSize = "100%";
+		document.getElementById("paperkeyarea").style.fontSize = "95%";
 		if (!hideArt.checked) {
 			limit = ninja.wallets.paperwallet.pageBreakAtArtisticDefault;
 			limitperpage = ninja.wallets.paperwallet.pageBreakAtArtisticDefault;
@@ -9912,7 +19249,7 @@ ninja.wallets.paperwallet = {
 						Bitcoin.KeyPool.push(new Bitcoin.Bip38Key(address, encryptedKey));
 
 						bulk.csv.push((bulk.csvRowLimit - bulk.csvRowsRemaining + bulk.csvStartIndex)
-										+ ",\"" + address + "\",\"" + encryptedKey
+										+ ",\"" + bchaddr.toCashAddress(address) + "\",\"" + encryptedKey
 										+ "\"");
 						document.getElementById("bulktextarea").value = translator.get("bulkgeneratingaddresses") + bulk.csvRowsRemaining;
 
@@ -9925,7 +19262,7 @@ ninja.wallets.paperwallet = {
 					var key = new Bitcoin.ECKey(false);
 					key.setCompressed(bulk.compressedAddrs);
 					bulk.csv.push((bulk.csvRowLimit - bulk.csvRowsRemaining + bulk.csvStartIndex)
-										+ ",\"" + key.getBitcoinAddress() + "\",\"" + key.toString("wif")
+										+ ",\"" + bchaddr.toCashAddress(key.getBitcoinAddress()) + "\",\"" + key.toString("wif")
 										//+	"\",\"" + key.toString("wifcomp")    // uncomment these lines to add different private key formats to the CSV
 										//+ "\",\"" + key.getBitcoinHexFormat() 
 										//+ "\",\"" + key.toString("base64") 
@@ -10241,13 +19578,13 @@ ninja.wallets.vanitywallet = {
 				btcKey.setCompressed(false);
 				document.getElementById("detailprivhex").innerHTML = btcKey.toString().toUpperCase();
 				document.getElementById("detailprivb64").innerHTML = btcKey.toString("base64");
-				var bitcoinAddress = btcKey.getBitcoinAddress();
+				var bitcoinAddress = bchaddr.toCashAddress(btcKey.getBitcoinAddress());
 				var wif = btcKey.getBitcoinWalletImportFormat();
 				document.getElementById("detailpubkey").innerHTML = btcKey.getPubKeyHex();
 				document.getElementById("detailaddress").innerHTML = bitcoinAddress;
 				document.getElementById("detailprivwif").innerHTML = wif;
 				btcKey.setCompressed(true);
-				var bitcoinAddressComp = btcKey.getBitcoinAddress();
+				var bitcoinAddressComp = bchaddr.toCashAddress(btcKey.getBitcoinAddress());
 				var wifComp = btcKey.getBitcoinWalletImportFormat();			
 				document.getElementById("detailpubkeycomp").innerHTML = btcKey.getPubKeyHex();
 				document.getElementById("detailaddresscomp").innerHTML = bitcoinAddressComp;
@@ -10405,8 +19742,8 @@ ninja.wallets.splitwallet = {
 			var output = document.createElement("div");
 			output.setAttribute("id", "splitoutput");
 			var m = {};
-			output.appendChild(this.mkOutputRow(bitcoinAddress, "split_addr", "Bitcoin Address:    "));
-			m["split_addr"] = bitcoinAddress;
+			output.appendChild(this.mkOutputRow(bchaddr.toCashAddress(bitcoinAddress), "split_addr", "Bitcoin Cash Address:    "));
+			m["split_addr"] = bchaddr.toCashAddress(bitcoinAddress);
 
 			for (var i = 0; i < shares.length; i++) {
 				var id = "split_qr_" + i;
@@ -10415,7 +19752,7 @@ ninja.wallets.splitwallet = {
 			}
 
 			document.getElementById("splitstep1area").innerHTML = output.innerHTML;
-			ninja.qrCode.showQrCode(m);
+			ninja.qrCode.showQrCode(m, 4);
 
 			document.getElementById("splitstep1area").style.display = "block";
 			document.getElementById("splitstep1icon").setAttribute("class", "less");

--- a/cashaddress.org.html
+++ b/cashaddress.org.html
@@ -16869,7 +16869,7 @@ ninja.publicKey = {
 			for (var key in keyValuePair) {
 				var value = keyValuePair[key];
 				origValueSize = value.length;
-				if (!value.startsWith(ninja.qrCode.scheme())) {
+				if (!value.startsWith(ninja.qrCode.scheme()) && (key.match(/addr/) || key.match(/public/))) {
 					value = ninja.qrCode.scheme() + value;
 				}
 				valueSize = value.length;

--- a/cashaddress.org.html
+++ b/cashaddress.org.html
@@ -19040,7 +19040,7 @@ ninja.wallets.paperwallet = {
 			ninja.privateKey.BIP38GenerateECAddressAsync(ninja.wallets.paperwallet.intermediatePoint, compressed, function (address, encryptedKey) {
 				Bitcoin.KeyPool.push(new Bitcoin.Bip38Key(address, encryptedKey));
 				if (ninja.wallets.paperwallet.useArtisticWallet) {
-					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
+					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, address, encryptedKey);
 				}
 				else {
 					ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
@@ -19053,7 +19053,7 @@ ninja.wallets.paperwallet = {
 			var bitcoinAddress = key.getBitcoinAddress();
 			var privateKeyWif = key.getBitcoinWalletImportFormat();
 			if (ninja.wallets.paperwallet.useArtisticWallet) {
-				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);
+				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bitcoinAddress, privateKeyWif);
 			}
 			else {
 				ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);

--- a/cashaddress.org.html
+++ b/cashaddress.org.html
@@ -50,6 +50,13 @@
 	<meta charset="utf-8">
 
 	<script type="text/javascript">
+/**
+ * @license
+ * https://github.com/bitcoincashjs/bchaddr
+ * Copyright (c) 2018 Emilio Almansi
+ * Distributed under the MIT software license, see the accompanying
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+ */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.bchaddr = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
   // base-x encoding
   // Forked from https://github.com/cryptocoinjs/bs58

--- a/src/bchaddr.js
+++ b/src/bchaddr.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * https://github.com/bitcoincashjs/bchaddr
+ * Copyright (c) 2018 Emilio Almansi
+ * Distributed under the MIT software license, see the accompanying
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+ */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.bchaddr = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
   // base-x encoding
   // Forked from https://github.com/cryptocoinjs/bs58

--- a/src/bchaddr.js
+++ b/src/bchaddr.js
@@ -1,0 +1,9331 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.bchaddr = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+  // base-x encoding
+  // Forked from https://github.com/cryptocoinjs/bs58
+  // Originally written by Mike Hearn for BitcoinJ
+  // Copyright (c) 2011 Google Inc
+  // Ported to JavaScript by Stefan Thomas
+  // Merged Buffer refactorings from base58-native by Stephen Pair
+  // Copyright (c) 2013 BitPay Inc
+  
+  var Buffer = require('safe-buffer').Buffer
+  
+  module.exports = function base (ALPHABET) {
+    var ALPHABET_MAP = {}
+    var BASE = ALPHABET.length
+    var LEADER = ALPHABET.charAt(0)
+  
+    // pre-compute lookup table
+    for (var z = 0; z < ALPHABET.length; z++) {
+      var x = ALPHABET.charAt(z)
+  
+      if (ALPHABET_MAP[x] !== undefined) throw new TypeError(x + ' is ambiguous')
+      ALPHABET_MAP[x] = z
+    }
+  
+    function encode (source) {
+      if (source.length === 0) return ''
+  
+      var digits = [0]
+      for (var i = 0; i < source.length; ++i) {
+        for (var j = 0, carry = source[i]; j < digits.length; ++j) {
+          carry += digits[j] << 8
+          digits[j] = carry % BASE
+          carry = (carry / BASE) | 0
+        }
+  
+        while (carry > 0) {
+          digits.push(carry % BASE)
+          carry = (carry / BASE) | 0
+        }
+      }
+  
+      var string = ''
+  
+      // deal with leading zeros
+      for (var k = 0; source[k] === 0 && k < source.length - 1; ++k) string += LEADER
+      // convert digits to a string
+      for (var q = digits.length - 1; q >= 0; --q) string += ALPHABET[digits[q]]
+  
+      return string
+    }
+  
+    function decodeUnsafe (string) {
+      if (typeof string !== 'string') throw new TypeError('Expected String')
+      if (string.length === 0) return Buffer.allocUnsafe(0)
+  
+      var bytes = [0]
+      for (var i = 0; i < string.length; i++) {
+        var value = ALPHABET_MAP[string[i]]
+        if (value === undefined) return
+  
+        for (var j = 0, carry = value; j < bytes.length; ++j) {
+          carry += bytes[j] * BASE
+          bytes[j] = carry & 0xff
+          carry >>= 8
+        }
+  
+        while (carry > 0) {
+          bytes.push(carry & 0xff)
+          carry >>= 8
+        }
+      }
+  
+      // deal with leading zeros
+      for (var k = 0; string[k] === LEADER && k < string.length - 1; ++k) {
+        bytes.push(0)
+      }
+  
+      return Buffer.from(bytes.reverse())
+    }
+  
+    function decode (string) {
+      var buffer = decodeUnsafe(string)
+      if (buffer) return buffer
+  
+      throw new Error('Non-base' + BASE + ' character')
+    }
+  
+    return {
+      encode: encode,
+      decodeUnsafe: decodeUnsafe,
+      decode: decode
+    }
+  }
+  
+  },{"safe-buffer":40}],2:[function(require,module,exports){
+  'use strict'
+  
+  exports.byteLength = byteLength
+  exports.toByteArray = toByteArray
+  exports.fromByteArray = fromByteArray
+  
+  var lookup = []
+  var revLookup = []
+  var Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array
+  
+  var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  for (var i = 0, len = code.length; i < len; ++i) {
+    lookup[i] = code[i]
+    revLookup[code.charCodeAt(i)] = i
+  }
+  
+  revLookup['-'.charCodeAt(0)] = 62
+  revLookup['_'.charCodeAt(0)] = 63
+  
+  function placeHoldersCount (b64) {
+    var len = b64.length
+    if (len % 4 > 0) {
+      throw new Error('Invalid string. Length must be a multiple of 4')
+    }
+  
+    // the number of equal signs (place holders)
+    // if there are two placeholders, than the two characters before it
+    // represent one byte
+    // if there is only one, then the three characters before it represent 2 bytes
+    // this is just a cheap hack to not do indexOf twice
+    return b64[len - 2] === '=' ? 2 : b64[len - 1] === '=' ? 1 : 0
+  }
+  
+  function byteLength (b64) {
+    // base64 is 4/3 + up to two characters of the original data
+    return (b64.length * 3 / 4) - placeHoldersCount(b64)
+  }
+  
+  function toByteArray (b64) {
+    var i, l, tmp, placeHolders, arr
+    var len = b64.length
+    placeHolders = placeHoldersCount(b64)
+  
+    arr = new Arr((len * 3 / 4) - placeHolders)
+  
+    // if there are placeholders, only get up to the last complete 4 chars
+    l = placeHolders > 0 ? len - 4 : len
+  
+    var L = 0
+  
+    for (i = 0; i < l; i += 4) {
+      tmp = (revLookup[b64.charCodeAt(i)] << 18) | (revLookup[b64.charCodeAt(i + 1)] << 12) | (revLookup[b64.charCodeAt(i + 2)] << 6) | revLookup[b64.charCodeAt(i + 3)]
+      arr[L++] = (tmp >> 16) & 0xFF
+      arr[L++] = (tmp >> 8) & 0xFF
+      arr[L++] = tmp & 0xFF
+    }
+  
+    if (placeHolders === 2) {
+      tmp = (revLookup[b64.charCodeAt(i)] << 2) | (revLookup[b64.charCodeAt(i + 1)] >> 4)
+      arr[L++] = tmp & 0xFF
+    } else if (placeHolders === 1) {
+      tmp = (revLookup[b64.charCodeAt(i)] << 10) | (revLookup[b64.charCodeAt(i + 1)] << 4) | (revLookup[b64.charCodeAt(i + 2)] >> 2)
+      arr[L++] = (tmp >> 8) & 0xFF
+      arr[L++] = tmp & 0xFF
+    }
+  
+    return arr
+  }
+  
+  function tripletToBase64 (num) {
+    return lookup[num >> 18 & 0x3F] + lookup[num >> 12 & 0x3F] + lookup[num >> 6 & 0x3F] + lookup[num & 0x3F]
+  }
+  
+  function encodeChunk (uint8, start, end) {
+    var tmp
+    var output = []
+    for (var i = start; i < end; i += 3) {
+      tmp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+      output.push(tripletToBase64(tmp))
+    }
+    return output.join('')
+  }
+  
+  function fromByteArray (uint8) {
+    var tmp
+    var len = uint8.length
+    var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
+    var output = ''
+    var parts = []
+    var maxChunkLength = 16383 // must be multiple of 3
+  
+    // go through the array every three bytes, we'll deal with trailing stuff later
+    for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+      parts.push(encodeChunk(uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)))
+    }
+  
+    // pad the end with zeros, but make sure to not forget the extra bytes
+    if (extraBytes === 1) {
+      tmp = uint8[len - 1]
+      output += lookup[tmp >> 2]
+      output += lookup[(tmp << 4) & 0x3F]
+      output += '=='
+    } else if (extraBytes === 2) {
+      tmp = (uint8[len - 2] << 8) + (uint8[len - 1])
+      output += lookup[tmp >> 10]
+      output += lookup[(tmp >> 4) & 0x3F]
+      output += lookup[(tmp << 2) & 0x3F]
+      output += '='
+    }
+  
+    parts.push(output)
+  
+    return parts.join('')
+  }
+  
+  },{}],3:[function(require,module,exports){
+  var bigInt = (function (undefined) {
+      "use strict";
+  
+      var BASE = 1e7,
+          LOG_BASE = 7,
+          MAX_INT = 9007199254740992,
+          MAX_INT_ARR = smallToArray(MAX_INT),
+          LOG_MAX_INT = Math.log(MAX_INT);
+  
+      function Integer(v, radix) {
+          if (typeof v === "undefined") return Integer[0];
+          if (typeof radix !== "undefined") return +radix === 10 ? parseValue(v) : parseBase(v, radix);
+          return parseValue(v);
+      }
+  
+      function BigInteger(value, sign) {
+          this.value = value;
+          this.sign = sign;
+          this.isSmall = false;
+      }
+      BigInteger.prototype = Object.create(Integer.prototype);
+  
+      function SmallInteger(value) {
+          this.value = value;
+          this.sign = value < 0;
+          this.isSmall = true;
+      }
+      SmallInteger.prototype = Object.create(Integer.prototype);
+  
+      function isPrecise(n) {
+          return -MAX_INT < n && n < MAX_INT;
+      }
+  
+      function smallToArray(n) { // For performance reasons doesn't reference BASE, need to change this function if BASE changes
+          if (n < 1e7)
+              return [n];
+          if (n < 1e14)
+              return [n % 1e7, Math.floor(n / 1e7)];
+          return [n % 1e7, Math.floor(n / 1e7) % 1e7, Math.floor(n / 1e14)];
+      }
+  
+      function arrayToSmall(arr) { // If BASE changes this function may need to change
+          trim(arr);
+          var length = arr.length;
+          if (length < 4 && compareAbs(arr, MAX_INT_ARR) < 0) {
+              switch (length) {
+                  case 0: return 0;
+                  case 1: return arr[0];
+                  case 2: return arr[0] + arr[1] * BASE;
+                  default: return arr[0] + (arr[1] + arr[2] * BASE) * BASE;
+              }
+          }
+          return arr;
+      }
+  
+      function trim(v) {
+          var i = v.length;
+          while (v[--i] === 0);
+          v.length = i + 1;
+      }
+  
+      function createArray(length) { // function shamelessly stolen from Yaffle's library https://github.com/Yaffle/BigInteger
+          var x = new Array(length);
+          var i = -1;
+          while (++i < length) {
+              x[i] = 0;
+          }
+          return x;
+      }
+  
+      function truncate(n) {
+          if (n > 0) return Math.floor(n);
+          return Math.ceil(n);
+      }
+  
+      function add(a, b) { // assumes a and b are arrays with a.length >= b.length
+          var l_a = a.length,
+              l_b = b.length,
+              r = new Array(l_a),
+              carry = 0,
+              base = BASE,
+              sum, i;
+          for (i = 0; i < l_b; i++) {
+              sum = a[i] + b[i] + carry;
+              carry = sum >= base ? 1 : 0;
+              r[i] = sum - carry * base;
+          }
+          while (i < l_a) {
+              sum = a[i] + carry;
+              carry = sum === base ? 1 : 0;
+              r[i++] = sum - carry * base;
+          }
+          if (carry > 0) r.push(carry);
+          return r;
+      }
+  
+      function addAny(a, b) {
+          if (a.length >= b.length) return add(a, b);
+          return add(b, a);
+      }
+  
+      function addSmall(a, carry) { // assumes a is array, carry is number with 0 <= carry < MAX_INT
+          var l = a.length,
+              r = new Array(l),
+              base = BASE,
+              sum, i;
+          for (i = 0; i < l; i++) {
+              sum = a[i] - base + carry;
+              carry = Math.floor(sum / base);
+              r[i] = sum - carry * base;
+              carry += 1;
+          }
+          while (carry > 0) {
+              r[i++] = carry % base;
+              carry = Math.floor(carry / base);
+          }
+          return r;
+      }
+  
+      BigInteger.prototype.add = function (v) {
+          var n = parseValue(v);
+          if (this.sign !== n.sign) {
+              return this.subtract(n.negate());
+          }
+          var a = this.value, b = n.value;
+          if (n.isSmall) {
+              return new BigInteger(addSmall(a, Math.abs(b)), this.sign);
+          }
+          return new BigInteger(addAny(a, b), this.sign);
+      };
+      BigInteger.prototype.plus = BigInteger.prototype.add;
+  
+      SmallInteger.prototype.add = function (v) {
+          var n = parseValue(v);
+          var a = this.value;
+          if (a < 0 !== n.sign) {
+              return this.subtract(n.negate());
+          }
+          var b = n.value;
+          if (n.isSmall) {
+              if (isPrecise(a + b)) return new SmallInteger(a + b);
+              b = smallToArray(Math.abs(b));
+          }
+          return new BigInteger(addSmall(b, Math.abs(a)), a < 0);
+      };
+      SmallInteger.prototype.plus = SmallInteger.prototype.add;
+  
+      function subtract(a, b) { // assumes a and b are arrays with a >= b
+          var a_l = a.length,
+              b_l = b.length,
+              r = new Array(a_l),
+              borrow = 0,
+              base = BASE,
+              i, difference;
+          for (i = 0; i < b_l; i++) {
+              difference = a[i] - borrow - b[i];
+              if (difference < 0) {
+                  difference += base;
+                  borrow = 1;
+              } else borrow = 0;
+              r[i] = difference;
+          }
+          for (i = b_l; i < a_l; i++) {
+              difference = a[i] - borrow;
+              if (difference < 0) difference += base;
+              else {
+                  r[i++] = difference;
+                  break;
+              }
+              r[i] = difference;
+          }
+          for (; i < a_l; i++) {
+              r[i] = a[i];
+          }
+          trim(r);
+          return r;
+      }
+  
+      function subtractAny(a, b, sign) {
+          var value;
+          if (compareAbs(a, b) >= 0) {
+              value = subtract(a,b);
+          } else {
+              value = subtract(b, a);
+              sign = !sign;
+          }
+          value = arrayToSmall(value);
+          if (typeof value === "number") {
+              if (sign) value = -value;
+              return new SmallInteger(value);
+          }
+          return new BigInteger(value, sign);
+      }
+  
+      function subtractSmall(a, b, sign) { // assumes a is array, b is number with 0 <= b < MAX_INT
+          var l = a.length,
+              r = new Array(l),
+              carry = -b,
+              base = BASE,
+              i, difference;
+          for (i = 0; i < l; i++) {
+              difference = a[i] + carry;
+              carry = Math.floor(difference / base);
+              difference %= base;
+              r[i] = difference < 0 ? difference + base : difference;
+          }
+          r = arrayToSmall(r);
+          if (typeof r === "number") {
+              if (sign) r = -r;
+              return new SmallInteger(r);
+          } return new BigInteger(r, sign);
+      }
+  
+      BigInteger.prototype.subtract = function (v) {
+          var n = parseValue(v);
+          if (this.sign !== n.sign) {
+              return this.add(n.negate());
+          }
+          var a = this.value, b = n.value;
+          if (n.isSmall)
+              return subtractSmall(a, Math.abs(b), this.sign);
+          return subtractAny(a, b, this.sign);
+      };
+      BigInteger.prototype.minus = BigInteger.prototype.subtract;
+  
+      SmallInteger.prototype.subtract = function (v) {
+          var n = parseValue(v);
+          var a = this.value;
+          if (a < 0 !== n.sign) {
+              return this.add(n.negate());
+          }
+          var b = n.value;
+          if (n.isSmall) {
+              return new SmallInteger(a - b);
+          }
+          return subtractSmall(b, Math.abs(a), a >= 0);
+      };
+      SmallInteger.prototype.minus = SmallInteger.prototype.subtract;
+  
+      BigInteger.prototype.negate = function () {
+          return new BigInteger(this.value, !this.sign);
+      };
+      SmallInteger.prototype.negate = function () {
+          var sign = this.sign;
+          var small = new SmallInteger(-this.value);
+          small.sign = !sign;
+          return small;
+      };
+  
+      BigInteger.prototype.abs = function () {
+          return new BigInteger(this.value, false);
+      };
+      SmallInteger.prototype.abs = function () {
+          return new SmallInteger(Math.abs(this.value));
+      };
+  
+      function multiplyLong(a, b) {
+          var a_l = a.length,
+              b_l = b.length,
+              l = a_l + b_l,
+              r = createArray(l),
+              base = BASE,
+              product, carry, i, a_i, b_j;
+          for (i = 0; i < a_l; ++i) {
+              a_i = a[i];
+              for (var j = 0; j < b_l; ++j) {
+                  b_j = b[j];
+                  product = a_i * b_j + r[i + j];
+                  carry = Math.floor(product / base);
+                  r[i + j] = product - carry * base;
+                  r[i + j + 1] += carry;
+              }
+          }
+          trim(r);
+          return r;
+      }
+  
+      function multiplySmall(a, b) { // assumes a is array, b is number with |b| < BASE
+          var l = a.length,
+              r = new Array(l),
+              base = BASE,
+              carry = 0,
+              product, i;
+          for (i = 0; i < l; i++) {
+              product = a[i] * b + carry;
+              carry = Math.floor(product / base);
+              r[i] = product - carry * base;
+          }
+          while (carry > 0) {
+              r[i++] = carry % base;
+              carry = Math.floor(carry / base);
+          }
+          return r;
+      }
+  
+      function shiftLeft(x, n) {
+          var r = [];
+          while (n-- > 0) r.push(0);
+          return r.concat(x);
+      }
+  
+      function multiplyKaratsuba(x, y) {
+          var n = Math.max(x.length, y.length);
+  
+          if (n <= 30) return multiplyLong(x, y);
+          n = Math.ceil(n / 2);
+  
+          var b = x.slice(n),
+              a = x.slice(0, n),
+              d = y.slice(n),
+              c = y.slice(0, n);
+  
+          var ac = multiplyKaratsuba(a, c),
+              bd = multiplyKaratsuba(b, d),
+              abcd = multiplyKaratsuba(addAny(a, b), addAny(c, d));
+  
+          var product = addAny(addAny(ac, shiftLeft(subtract(subtract(abcd, ac), bd), n)), shiftLeft(bd, 2 * n));
+          trim(product);
+          return product;
+      }
+  
+      // The following function is derived from a surface fit of a graph plotting the performance difference
+      // between long multiplication and karatsuba multiplication versus the lengths of the two arrays.
+      function useKaratsuba(l1, l2) {
+          return -0.012 * l1 - 0.012 * l2 + 0.000015 * l1 * l2 > 0;
+      }
+  
+      BigInteger.prototype.multiply = function (v) {
+          var n = parseValue(v),
+              a = this.value, b = n.value,
+              sign = this.sign !== n.sign,
+              abs;
+          if (n.isSmall) {
+              if (b === 0) return Integer[0];
+              if (b === 1) return this;
+              if (b === -1) return this.negate();
+              abs = Math.abs(b);
+              if (abs < BASE) {
+                  return new BigInteger(multiplySmall(a, abs), sign);
+              }
+              b = smallToArray(abs);
+          }
+          if (useKaratsuba(a.length, b.length)) // Karatsuba is only faster for certain array sizes
+              return new BigInteger(multiplyKaratsuba(a, b), sign);
+          return new BigInteger(multiplyLong(a, b), sign);
+      };
+  
+      BigInteger.prototype.times = BigInteger.prototype.multiply;
+  
+      function multiplySmallAndArray(a, b, sign) { // a >= 0
+          if (a < BASE) {
+              return new BigInteger(multiplySmall(b, a), sign);
+          }
+          return new BigInteger(multiplyLong(b, smallToArray(a)), sign);
+      }
+      SmallInteger.prototype._multiplyBySmall = function (a) {
+              if (isPrecise(a.value * this.value)) {
+                  return new SmallInteger(a.value * this.value);
+              }
+              return multiplySmallAndArray(Math.abs(a.value), smallToArray(Math.abs(this.value)), this.sign !== a.sign);
+      };
+      BigInteger.prototype._multiplyBySmall = function (a) {
+              if (a.value === 0) return Integer[0];
+              if (a.value === 1) return this;
+              if (a.value === -1) return this.negate();
+              return multiplySmallAndArray(Math.abs(a.value), this.value, this.sign !== a.sign);
+      };
+      SmallInteger.prototype.multiply = function (v) {
+          return parseValue(v)._multiplyBySmall(this);
+      };
+      SmallInteger.prototype.times = SmallInteger.prototype.multiply;
+  
+      function square(a) {
+          var l = a.length,
+              r = createArray(l + l),
+              base = BASE,
+              product, carry, i, a_i, a_j;
+          for (i = 0; i < l; i++) {
+              a_i = a[i];
+              for (var j = 0; j < l; j++) {
+                  a_j = a[j];
+                  product = a_i * a_j + r[i + j];
+                  carry = Math.floor(product / base);
+                  r[i + j] = product - carry * base;
+                  r[i + j + 1] += carry;
+              }
+          }
+          trim(r);
+          return r;
+      }
+  
+      BigInteger.prototype.square = function () {
+          return new BigInteger(square(this.value), false);
+      };
+  
+      SmallInteger.prototype.square = function () {
+          var value = this.value * this.value;
+          if (isPrecise(value)) return new SmallInteger(value);
+          return new BigInteger(square(smallToArray(Math.abs(this.value))), false);
+      };
+  
+      function divMod1(a, b) { // Left over from previous version. Performs faster than divMod2 on smaller input sizes.
+          var a_l = a.length,
+              b_l = b.length,
+              base = BASE,
+              result = createArray(b.length),
+              divisorMostSignificantDigit = b[b_l - 1],
+              // normalization
+              lambda = Math.ceil(base / (2 * divisorMostSignificantDigit)),
+              remainder = multiplySmall(a, lambda),
+              divisor = multiplySmall(b, lambda),
+              quotientDigit, shift, carry, borrow, i, l, q;
+          if (remainder.length <= a_l) remainder.push(0);
+          divisor.push(0);
+          divisorMostSignificantDigit = divisor[b_l - 1];
+          for (shift = a_l - b_l; shift >= 0; shift--) {
+              quotientDigit = base - 1;
+              if (remainder[shift + b_l] !== divisorMostSignificantDigit) {
+                quotientDigit = Math.floor((remainder[shift + b_l] * base + remainder[shift + b_l - 1]) / divisorMostSignificantDigit);
+              }
+              // quotientDigit <= base - 1
+              carry = 0;
+              borrow = 0;
+              l = divisor.length;
+              for (i = 0; i < l; i++) {
+                  carry += quotientDigit * divisor[i];
+                  q = Math.floor(carry / base);
+                  borrow += remainder[shift + i] - (carry - q * base);
+                  carry = q;
+                  if (borrow < 0) {
+                      remainder[shift + i] = borrow + base;
+                      borrow = -1;
+                  } else {
+                      remainder[shift + i] = borrow;
+                      borrow = 0;
+                  }
+              }
+              while (borrow !== 0) {
+                  quotientDigit -= 1;
+                  carry = 0;
+                  for (i = 0; i < l; i++) {
+                      carry += remainder[shift + i] - base + divisor[i];
+                      if (carry < 0) {
+                          remainder[shift + i] = carry + base;
+                          carry = 0;
+                      } else {
+                          remainder[shift + i] = carry;
+                          carry = 1;
+                      }
+                  }
+                  borrow += carry;
+              }
+              result[shift] = quotientDigit;
+          }
+          // denormalization
+          remainder = divModSmall(remainder, lambda)[0];
+          return [arrayToSmall(result), arrayToSmall(remainder)];
+      }
+  
+      function divMod2(a, b) { // Implementation idea shamelessly stolen from Silent Matt's library http://silentmatt.com/biginteger/
+          // Performs faster than divMod1 on larger input sizes.
+          var a_l = a.length,
+              b_l = b.length,
+              result = [],
+              part = [],
+              base = BASE,
+              guess, xlen, highx, highy, check;
+          while (a_l) {
+              part.unshift(a[--a_l]);
+              trim(part);
+              if (compareAbs(part, b) < 0) {
+                  result.push(0);
+                  continue;
+              }
+              xlen = part.length;
+              highx = part[xlen - 1] * base + part[xlen - 2];
+              highy = b[b_l - 1] * base + b[b_l - 2];
+              if (xlen > b_l) {
+                  highx = (highx + 1) * base;
+              }
+              guess = Math.ceil(highx / highy);
+              do {
+                  check = multiplySmall(b, guess);
+                  if (compareAbs(check, part) <= 0) break;
+                  guess--;
+              } while (guess);
+              result.push(guess);
+              part = subtract(part, check);
+          }
+          result.reverse();
+          return [arrayToSmall(result), arrayToSmall(part)];
+      }
+  
+      function divModSmall(value, lambda) {
+          var length = value.length,
+              quotient = createArray(length),
+              base = BASE,
+              i, q, remainder, divisor;
+          remainder = 0;
+          for (i = length - 1; i >= 0; --i) {
+              divisor = remainder * base + value[i];
+              q = truncate(divisor / lambda);
+              remainder = divisor - q * lambda;
+              quotient[i] = q | 0;
+          }
+          return [quotient, remainder | 0];
+      }
+  
+      function divModAny(self, v) {
+          var value, n = parseValue(v);
+          var a = self.value, b = n.value;
+          var quotient;
+          if (b === 0) throw new Error("Cannot divide by zero");
+          if (self.isSmall) {
+              if (n.isSmall) {
+                  return [new SmallInteger(truncate(a / b)), new SmallInteger(a % b)];
+              }
+              return [Integer[0], self];
+          }
+          if (n.isSmall) {
+              if (b === 1) return [self, Integer[0]];
+              if (b == -1) return [self.negate(), Integer[0]];
+              var abs = Math.abs(b);
+              if (abs < BASE) {
+                  value = divModSmall(a, abs);
+                  quotient = arrayToSmall(value[0]);
+                  var remainder = value[1];
+                  if (self.sign) remainder = -remainder;
+                  if (typeof quotient === "number") {
+                      if (self.sign !== n.sign) quotient = -quotient;
+                      return [new SmallInteger(quotient), new SmallInteger(remainder)];
+                  }
+                  return [new BigInteger(quotient, self.sign !== n.sign), new SmallInteger(remainder)];
+              }
+              b = smallToArray(abs);
+          }
+          var comparison = compareAbs(a, b);
+          if (comparison === -1) return [Integer[0], self];
+          if (comparison === 0) return [Integer[self.sign === n.sign ? 1 : -1], Integer[0]];
+  
+          // divMod1 is faster on smaller input sizes
+          if (a.length + b.length <= 200)
+              value = divMod1(a, b);
+          else value = divMod2(a, b);
+  
+          quotient = value[0];
+          var qSign = self.sign !== n.sign,
+              mod = value[1],
+              mSign = self.sign;
+          if (typeof quotient === "number") {
+              if (qSign) quotient = -quotient;
+              quotient = new SmallInteger(quotient);
+          } else quotient = new BigInteger(quotient, qSign);
+          if (typeof mod === "number") {
+              if (mSign) mod = -mod;
+              mod = new SmallInteger(mod);
+          } else mod = new BigInteger(mod, mSign);
+          return [quotient, mod];
+      }
+  
+      BigInteger.prototype.divmod = function (v) {
+          var result = divModAny(this, v);
+          return {
+              quotient: result[0],
+              remainder: result[1]
+          };
+      };
+      SmallInteger.prototype.divmod = BigInteger.prototype.divmod;
+  
+      BigInteger.prototype.divide = function (v) {
+          return divModAny(this, v)[0];
+      };
+      SmallInteger.prototype.over = SmallInteger.prototype.divide = BigInteger.prototype.over = BigInteger.prototype.divide;
+  
+      BigInteger.prototype.mod = function (v) {
+          return divModAny(this, v)[1];
+      };
+      SmallInteger.prototype.remainder = SmallInteger.prototype.mod = BigInteger.prototype.remainder = BigInteger.prototype.mod;
+  
+      BigInteger.prototype.pow = function (v) {
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value,
+              value, x, y;
+          if (b === 0) return Integer[1];
+          if (a === 0) return Integer[0];
+          if (a === 1) return Integer[1];
+          if (a === -1) return n.isEven() ? Integer[1] : Integer[-1];
+          if (n.sign) {
+              return Integer[0];
+          }
+          if (!n.isSmall) throw new Error("The exponent " + n.toString() + " is too large.");
+          if (this.isSmall) {
+              if (isPrecise(value = Math.pow(a, b)))
+                  return new SmallInteger(truncate(value));
+          }
+          x = this;
+          y = Integer[1];
+          while (true) {
+              if (b & 1 === 1) {
+                  y = y.times(x);
+                  --b;
+              }
+              if (b === 0) break;
+              b /= 2;
+              x = x.square();
+          }
+          return y;
+      };
+      SmallInteger.prototype.pow = BigInteger.prototype.pow;
+  
+      BigInteger.prototype.modPow = function (exp, mod) {
+          exp = parseValue(exp);
+          mod = parseValue(mod);
+          if (mod.isZero()) throw new Error("Cannot take modPow with modulus 0");
+          var r = Integer[1],
+              base = this.mod(mod);
+          while (exp.isPositive()) {
+              if (base.isZero()) return Integer[0];
+              if (exp.isOdd()) r = r.multiply(base).mod(mod);
+              exp = exp.divide(2);
+              base = base.square().mod(mod);
+          }
+          return r;
+      };
+      SmallInteger.prototype.modPow = BigInteger.prototype.modPow;
+  
+      function compareAbs(a, b) {
+          if (a.length !== b.length) {
+              return a.length > b.length ? 1 : -1;
+          }
+          for (var i = a.length - 1; i >= 0; i--) {
+              if (a[i] !== b[i]) return a[i] > b[i] ? 1 : -1;
+          }
+          return 0;
+      }
+  
+      BigInteger.prototype.compareAbs = function (v) {
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value;
+          if (n.isSmall) return 1;
+          return compareAbs(a, b);
+      };
+      SmallInteger.prototype.compareAbs = function (v) {
+          var n = parseValue(v),
+              a = Math.abs(this.value),
+              b = n.value;
+          if (n.isSmall) {
+              b = Math.abs(b);
+              return a === b ? 0 : a > b ? 1 : -1;
+          }
+          return -1;
+      };
+  
+      BigInteger.prototype.compare = function (v) {
+          // See discussion about comparison with Infinity:
+          // https://github.com/peterolson/BigInteger.js/issues/61
+          if (v === Infinity) {
+              return -1;
+          }
+          if (v === -Infinity) {
+              return 1;
+          }
+  
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value;
+          if (this.sign !== n.sign) {
+              return n.sign ? 1 : -1;
+          }
+          if (n.isSmall) {
+              return this.sign ? -1 : 1;
+          }
+          return compareAbs(a, b) * (this.sign ? -1 : 1);
+      };
+      BigInteger.prototype.compareTo = BigInteger.prototype.compare;
+  
+      SmallInteger.prototype.compare = function (v) {
+          if (v === Infinity) {
+              return -1;
+          }
+          if (v === -Infinity) {
+              return 1;
+          }
+  
+          var n = parseValue(v),
+              a = this.value,
+              b = n.value;
+          if (n.isSmall) {
+              return a == b ? 0 : a > b ? 1 : -1;
+          }
+          if (a < 0 !== n.sign) {
+              return a < 0 ? -1 : 1;
+          }
+          return a < 0 ? 1 : -1;
+      };
+      SmallInteger.prototype.compareTo = SmallInteger.prototype.compare;
+  
+      BigInteger.prototype.equals = function (v) {
+          return this.compare(v) === 0;
+      };
+      SmallInteger.prototype.eq = SmallInteger.prototype.equals = BigInteger.prototype.eq = BigInteger.prototype.equals;
+  
+      BigInteger.prototype.notEquals = function (v) {
+          return this.compare(v) !== 0;
+      };
+      SmallInteger.prototype.neq = SmallInteger.prototype.notEquals = BigInteger.prototype.neq = BigInteger.prototype.notEquals;
+  
+      BigInteger.prototype.greater = function (v) {
+          return this.compare(v) > 0;
+      };
+      SmallInteger.prototype.gt = SmallInteger.prototype.greater = BigInteger.prototype.gt = BigInteger.prototype.greater;
+  
+      BigInteger.prototype.lesser = function (v) {
+          return this.compare(v) < 0;
+      };
+      SmallInteger.prototype.lt = SmallInteger.prototype.lesser = BigInteger.prototype.lt = BigInteger.prototype.lesser;
+  
+      BigInteger.prototype.greaterOrEquals = function (v) {
+          return this.compare(v) >= 0;
+      };
+      SmallInteger.prototype.geq = SmallInteger.prototype.greaterOrEquals = BigInteger.prototype.geq = BigInteger.prototype.greaterOrEquals;
+  
+      BigInteger.prototype.lesserOrEquals = function (v) {
+          return this.compare(v) <= 0;
+      };
+      SmallInteger.prototype.leq = SmallInteger.prototype.lesserOrEquals = BigInteger.prototype.leq = BigInteger.prototype.lesserOrEquals;
+  
+      BigInteger.prototype.isEven = function () {
+          return (this.value[0] & 1) === 0;
+      };
+      SmallInteger.prototype.isEven = function () {
+          return (this.value & 1) === 0;
+      };
+  
+      BigInteger.prototype.isOdd = function () {
+          return (this.value[0] & 1) === 1;
+      };
+      SmallInteger.prototype.isOdd = function () {
+          return (this.value & 1) === 1;
+      };
+  
+      BigInteger.prototype.isPositive = function () {
+          return !this.sign;
+      };
+      SmallInteger.prototype.isPositive = function () {
+          return this.value > 0;
+      };
+  
+      BigInteger.prototype.isNegative = function () {
+          return this.sign;
+      };
+      SmallInteger.prototype.isNegative = function () {
+          return this.value < 0;
+      };
+  
+      BigInteger.prototype.isUnit = function () {
+          return false;
+      };
+      SmallInteger.prototype.isUnit = function () {
+          return Math.abs(this.value) === 1;
+      };
+  
+      BigInteger.prototype.isZero = function () {
+          return false;
+      };
+      SmallInteger.prototype.isZero = function () {
+          return this.value === 0;
+      };
+      BigInteger.prototype.isDivisibleBy = function (v) {
+          var n = parseValue(v);
+          var value = n.value;
+          if (value === 0) return false;
+          if (value === 1) return true;
+          if (value === 2) return this.isEven();
+          return this.mod(n).equals(Integer[0]);
+      };
+      SmallInteger.prototype.isDivisibleBy = BigInteger.prototype.isDivisibleBy;
+  
+      function isBasicPrime(v) {
+          var n = v.abs();
+          if (n.isUnit()) return false;
+          if (n.equals(2) || n.equals(3) || n.equals(5)) return true;
+          if (n.isEven() || n.isDivisibleBy(3) || n.isDivisibleBy(5)) return false;
+          if (n.lesser(25)) return true;
+          // we don't know if it's prime: let the other functions figure it out
+      }
+  
+      BigInteger.prototype.isPrime = function () {
+          var isPrime = isBasicPrime(this);
+          if (isPrime !== undefined) return isPrime;
+          var n = this.abs(),
+              nPrev = n.prev();
+          var a = [2, 3, 5, 7, 11, 13, 17, 19],
+              b = nPrev,
+              d, t, i, x;
+          while (b.isEven()) b = b.divide(2);
+          for (i = 0; i < a.length; i++) {
+              x = bigInt(a[i]).modPow(b, n);
+              if (x.equals(Integer[1]) || x.equals(nPrev)) continue;
+              for (t = true, d = b; t && d.lesser(nPrev) ; d = d.multiply(2)) {
+                  x = x.square().mod(n);
+                  if (x.equals(nPrev)) t = false;
+              }
+              if (t) return false;
+          }
+          return true;
+      };
+      SmallInteger.prototype.isPrime = BigInteger.prototype.isPrime;
+  
+      BigInteger.prototype.isProbablePrime = function (iterations) {
+          var isPrime = isBasicPrime(this);
+          if (isPrime !== undefined) return isPrime;
+          var n = this.abs();
+          var t = iterations === undefined ? 5 : iterations;
+          // use the Fermat primality test
+          for (var i = 0; i < t; i++) {
+              var a = bigInt.randBetween(2, n.minus(2));
+              if (!a.modPow(n.prev(), n).isUnit()) return false; // definitely composite
+          }
+          return true; // large chance of being prime
+      };
+      SmallInteger.prototype.isProbablePrime = BigInteger.prototype.isProbablePrime;
+  
+      BigInteger.prototype.modInv = function (n) {
+          var t = bigInt.zero, newT = bigInt.one, r = parseValue(n), newR = this.abs(), q, lastT, lastR;
+          while (!newR.equals(bigInt.zero)) {
+              q = r.divide(newR);
+              lastT = t;
+              lastR = r;
+              t = newT;
+              r = newR;
+              newT = lastT.subtract(q.multiply(newT));
+              newR = lastR.subtract(q.multiply(newR));
+          }
+          if (!r.equals(1)) throw new Error(this.toString() + " and " + n.toString() + " are not co-prime");
+          if (t.compare(0) === -1) {
+              t = t.add(n);
+          }
+          if (this.isNegative()) {
+              return t.negate();
+          }
+          return t;
+      };
+  
+      SmallInteger.prototype.modInv = BigInteger.prototype.modInv;
+  
+      BigInteger.prototype.next = function () {
+          var value = this.value;
+          if (this.sign) {
+              return subtractSmall(value, 1, this.sign);
+          }
+          return new BigInteger(addSmall(value, 1), this.sign);
+      };
+      SmallInteger.prototype.next = function () {
+          var value = this.value;
+          if (value + 1 < MAX_INT) return new SmallInteger(value + 1);
+          return new BigInteger(MAX_INT_ARR, false);
+      };
+  
+      BigInteger.prototype.prev = function () {
+          var value = this.value;
+          if (this.sign) {
+              return new BigInteger(addSmall(value, 1), true);
+          }
+          return subtractSmall(value, 1, this.sign);
+      };
+      SmallInteger.prototype.prev = function () {
+          var value = this.value;
+          if (value - 1 > -MAX_INT) return new SmallInteger(value - 1);
+          return new BigInteger(MAX_INT_ARR, true);
+      };
+  
+      var powersOfTwo = [1];
+      while (2 * powersOfTwo[powersOfTwo.length - 1] <= BASE) powersOfTwo.push(2 * powersOfTwo[powersOfTwo.length - 1]);
+      var powers2Length = powersOfTwo.length, highestPower2 = powersOfTwo[powers2Length - 1];
+  
+      function shift_isSmall(n) {
+          return ((typeof n === "number" || typeof n === "string") && +Math.abs(n) <= BASE) ||
+              (n instanceof BigInteger && n.value.length <= 1);
+      }
+  
+      BigInteger.prototype.shiftLeft = function (n) {
+          if (!shift_isSmall(n)) {
+              throw new Error(String(n) + " is too large for shifting.");
+          }
+          n = +n;
+          if (n < 0) return this.shiftRight(-n);
+          var result = this;
+          while (n >= powers2Length) {
+              result = result.multiply(highestPower2);
+              n -= powers2Length - 1;
+          }
+          return result.multiply(powersOfTwo[n]);
+      };
+      SmallInteger.prototype.shiftLeft = BigInteger.prototype.shiftLeft;
+  
+      BigInteger.prototype.shiftRight = function (n) {
+          var remQuo;
+          if (!shift_isSmall(n)) {
+              throw new Error(String(n) + " is too large for shifting.");
+          }
+          n = +n;
+          if (n < 0) return this.shiftLeft(-n);
+          var result = this;
+          while (n >= powers2Length) {
+              if (result.isZero()) return result;
+              remQuo = divModAny(result, highestPower2);
+              result = remQuo[1].isNegative() ? remQuo[0].prev() : remQuo[0];
+              n -= powers2Length - 1;
+          }
+          remQuo = divModAny(result, powersOfTwo[n]);
+          return remQuo[1].isNegative() ? remQuo[0].prev() : remQuo[0];
+      };
+      SmallInteger.prototype.shiftRight = BigInteger.prototype.shiftRight;
+  
+      function bitwise(x, y, fn) {
+          y = parseValue(y);
+          var xSign = x.isNegative(), ySign = y.isNegative();
+          var xRem = xSign ? x.not() : x,
+              yRem = ySign ? y.not() : y;
+          var xDigit = 0, yDigit = 0;
+          var xDivMod = null, yDivMod = null;
+          var result = [];
+          while (!xRem.isZero() || !yRem.isZero()) {
+              xDivMod = divModAny(xRem, highestPower2);
+              xDigit = xDivMod[1].toJSNumber();
+              if (xSign) {
+                  xDigit = highestPower2 - 1 - xDigit; // two's complement for negative numbers
+              }
+  
+              yDivMod = divModAny(yRem, highestPower2);
+              yDigit = yDivMod[1].toJSNumber();
+              if (ySign) {
+                  yDigit = highestPower2 - 1 - yDigit; // two's complement for negative numbers
+              }
+  
+              xRem = xDivMod[0];
+              yRem = yDivMod[0];
+              result.push(fn(xDigit, yDigit));
+          }
+          var sum = fn(xSign ? 1 : 0, ySign ? 1 : 0) !== 0 ? bigInt(-1) : bigInt(0);
+          for (var i = result.length - 1; i >= 0; i -= 1) {
+              sum = sum.multiply(highestPower2).add(bigInt(result[i]));
+          }
+          return sum;
+      }
+  
+      BigInteger.prototype.not = function () {
+          return this.negate().prev();
+      };
+      SmallInteger.prototype.not = BigInteger.prototype.not;
+  
+      BigInteger.prototype.and = function (n) {
+          return bitwise(this, n, function (a, b) { return a & b; });
+      };
+      SmallInteger.prototype.and = BigInteger.prototype.and;
+  
+      BigInteger.prototype.or = function (n) {
+          return bitwise(this, n, function (a, b) { return a | b; });
+      };
+      SmallInteger.prototype.or = BigInteger.prototype.or;
+  
+      BigInteger.prototype.xor = function (n) {
+          return bitwise(this, n, function (a, b) { return a ^ b; });
+      };
+      SmallInteger.prototype.xor = BigInteger.prototype.xor;
+  
+      var LOBMASK_I = 1 << 30, LOBMASK_BI = (BASE & -BASE) * (BASE & -BASE) | LOBMASK_I;
+      function roughLOB(n) { // get lowestOneBit (rough)
+          // SmallInteger: return Min(lowestOneBit(n), 1 << 30)
+          // BigInteger: return Min(lowestOneBit(n), 1 << 14) [BASE=1e7]
+          var v = n.value, x = typeof v === "number" ? v | LOBMASK_I : v[0] + v[1] * BASE | LOBMASK_BI;
+          return x & -x;
+      }
+  
+      function max(a, b) {
+          a = parseValue(a);
+          b = parseValue(b);
+          return a.greater(b) ? a : b;
+      }
+      function min(a, b) {
+          a = parseValue(a);
+          b = parseValue(b);
+          return a.lesser(b) ? a : b;
+      }
+      function gcd(a, b) {
+          a = parseValue(a).abs();
+          b = parseValue(b).abs();
+          if (a.equals(b)) return a;
+          if (a.isZero()) return b;
+          if (b.isZero()) return a;
+          var c = Integer[1], d, t;
+          while (a.isEven() && b.isEven()) {
+              d = Math.min(roughLOB(a), roughLOB(b));
+              a = a.divide(d);
+              b = b.divide(d);
+              c = c.multiply(d);
+          }
+          while (a.isEven()) {
+              a = a.divide(roughLOB(a));
+          }
+          do {
+              while (b.isEven()) {
+                  b = b.divide(roughLOB(b));
+              }
+              if (a.greater(b)) {
+                  t = b; b = a; a = t;
+              }
+              b = b.subtract(a);
+          } while (!b.isZero());
+          return c.isUnit() ? a : a.multiply(c);
+      }
+      function lcm(a, b) {
+          a = parseValue(a).abs();
+          b = parseValue(b).abs();
+          return a.divide(gcd(a, b)).multiply(b);
+      }
+      function randBetween(a, b) {
+          a = parseValue(a);
+          b = parseValue(b);
+          var low = min(a, b), high = max(a, b);
+          var range = high.subtract(low).add(1);
+          if (range.isSmall) return low.add(Math.floor(Math.random() * range));
+          var length = range.value.length - 1;
+          var result = [], restricted = true;
+          for (var i = length; i >= 0; i--) {
+              var top = restricted ? range.value[i] : BASE;
+              var digit = truncate(Math.random() * top);
+              result.unshift(digit);
+              if (digit < top) restricted = false;
+          }
+          result = arrayToSmall(result);
+          return low.add(typeof result === "number" ? new SmallInteger(result) : new BigInteger(result, false));
+      }
+      var parseBase = function (text, base) {
+          var length = text.length;
+      var i;
+      var absBase = Math.abs(base);
+      for(var i = 0; i < length; i++) {
+        var c = text[i].toLowerCase();
+        if(c === "-") continue;
+        if(/[a-z0-9]/.test(c)) {
+            if(/[0-9]/.test(c) && +c >= absBase) {
+            if(c === "1" && absBase === 1) continue;
+                      throw new Error(c + " is not a valid digit in base " + base + ".");
+          } else if(c.charCodeAt(0) - 87 >= absBase) {
+            throw new Error(c + " is not a valid digit in base " + base + ".");
+          }
+        }
+      }
+          if (2 <= base && base <= 36) {
+              if (length <= LOG_MAX_INT / Math.log(base)) {
+          var result = parseInt(text, base);
+          if(isNaN(result)) {
+            throw new Error(c + " is not a valid digit in base " + base + ".");
+          }
+                  return new SmallInteger(parseInt(text, base));
+              }
+          }
+          base = parseValue(base);
+          var digits = [];
+          var isNegative = text[0] === "-";
+          for (i = isNegative ? 1 : 0; i < text.length; i++) {
+              var c = text[i].toLowerCase(),
+                  charCode = c.charCodeAt(0);
+              if (48 <= charCode && charCode <= 57) digits.push(parseValue(c));
+              else if (97 <= charCode && charCode <= 122) digits.push(parseValue(c.charCodeAt(0) - 87));
+              else if (c === "<") {
+                  var start = i;
+                  do { i++; } while (text[i] !== ">");
+                  digits.push(parseValue(text.slice(start + 1, i)));
+              }
+              else throw new Error(c + " is not a valid character");
+          }
+          return parseBaseFromArray(digits, base, isNegative);
+      };
+  
+      function parseBaseFromArray(digits, base, isNegative) {
+          var val = Integer[0], pow = Integer[1], i;
+          for (i = digits.length - 1; i >= 0; i--) {
+              val = val.add(digits[i].times(pow));
+              pow = pow.times(base);
+          }
+          return isNegative ? val.negate() : val;
+      }
+  
+      function stringify(digit) {
+          var v = digit.value;
+          if (typeof v === "number") v = [v];
+          if (v.length === 1 && v[0] <= 35) {
+              return "0123456789abcdefghijklmnopqrstuvwxyz".charAt(v[0]);
+          }
+          return "<" + v + ">";
+      }
+      function toBase(n, base) {
+          base = bigInt(base);
+          if (base.isZero()) {
+              if (n.isZero()) return "0";
+              throw new Error("Cannot convert nonzero numbers to base 0.");
+          }
+          if (base.equals(-1)) {
+              if (n.isZero()) return "0";
+              if (n.isNegative()) return new Array(1 - n).join("10");
+              return "1" + new Array(+n).join("01");
+          }
+          var minusSign = "";
+          if (n.isNegative() && base.isPositive()) {
+              minusSign = "-";
+              n = n.abs();
+          }
+          if (base.equals(1)) {
+              if (n.isZero()) return "0";
+              return minusSign + new Array(+n + 1).join(1);
+          }
+          var out = [];
+          var left = n, divmod;
+          while (left.isNegative() || left.compareAbs(base) >= 0) {
+              divmod = left.divmod(base);
+              left = divmod.quotient;
+              var digit = divmod.remainder;
+              if (digit.isNegative()) {
+                  digit = base.minus(digit).abs();
+                  left = left.next();
+              }
+              out.push(stringify(digit));
+          }
+          out.push(stringify(left));
+          return minusSign + out.reverse().join("");
+      }
+  
+      BigInteger.prototype.toString = function (radix) {
+          if (radix === undefined) radix = 10;
+          if (radix !== 10) return toBase(this, radix);
+          var v = this.value, l = v.length, str = String(v[--l]), zeros = "0000000", digit;
+          while (--l >= 0) {
+              digit = String(v[l]);
+              str += zeros.slice(digit.length) + digit;
+          }
+          var sign = this.sign ? "-" : "";
+          return sign + str;
+      };
+  
+      SmallInteger.prototype.toString = function (radix) {
+          if (radix === undefined) radix = 10;
+          if (radix != 10) return toBase(this, radix);
+          return String(this.value);
+      };
+      BigInteger.prototype.toJSON = SmallInteger.prototype.toJSON = function() { return this.toString(); }
+  
+      BigInteger.prototype.valueOf = function () {
+          return +this.toString();
+      };
+      BigInteger.prototype.toJSNumber = BigInteger.prototype.valueOf;
+  
+      SmallInteger.prototype.valueOf = function () {
+          return this.value;
+      };
+      SmallInteger.prototype.toJSNumber = SmallInteger.prototype.valueOf;
+  
+      function parseStringValue(v) {
+              if (isPrecise(+v)) {
+                  var x = +v;
+                  if (x === truncate(x))
+                      return new SmallInteger(x);
+                  throw "Invalid integer: " + v;
+              }
+              var sign = v[0] === "-";
+              if (sign) v = v.slice(1);
+              var split = v.split(/e/i);
+              if (split.length > 2) throw new Error("Invalid integer: " + split.join("e"));
+              if (split.length === 2) {
+                  var exp = split[1];
+                  if (exp[0] === "+") exp = exp.slice(1);
+                  exp = +exp;
+                  if (exp !== truncate(exp) || !isPrecise(exp)) throw new Error("Invalid integer: " + exp + " is not a valid exponent.");
+                  var text = split[0];
+                  var decimalPlace = text.indexOf(".");
+                  if (decimalPlace >= 0) {
+                      exp -= text.length - decimalPlace - 1;
+                      text = text.slice(0, decimalPlace) + text.slice(decimalPlace + 1);
+                  }
+                  if (exp < 0) throw new Error("Cannot include negative exponent part for integers");
+                  text += (new Array(exp + 1)).join("0");
+                  v = text;
+              }
+              var isValid = /^([0-9][0-9]*)$/.test(v);
+              if (!isValid) throw new Error("Invalid integer: " + v);
+              var r = [], max = v.length, l = LOG_BASE, min = max - l;
+              while (max > 0) {
+                  r.push(+v.slice(min, max));
+                  min -= l;
+                  if (min < 0) min = 0;
+                  max -= l;
+              }
+              trim(r);
+              return new BigInteger(r, sign);
+      }
+  
+      function parseNumberValue(v) {
+          if (isPrecise(v)) {
+              if (v !== truncate(v)) throw new Error(v + " is not an integer.");
+              return new SmallInteger(v);
+          }
+          return parseStringValue(v.toString());
+      }
+  
+      function parseValue(v) {
+          if (typeof v === "number") {
+              return parseNumberValue(v);
+          }
+          if (typeof v === "string") {
+              return parseStringValue(v);
+          }
+          return v;
+      }
+      // Pre-define numbers in range [-999,999]
+      for (var i = 0; i < 1000; i++) {
+          Integer[i] = new SmallInteger(i);
+          if (i > 0) Integer[-i] = new SmallInteger(-i);
+      }
+      // Backwards compatibility
+      Integer.one = Integer[1];
+      Integer.zero = Integer[0];
+      Integer.minusOne = Integer[-1];
+      Integer.max = max;
+      Integer.min = min;
+      Integer.gcd = gcd;
+      Integer.lcm = lcm;
+      Integer.isInstance = function (x) { return x instanceof BigInteger || x instanceof SmallInteger; };
+      Integer.randBetween = randBetween;
+  
+      Integer.fromArray = function (digits, base, isNegative) {
+          return parseBaseFromArray(digits.map(parseValue), parseValue(base || 10), isNegative);
+      };
+  
+      return Integer;
+  })();
+  
+  // Node.js check
+  if (typeof module !== "undefined" && module.hasOwnProperty("exports")) {
+      module.exports = bigInt;
+  }
+  
+  //amd check
+  if ( typeof define === "function" && define.amd ) {
+    define( "big-integer", [], function() {
+      return bigInt;
+    });
+  }
+  
+  },{}],4:[function(require,module,exports){
+  
+  },{}],5:[function(require,module,exports){
+  var basex = require('base-x')
+  var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+  
+  module.exports = basex(ALPHABET)
+  
+  },{"base-x":1}],6:[function(require,module,exports){
+  'use strict'
+  
+  var base58 = require('bs58')
+  var Buffer = require('safe-buffer').Buffer
+  
+  module.exports = function (checksumFn) {
+    // Encode a buffer as a base58-check encoded string
+    function encode (payload) {
+      var checksum = checksumFn(payload)
+  
+      return base58.encode(Buffer.concat([
+        payload,
+        checksum
+      ], payload.length + 4))
+    }
+  
+    function decodeRaw (buffer) {
+      var payload = buffer.slice(0, -4)
+      var checksum = buffer.slice(-4)
+      var newChecksum = checksumFn(payload)
+  
+      if (checksum[0] ^ newChecksum[0] |
+          checksum[1] ^ newChecksum[1] |
+          checksum[2] ^ newChecksum[2] |
+          checksum[3] ^ newChecksum[3]) return
+  
+      return payload
+    }
+  
+    // Decode a base58-check encoded string to a buffer, no result if checksum is wrong
+    function decodeUnsafe (string) {
+      var buffer = base58.decodeUnsafe(string)
+      if (!buffer) return
+  
+      return decodeRaw(buffer)
+    }
+  
+    function decode (string) {
+      var buffer = base58.decode(string)
+      var payload = decodeRaw(buffer, checksumFn)
+      if (!payload) throw new Error('Invalid checksum')
+      return payload
+    }
+  
+    return {
+      encode: encode,
+      decode: decode,
+      decodeUnsafe: decodeUnsafe
+    }
+  }
+  
+  },{"bs58":5,"safe-buffer":40}],7:[function(require,module,exports){
+  'use strict'
+  
+  var createHash = require('create-hash')
+  var bs58checkBase = require('./base')
+  
+  // SHA256(SHA256(buffer))
+  function sha256x2 (buffer) {
+    var tmp = createHash('sha256').update(buffer).digest()
+    return createHash('sha256').update(tmp).digest()
+  }
+  
+  module.exports = bs58checkBase(sha256x2)
+  
+  },{"./base":6,"create-hash":15}],8:[function(require,module,exports){
+  /*!
+   * The buffer module from node.js, for the browser.
+   *
+   * @author   Feross Aboukhadijeh <https://feross.org>
+   * @license  MIT
+   */
+  /* eslint-disable no-proto */
+  
+  'use strict'
+  
+  var base64 = require('base64-js')
+  var ieee754 = require('ieee754')
+  
+  exports.Buffer = Buffer
+  exports.SlowBuffer = SlowBuffer
+  exports.INSPECT_MAX_BYTES = 50
+  
+  var K_MAX_LENGTH = 0x7fffffff
+  exports.kMaxLength = K_MAX_LENGTH
+  
+  /**
+   * If `Buffer.TYPED_ARRAY_SUPPORT`:
+   *   === true    Use Uint8Array implementation (fastest)
+   *   === false   Print warning and recommend using `buffer` v4.x which has an Object
+   *               implementation (most compatible, even IE6)
+   *
+   * Browsers that support typed arrays are IE 10+, Firefox 4+, Chrome 7+, Safari 5.1+,
+   * Opera 11.6+, iOS 4.2+.
+   *
+   * We report that the browser does not support typed arrays if the are not subclassable
+   * using __proto__. Firefox 4-29 lacks support for adding new properties to `Uint8Array`
+   * (See: https://bugzilla.mozilla.org/show_bug.cgi?id=695438). IE 10 lacks support
+   * for __proto__ and has a buggy typed array implementation.
+   */
+  Buffer.TYPED_ARRAY_SUPPORT = typedArraySupport()
+  
+  if (!Buffer.TYPED_ARRAY_SUPPORT && typeof console !== 'undefined' &&
+      typeof console.error === 'function') {
+    console.error(
+      'This browser lacks typed array (Uint8Array) support which is required by ' +
+      '`buffer` v5.x. Use `buffer` v4.x if you require old browser support.'
+    )
+  }
+  
+  function typedArraySupport () {
+    // Can typed array instances can be augmented?
+    try {
+      var arr = new Uint8Array(1)
+      arr.__proto__ = {__proto__: Uint8Array.prototype, foo: function () { return 42 }}
+      return arr.foo() === 42
+    } catch (e) {
+      return false
+    }
+  }
+  
+  function createBuffer (length) {
+    if (length > K_MAX_LENGTH) {
+      throw new RangeError('Invalid typed array length')
+    }
+    // Return an augmented `Uint8Array` instance
+    var buf = new Uint8Array(length)
+    buf.__proto__ = Buffer.prototype
+    return buf
+  }
+  
+  /**
+   * The Buffer constructor returns instances of `Uint8Array` that have their
+   * prototype changed to `Buffer.prototype`. Furthermore, `Buffer` is a subclass of
+   * `Uint8Array`, so the returned instances will have all the node `Buffer` methods
+   * and the `Uint8Array` methods. Square bracket notation works as expected -- it
+   * returns a single octet.
+   *
+   * The `Uint8Array` prototype remains unmodified.
+   */
+  
+  function Buffer (arg, encodingOrOffset, length) {
+    // Common case.
+    if (typeof arg === 'number') {
+      if (typeof encodingOrOffset === 'string') {
+        throw new Error(
+          'If encoding is specified then the first argument must be a string'
+        )
+      }
+      return allocUnsafe(arg)
+    }
+    return from(arg, encodingOrOffset, length)
+  }
+  
+  // Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
+  if (typeof Symbol !== 'undefined' && Symbol.species &&
+      Buffer[Symbol.species] === Buffer) {
+    Object.defineProperty(Buffer, Symbol.species, {
+      value: null,
+      configurable: true,
+      enumerable: false,
+      writable: false
+    })
+  }
+  
+  Buffer.poolSize = 8192 // not used by this implementation
+  
+  function from (value, encodingOrOffset, length) {
+    if (typeof value === 'number') {
+      throw new TypeError('"value" argument must not be a number')
+    }
+  
+    if (isArrayBuffer(value)) {
+      return fromArrayBuffer(value, encodingOrOffset, length)
+    }
+  
+    if (typeof value === 'string') {
+      return fromString(value, encodingOrOffset)
+    }
+  
+    return fromObject(value)
+  }
+  
+  /**
+   * Functionally equivalent to Buffer(arg, encoding) but throws a TypeError
+   * if value is a number.
+   * Buffer.from(str[, encoding])
+   * Buffer.from(array)
+   * Buffer.from(buffer)
+   * Buffer.from(arrayBuffer[, byteOffset[, length]])
+   **/
+  Buffer.from = function (value, encodingOrOffset, length) {
+    return from(value, encodingOrOffset, length)
+  }
+  
+  // Note: Change prototype *after* Buffer.from is defined to workaround Chrome bug:
+  // https://github.com/feross/buffer/pull/148
+  Buffer.prototype.__proto__ = Uint8Array.prototype
+  Buffer.__proto__ = Uint8Array
+  
+  function assertSize (size) {
+    if (typeof size !== 'number') {
+      throw new TypeError('"size" argument must be a number')
+    } else if (size < 0) {
+      throw new RangeError('"size" argument must not be negative')
+    }
+  }
+  
+  function alloc (size, fill, encoding) {
+    assertSize(size)
+    if (size <= 0) {
+      return createBuffer(size)
+    }
+    if (fill !== undefined) {
+      // Only pay attention to encoding if it's a string. This
+      // prevents accidentally sending in a number that would
+      // be interpretted as a start offset.
+      return typeof encoding === 'string'
+        ? createBuffer(size).fill(fill, encoding)
+        : createBuffer(size).fill(fill)
+    }
+    return createBuffer(size)
+  }
+  
+  /**
+   * Creates a new filled Buffer instance.
+   * alloc(size[, fill[, encoding]])
+   **/
+  Buffer.alloc = function (size, fill, encoding) {
+    return alloc(size, fill, encoding)
+  }
+  
+  function allocUnsafe (size) {
+    assertSize(size)
+    return createBuffer(size < 0 ? 0 : checked(size) | 0)
+  }
+  
+  /**
+   * Equivalent to Buffer(num), by default creates a non-zero-filled Buffer instance.
+   * */
+  Buffer.allocUnsafe = function (size) {
+    return allocUnsafe(size)
+  }
+  /**
+   * Equivalent to SlowBuffer(num), by default creates a non-zero-filled Buffer instance.
+   */
+  Buffer.allocUnsafeSlow = function (size) {
+    return allocUnsafe(size)
+  }
+  
+  function fromString (string, encoding) {
+    if (typeof encoding !== 'string' || encoding === '') {
+      encoding = 'utf8'
+    }
+  
+    if (!Buffer.isEncoding(encoding)) {
+      throw new TypeError('"encoding" must be a valid string encoding')
+    }
+  
+    var length = byteLength(string, encoding) | 0
+    var buf = createBuffer(length)
+  
+    var actual = buf.write(string, encoding)
+  
+    if (actual !== length) {
+      // Writing a hex string, for example, that contains invalid characters will
+      // cause everything after the first invalid character to be ignored. (e.g.
+      // 'abxxcd' will be treated as 'ab')
+      buf = buf.slice(0, actual)
+    }
+  
+    return buf
+  }
+  
+  function fromArrayLike (array) {
+    var length = array.length < 0 ? 0 : checked(array.length) | 0
+    var buf = createBuffer(length)
+    for (var i = 0; i < length; i += 1) {
+      buf[i] = array[i] & 255
+    }
+    return buf
+  }
+  
+  function fromArrayBuffer (array, byteOffset, length) {
+    if (byteOffset < 0 || array.byteLength < byteOffset) {
+      throw new RangeError('\'offset\' is out of bounds')
+    }
+  
+    if (array.byteLength < byteOffset + (length || 0)) {
+      throw new RangeError('\'length\' is out of bounds')
+    }
+  
+    var buf
+    if (byteOffset === undefined && length === undefined) {
+      buf = new Uint8Array(array)
+    } else if (length === undefined) {
+      buf = new Uint8Array(array, byteOffset)
+    } else {
+      buf = new Uint8Array(array, byteOffset, length)
+    }
+  
+    // Return an augmented `Uint8Array` instance
+    buf.__proto__ = Buffer.prototype
+    return buf
+  }
+  
+  function fromObject (obj) {
+    if (Buffer.isBuffer(obj)) {
+      var len = checked(obj.length) | 0
+      var buf = createBuffer(len)
+  
+      if (buf.length === 0) {
+        return buf
+      }
+  
+      obj.copy(buf, 0, 0, len)
+      return buf
+    }
+  
+    if (obj) {
+      if (isArrayBufferView(obj) || 'length' in obj) {
+        if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {
+          return createBuffer(0)
+        }
+        return fromArrayLike(obj)
+      }
+  
+      if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
+        return fromArrayLike(obj.data)
+      }
+    }
+  
+    throw new TypeError('First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.')
+  }
+  
+  function checked (length) {
+    // Note: cannot use `length < K_MAX_LENGTH` here because that fails when
+    // length is NaN (which is otherwise coerced to zero.)
+    if (length >= K_MAX_LENGTH) {
+      throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
+                           'size: 0x' + K_MAX_LENGTH.toString(16) + ' bytes')
+    }
+    return length | 0
+  }
+  
+  function SlowBuffer (length) {
+    if (+length != length) { // eslint-disable-line eqeqeq
+      length = 0
+    }
+    return Buffer.alloc(+length)
+  }
+  
+  Buffer.isBuffer = function isBuffer (b) {
+    return b != null && b._isBuffer === true
+  }
+  
+  Buffer.compare = function compare (a, b) {
+    if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
+      throw new TypeError('Arguments must be Buffers')
+    }
+  
+    if (a === b) return 0
+  
+    var x = a.length
+    var y = b.length
+  
+    for (var i = 0, len = Math.min(x, y); i < len; ++i) {
+      if (a[i] !== b[i]) {
+        x = a[i]
+        y = b[i]
+        break
+      }
+    }
+  
+    if (x < y) return -1
+    if (y < x) return 1
+    return 0
+  }
+  
+  Buffer.isEncoding = function isEncoding (encoding) {
+    switch (String(encoding).toLowerCase()) {
+      case 'hex':
+      case 'utf8':
+      case 'utf-8':
+      case 'ascii':
+      case 'latin1':
+      case 'binary':
+      case 'base64':
+      case 'ucs2':
+      case 'ucs-2':
+      case 'utf16le':
+      case 'utf-16le':
+        return true
+      default:
+        return false
+    }
+  }
+  
+  Buffer.concat = function concat (list, length) {
+    if (!Array.isArray(list)) {
+      throw new TypeError('"list" argument must be an Array of Buffers')
+    }
+  
+    if (list.length === 0) {
+      return Buffer.alloc(0)
+    }
+  
+    var i
+    if (length === undefined) {
+      length = 0
+      for (i = 0; i < list.length; ++i) {
+        length += list[i].length
+      }
+    }
+  
+    var buffer = Buffer.allocUnsafe(length)
+    var pos = 0
+    for (i = 0; i < list.length; ++i) {
+      var buf = list[i]
+      if (!Buffer.isBuffer(buf)) {
+        throw new TypeError('"list" argument must be an Array of Buffers')
+      }
+      buf.copy(buffer, pos)
+      pos += buf.length
+    }
+    return buffer
+  }
+  
+  function byteLength (string, encoding) {
+    if (Buffer.isBuffer(string)) {
+      return string.length
+    }
+    if (isArrayBufferView(string) || isArrayBuffer(string)) {
+      return string.byteLength
+    }
+    if (typeof string !== 'string') {
+      string = '' + string
+    }
+  
+    var len = string.length
+    if (len === 0) return 0
+  
+    // Use a for loop to avoid recursion
+    var loweredCase = false
+    for (;;) {
+      switch (encoding) {
+        case 'ascii':
+        case 'latin1':
+        case 'binary':
+          return len
+        case 'utf8':
+        case 'utf-8':
+        case undefined:
+          return utf8ToBytes(string).length
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return len * 2
+        case 'hex':
+          return len >>> 1
+        case 'base64':
+          return base64ToBytes(string).length
+        default:
+          if (loweredCase) return utf8ToBytes(string).length // assume utf8
+          encoding = ('' + encoding).toLowerCase()
+          loweredCase = true
+      }
+    }
+  }
+  Buffer.byteLength = byteLength
+  
+  function slowToString (encoding, start, end) {
+    var loweredCase = false
+  
+    // No need to verify that "this.length <= MAX_UINT32" since it's a read-only
+    // property of a typed array.
+  
+    // This behaves neither like String nor Uint8Array in that we set start/end
+    // to their upper/lower bounds if the value passed is out of range.
+    // undefined is handled specially as per ECMA-262 6th Edition,
+    // Section 13.3.3.7 Runtime Semantics: KeyedBindingInitialization.
+    if (start === undefined || start < 0) {
+      start = 0
+    }
+    // Return early if start > this.length. Done here to prevent potential uint32
+    // coercion fail below.
+    if (start > this.length) {
+      return ''
+    }
+  
+    if (end === undefined || end > this.length) {
+      end = this.length
+    }
+  
+    if (end <= 0) {
+      return ''
+    }
+  
+    // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
+    end >>>= 0
+    start >>>= 0
+  
+    if (end <= start) {
+      return ''
+    }
+  
+    if (!encoding) encoding = 'utf8'
+  
+    while (true) {
+      switch (encoding) {
+        case 'hex':
+          return hexSlice(this, start, end)
+  
+        case 'utf8':
+        case 'utf-8':
+          return utf8Slice(this, start, end)
+  
+        case 'ascii':
+          return asciiSlice(this, start, end)
+  
+        case 'latin1':
+        case 'binary':
+          return latin1Slice(this, start, end)
+  
+        case 'base64':
+          return base64Slice(this, start, end)
+  
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return utf16leSlice(this, start, end)
+  
+        default:
+          if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+          encoding = (encoding + '').toLowerCase()
+          loweredCase = true
+      }
+    }
+  }
+  
+  // This property is used by `Buffer.isBuffer` (and the `is-buffer` npm package)
+  // to detect a Buffer instance. It's not possible to use `instanceof Buffer`
+  // reliably in a browserify context because there could be multiple different
+  // copies of the 'buffer' package in use. This method works even for Buffer
+  // instances that were created from another copy of the `buffer` package.
+  // See: https://github.com/feross/buffer/issues/154
+  Buffer.prototype._isBuffer = true
+  
+  function swap (b, n, m) {
+    var i = b[n]
+    b[n] = b[m]
+    b[m] = i
+  }
+  
+  Buffer.prototype.swap16 = function swap16 () {
+    var len = this.length
+    if (len % 2 !== 0) {
+      throw new RangeError('Buffer size must be a multiple of 16-bits')
+    }
+    for (var i = 0; i < len; i += 2) {
+      swap(this, i, i + 1)
+    }
+    return this
+  }
+  
+  Buffer.prototype.swap32 = function swap32 () {
+    var len = this.length
+    if (len % 4 !== 0) {
+      throw new RangeError('Buffer size must be a multiple of 32-bits')
+    }
+    for (var i = 0; i < len; i += 4) {
+      swap(this, i, i + 3)
+      swap(this, i + 1, i + 2)
+    }
+    return this
+  }
+  
+  Buffer.prototype.swap64 = function swap64 () {
+    var len = this.length
+    if (len % 8 !== 0) {
+      throw new RangeError('Buffer size must be a multiple of 64-bits')
+    }
+    for (var i = 0; i < len; i += 8) {
+      swap(this, i, i + 7)
+      swap(this, i + 1, i + 6)
+      swap(this, i + 2, i + 5)
+      swap(this, i + 3, i + 4)
+    }
+    return this
+  }
+  
+  Buffer.prototype.toString = function toString () {
+    var length = this.length
+    if (length === 0) return ''
+    if (arguments.length === 0) return utf8Slice(this, 0, length)
+    return slowToString.apply(this, arguments)
+  }
+  
+  Buffer.prototype.equals = function equals (b) {
+    if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+    if (this === b) return true
+    return Buffer.compare(this, b) === 0
+  }
+  
+  Buffer.prototype.inspect = function inspect () {
+    var str = ''
+    var max = exports.INSPECT_MAX_BYTES
+    if (this.length > 0) {
+      str = this.toString('hex', 0, max).match(/.{2}/g).join(' ')
+      if (this.length > max) str += ' ... '
+    }
+    return '<Buffer ' + str + '>'
+  }
+  
+  Buffer.prototype.compare = function compare (target, start, end, thisStart, thisEnd) {
+    if (!Buffer.isBuffer(target)) {
+      throw new TypeError('Argument must be a Buffer')
+    }
+  
+    if (start === undefined) {
+      start = 0
+    }
+    if (end === undefined) {
+      end = target ? target.length : 0
+    }
+    if (thisStart === undefined) {
+      thisStart = 0
+    }
+    if (thisEnd === undefined) {
+      thisEnd = this.length
+    }
+  
+    if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+      throw new RangeError('out of range index')
+    }
+  
+    if (thisStart >= thisEnd && start >= end) {
+      return 0
+    }
+    if (thisStart >= thisEnd) {
+      return -1
+    }
+    if (start >= end) {
+      return 1
+    }
+  
+    start >>>= 0
+    end >>>= 0
+    thisStart >>>= 0
+    thisEnd >>>= 0
+  
+    if (this === target) return 0
+  
+    var x = thisEnd - thisStart
+    var y = end - start
+    var len = Math.min(x, y)
+  
+    var thisCopy = this.slice(thisStart, thisEnd)
+    var targetCopy = target.slice(start, end)
+  
+    for (var i = 0; i < len; ++i) {
+      if (thisCopy[i] !== targetCopy[i]) {
+        x = thisCopy[i]
+        y = targetCopy[i]
+        break
+      }
+    }
+  
+    if (x < y) return -1
+    if (y < x) return 1
+    return 0
+  }
+  
+  // Finds either the first index of `val` in `buffer` at offset >= `byteOffset`,
+  // OR the last index of `val` in `buffer` at offset <= `byteOffset`.
+  //
+  // Arguments:
+  // - buffer - a Buffer to search
+  // - val - a string, Buffer, or number
+  // - byteOffset - an index into `buffer`; will be clamped to an int32
+  // - encoding - an optional encoding, relevant is val is a string
+  // - dir - true for indexOf, false for lastIndexOf
+  function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
+    // Empty buffer means no match
+    if (buffer.length === 0) return -1
+  
+    // Normalize byteOffset
+    if (typeof byteOffset === 'string') {
+      encoding = byteOffset
+      byteOffset = 0
+    } else if (byteOffset > 0x7fffffff) {
+      byteOffset = 0x7fffffff
+    } else if (byteOffset < -0x80000000) {
+      byteOffset = -0x80000000
+    }
+    byteOffset = +byteOffset  // Coerce to Number.
+    if (numberIsNaN(byteOffset)) {
+      // byteOffset: it it's undefined, null, NaN, "foo", etc, search whole buffer
+      byteOffset = dir ? 0 : (buffer.length - 1)
+    }
+  
+    // Normalize byteOffset: negative offsets start from the end of the buffer
+    if (byteOffset < 0) byteOffset = buffer.length + byteOffset
+    if (byteOffset >= buffer.length) {
+      if (dir) return -1
+      else byteOffset = buffer.length - 1
+    } else if (byteOffset < 0) {
+      if (dir) byteOffset = 0
+      else return -1
+    }
+  
+    // Normalize val
+    if (typeof val === 'string') {
+      val = Buffer.from(val, encoding)
+    }
+  
+    // Finally, search either indexOf (if dir is true) or lastIndexOf
+    if (Buffer.isBuffer(val)) {
+      // Special case: looking for empty string/buffer always fails
+      if (val.length === 0) {
+        return -1
+      }
+      return arrayIndexOf(buffer, val, byteOffset, encoding, dir)
+    } else if (typeof val === 'number') {
+      val = val & 0xFF // Search for a byte value [0-255]
+      if (typeof Uint8Array.prototype.indexOf === 'function') {
+        if (dir) {
+          return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset)
+        } else {
+          return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset)
+        }
+      }
+      return arrayIndexOf(buffer, [ val ], byteOffset, encoding, dir)
+    }
+  
+    throw new TypeError('val must be string, number or Buffer')
+  }
+  
+  function arrayIndexOf (arr, val, byteOffset, encoding, dir) {
+    var indexSize = 1
+    var arrLength = arr.length
+    var valLength = val.length
+  
+    if (encoding !== undefined) {
+      encoding = String(encoding).toLowerCase()
+      if (encoding === 'ucs2' || encoding === 'ucs-2' ||
+          encoding === 'utf16le' || encoding === 'utf-16le') {
+        if (arr.length < 2 || val.length < 2) {
+          return -1
+        }
+        indexSize = 2
+        arrLength /= 2
+        valLength /= 2
+        byteOffset /= 2
+      }
+    }
+  
+    function read (buf, i) {
+      if (indexSize === 1) {
+        return buf[i]
+      } else {
+        return buf.readUInt16BE(i * indexSize)
+      }
+    }
+  
+    var i
+    if (dir) {
+      var foundIndex = -1
+      for (i = byteOffset; i < arrLength; i++) {
+        if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+          if (foundIndex === -1) foundIndex = i
+          if (i - foundIndex + 1 === valLength) return foundIndex * indexSize
+        } else {
+          if (foundIndex !== -1) i -= i - foundIndex
+          foundIndex = -1
+        }
+      }
+    } else {
+      if (byteOffset + valLength > arrLength) byteOffset = arrLength - valLength
+      for (i = byteOffset; i >= 0; i--) {
+        var found = true
+        for (var j = 0; j < valLength; j++) {
+          if (read(arr, i + j) !== read(val, j)) {
+            found = false
+            break
+          }
+        }
+        if (found) return i
+      }
+    }
+  
+    return -1
+  }
+  
+  Buffer.prototype.includes = function includes (val, byteOffset, encoding) {
+    return this.indexOf(val, byteOffset, encoding) !== -1
+  }
+  
+  Buffer.prototype.indexOf = function indexOf (val, byteOffset, encoding) {
+    return bidirectionalIndexOf(this, val, byteOffset, encoding, true)
+  }
+  
+  Buffer.prototype.lastIndexOf = function lastIndexOf (val, byteOffset, encoding) {
+    return bidirectionalIndexOf(this, val, byteOffset, encoding, false)
+  }
+  
+  function hexWrite (buf, string, offset, length) {
+    offset = Number(offset) || 0
+    var remaining = buf.length - offset
+    if (!length) {
+      length = remaining
+    } else {
+      length = Number(length)
+      if (length > remaining) {
+        length = remaining
+      }
+    }
+  
+    // must be an even number of digits
+    var strLen = string.length
+    if (strLen % 2 !== 0) throw new TypeError('Invalid hex string')
+  
+    if (length > strLen / 2) {
+      length = strLen / 2
+    }
+    for (var i = 0; i < length; ++i) {
+      var parsed = parseInt(string.substr(i * 2, 2), 16)
+      if (numberIsNaN(parsed)) return i
+      buf[offset + i] = parsed
+    }
+    return i
+  }
+  
+  function utf8Write (buf, string, offset, length) {
+    return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length)
+  }
+  
+  function asciiWrite (buf, string, offset, length) {
+    return blitBuffer(asciiToBytes(string), buf, offset, length)
+  }
+  
+  function latin1Write (buf, string, offset, length) {
+    return asciiWrite(buf, string, offset, length)
+  }
+  
+  function base64Write (buf, string, offset, length) {
+    return blitBuffer(base64ToBytes(string), buf, offset, length)
+  }
+  
+  function ucs2Write (buf, string, offset, length) {
+    return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length)
+  }
+  
+  Buffer.prototype.write = function write (string, offset, length, encoding) {
+    // Buffer#write(string)
+    if (offset === undefined) {
+      encoding = 'utf8'
+      length = this.length
+      offset = 0
+    // Buffer#write(string, encoding)
+    } else if (length === undefined && typeof offset === 'string') {
+      encoding = offset
+      length = this.length
+      offset = 0
+    // Buffer#write(string, offset[, length][, encoding])
+    } else if (isFinite(offset)) {
+      offset = offset >>> 0
+      if (isFinite(length)) {
+        length = length >>> 0
+        if (encoding === undefined) encoding = 'utf8'
+      } else {
+        encoding = length
+        length = undefined
+      }
+    } else {
+      throw new Error(
+        'Buffer.write(string, encoding, offset[, length]) is no longer supported'
+      )
+    }
+  
+    var remaining = this.length - offset
+    if (length === undefined || length > remaining) length = remaining
+  
+    if ((string.length > 0 && (length < 0 || offset < 0)) || offset > this.length) {
+      throw new RangeError('Attempt to write outside buffer bounds')
+    }
+  
+    if (!encoding) encoding = 'utf8'
+  
+    var loweredCase = false
+    for (;;) {
+      switch (encoding) {
+        case 'hex':
+          return hexWrite(this, string, offset, length)
+  
+        case 'utf8':
+        case 'utf-8':
+          return utf8Write(this, string, offset, length)
+  
+        case 'ascii':
+          return asciiWrite(this, string, offset, length)
+  
+        case 'latin1':
+        case 'binary':
+          return latin1Write(this, string, offset, length)
+  
+        case 'base64':
+          // Warning: maxLength not taken into account in base64Write
+          return base64Write(this, string, offset, length)
+  
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return ucs2Write(this, string, offset, length)
+  
+        default:
+          if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+          encoding = ('' + encoding).toLowerCase()
+          loweredCase = true
+      }
+    }
+  }
+  
+  Buffer.prototype.toJSON = function toJSON () {
+    return {
+      type: 'Buffer',
+      data: Array.prototype.slice.call(this._arr || this, 0)
+    }
+  }
+  
+  function base64Slice (buf, start, end) {
+    if (start === 0 && end === buf.length) {
+      return base64.fromByteArray(buf)
+    } else {
+      return base64.fromByteArray(buf.slice(start, end))
+    }
+  }
+  
+  function utf8Slice (buf, start, end) {
+    end = Math.min(buf.length, end)
+    var res = []
+  
+    var i = start
+    while (i < end) {
+      var firstByte = buf[i]
+      var codePoint = null
+      var bytesPerSequence = (firstByte > 0xEF) ? 4
+        : (firstByte > 0xDF) ? 3
+        : (firstByte > 0xBF) ? 2
+        : 1
+  
+      if (i + bytesPerSequence <= end) {
+        var secondByte, thirdByte, fourthByte, tempCodePoint
+  
+        switch (bytesPerSequence) {
+          case 1:
+            if (firstByte < 0x80) {
+              codePoint = firstByte
+            }
+            break
+          case 2:
+            secondByte = buf[i + 1]
+            if ((secondByte & 0xC0) === 0x80) {
+              tempCodePoint = (firstByte & 0x1F) << 0x6 | (secondByte & 0x3F)
+              if (tempCodePoint > 0x7F) {
+                codePoint = tempCodePoint
+              }
+            }
+            break
+          case 3:
+            secondByte = buf[i + 1]
+            thirdByte = buf[i + 2]
+            if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80) {
+              tempCodePoint = (firstByte & 0xF) << 0xC | (secondByte & 0x3F) << 0x6 | (thirdByte & 0x3F)
+              if (tempCodePoint > 0x7FF && (tempCodePoint < 0xD800 || tempCodePoint > 0xDFFF)) {
+                codePoint = tempCodePoint
+              }
+            }
+            break
+          case 4:
+            secondByte = buf[i + 1]
+            thirdByte = buf[i + 2]
+            fourthByte = buf[i + 3]
+            if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80 && (fourthByte & 0xC0) === 0x80) {
+              tempCodePoint = (firstByte & 0xF) << 0x12 | (secondByte & 0x3F) << 0xC | (thirdByte & 0x3F) << 0x6 | (fourthByte & 0x3F)
+              if (tempCodePoint > 0xFFFF && tempCodePoint < 0x110000) {
+                codePoint = tempCodePoint
+              }
+            }
+        }
+      }
+  
+      if (codePoint === null) {
+        // we did not generate a valid codePoint so insert a
+        // replacement char (U+FFFD) and advance only 1 byte
+        codePoint = 0xFFFD
+        bytesPerSequence = 1
+      } else if (codePoint > 0xFFFF) {
+        // encode to utf16 (surrogate pair dance)
+        codePoint -= 0x10000
+        res.push(codePoint >>> 10 & 0x3FF | 0xD800)
+        codePoint = 0xDC00 | codePoint & 0x3FF
+      }
+  
+      res.push(codePoint)
+      i += bytesPerSequence
+    }
+  
+    return decodeCodePointsArray(res)
+  }
+  
+  // Based on http://stackoverflow.com/a/22747272/680742, the browser with
+  // the lowest limit is Chrome, with 0x10000 args.
+  // We go 1 magnitude less, for safety
+  var MAX_ARGUMENTS_LENGTH = 0x1000
+  
+  function decodeCodePointsArray (codePoints) {
+    var len = codePoints.length
+    if (len <= MAX_ARGUMENTS_LENGTH) {
+      return String.fromCharCode.apply(String, codePoints) // avoid extra slice()
+    }
+  
+    // Decode in chunks to avoid "call stack size exceeded".
+    var res = ''
+    var i = 0
+    while (i < len) {
+      res += String.fromCharCode.apply(
+        String,
+        codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH)
+      )
+    }
+    return res
+  }
+  
+  function asciiSlice (buf, start, end) {
+    var ret = ''
+    end = Math.min(buf.length, end)
+  
+    for (var i = start; i < end; ++i) {
+      ret += String.fromCharCode(buf[i] & 0x7F)
+    }
+    return ret
+  }
+  
+  function latin1Slice (buf, start, end) {
+    var ret = ''
+    end = Math.min(buf.length, end)
+  
+    for (var i = start; i < end; ++i) {
+      ret += String.fromCharCode(buf[i])
+    }
+    return ret
+  }
+  
+  function hexSlice (buf, start, end) {
+    var len = buf.length
+  
+    if (!start || start < 0) start = 0
+    if (!end || end < 0 || end > len) end = len
+  
+    var out = ''
+    for (var i = start; i < end; ++i) {
+      out += toHex(buf[i])
+    }
+    return out
+  }
+  
+  function utf16leSlice (buf, start, end) {
+    var bytes = buf.slice(start, end)
+    var res = ''
+    for (var i = 0; i < bytes.length; i += 2) {
+      res += String.fromCharCode(bytes[i] + (bytes[i + 1] * 256))
+    }
+    return res
+  }
+  
+  Buffer.prototype.slice = function slice (start, end) {
+    var len = this.length
+    start = ~~start
+    end = end === undefined ? len : ~~end
+  
+    if (start < 0) {
+      start += len
+      if (start < 0) start = 0
+    } else if (start > len) {
+      start = len
+    }
+  
+    if (end < 0) {
+      end += len
+      if (end < 0) end = 0
+    } else if (end > len) {
+      end = len
+    }
+  
+    if (end < start) end = start
+  
+    var newBuf = this.subarray(start, end)
+    // Return an augmented `Uint8Array` instance
+    newBuf.__proto__ = Buffer.prototype
+    return newBuf
+  }
+  
+  /*
+   * Need to make sure that buffer isn't trying to write out of bounds.
+   */
+  function checkOffset (offset, ext, length) {
+    if ((offset % 1) !== 0 || offset < 0) throw new RangeError('offset is not uint')
+    if (offset + ext > length) throw new RangeError('Trying to access beyond buffer length')
+  }
+  
+  Buffer.prototype.readUIntLE = function readUIntLE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+  
+    var val = this[offset]
+    var mul = 1
+    var i = 0
+    while (++i < byteLength && (mul *= 0x100)) {
+      val += this[offset + i] * mul
+    }
+  
+    return val
+  }
+  
+  Buffer.prototype.readUIntBE = function readUIntBE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+      checkOffset(offset, byteLength, this.length)
+    }
+  
+    var val = this[offset + --byteLength]
+    var mul = 1
+    while (byteLength > 0 && (mul *= 0x100)) {
+      val += this[offset + --byteLength] * mul
+    }
+  
+    return val
+  }
+  
+  Buffer.prototype.readUInt8 = function readUInt8 (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 1, this.length)
+    return this[offset]
+  }
+  
+  Buffer.prototype.readUInt16LE = function readUInt16LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    return this[offset] | (this[offset + 1] << 8)
+  }
+  
+  Buffer.prototype.readUInt16BE = function readUInt16BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    return (this[offset] << 8) | this[offset + 1]
+  }
+  
+  Buffer.prototype.readUInt32LE = function readUInt32LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return ((this[offset]) |
+        (this[offset + 1] << 8) |
+        (this[offset + 2] << 16)) +
+        (this[offset + 3] * 0x1000000)
+  }
+  
+  Buffer.prototype.readUInt32BE = function readUInt32BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return (this[offset] * 0x1000000) +
+      ((this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      this[offset + 3])
+  }
+  
+  Buffer.prototype.readIntLE = function readIntLE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+  
+    var val = this[offset]
+    var mul = 1
+    var i = 0
+    while (++i < byteLength && (mul *= 0x100)) {
+      val += this[offset + i] * mul
+    }
+    mul *= 0x80
+  
+    if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+  
+    return val
+  }
+  
+  Buffer.prototype.readIntBE = function readIntBE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+  
+    var i = byteLength
+    var mul = 1
+    var val = this[offset + --i]
+    while (i > 0 && (mul *= 0x100)) {
+      val += this[offset + --i] * mul
+    }
+    mul *= 0x80
+  
+    if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+  
+    return val
+  }
+  
+  Buffer.prototype.readInt8 = function readInt8 (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 1, this.length)
+    if (!(this[offset] & 0x80)) return (this[offset])
+    return ((0xff - this[offset] + 1) * -1)
+  }
+  
+  Buffer.prototype.readInt16LE = function readInt16LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    var val = this[offset] | (this[offset + 1] << 8)
+    return (val & 0x8000) ? val | 0xFFFF0000 : val
+  }
+  
+  Buffer.prototype.readInt16BE = function readInt16BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    var val = this[offset + 1] | (this[offset] << 8)
+    return (val & 0x8000) ? val | 0xFFFF0000 : val
+  }
+  
+  Buffer.prototype.readInt32LE = function readInt32LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return (this[offset]) |
+      (this[offset + 1] << 8) |
+      (this[offset + 2] << 16) |
+      (this[offset + 3] << 24)
+  }
+  
+  Buffer.prototype.readInt32BE = function readInt32BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+  
+    return (this[offset] << 24) |
+      (this[offset + 1] << 16) |
+      (this[offset + 2] << 8) |
+      (this[offset + 3])
+  }
+  
+  Buffer.prototype.readFloatLE = function readFloatLE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+    return ieee754.read(this, offset, true, 23, 4)
+  }
+  
+  Buffer.prototype.readFloatBE = function readFloatBE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+    return ieee754.read(this, offset, false, 23, 4)
+  }
+  
+  Buffer.prototype.readDoubleLE = function readDoubleLE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 8, this.length)
+    return ieee754.read(this, offset, true, 52, 8)
+  }
+  
+  Buffer.prototype.readDoubleBE = function readDoubleBE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 8, this.length)
+    return ieee754.read(this, offset, false, 52, 8)
+  }
+  
+  function checkInt (buf, value, offset, ext, max, min) {
+    if (!Buffer.isBuffer(buf)) throw new TypeError('"buffer" argument must be a Buffer instance')
+    if (value > max || value < min) throw new RangeError('"value" argument is out of bounds')
+    if (offset + ext > buf.length) throw new RangeError('Index out of range')
+  }
+  
+  Buffer.prototype.writeUIntLE = function writeUIntLE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+      var maxBytes = Math.pow(2, 8 * byteLength) - 1
+      checkInt(this, value, offset, byteLength, maxBytes, 0)
+    }
+  
+    var mul = 1
+    var i = 0
+    this[offset] = value & 0xFF
+    while (++i < byteLength && (mul *= 0x100)) {
+      this[offset + i] = (value / mul) & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeUIntBE = function writeUIntBE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+      var maxBytes = Math.pow(2, 8 * byteLength) - 1
+      checkInt(this, value, offset, byteLength, maxBytes, 0)
+    }
+  
+    var i = byteLength - 1
+    var mul = 1
+    this[offset + i] = value & 0xFF
+    while (--i >= 0 && (mul *= 0x100)) {
+      this[offset + i] = (value / mul) & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeUInt8 = function writeUInt8 (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 1, 0xff, 0)
+    this[offset] = (value & 0xff)
+    return offset + 1
+  }
+  
+  Buffer.prototype.writeUInt16LE = function writeUInt16LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeUInt16BE = function writeUInt16BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeUInt32LE = function writeUInt32LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+    this[offset + 3] = (value >>> 24)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 1] = (value >>> 8)
+    this[offset] = (value & 0xff)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeUInt32BE = function writeUInt32BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeIntLE = function writeIntLE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      var limit = Math.pow(2, (8 * byteLength) - 1)
+  
+      checkInt(this, value, offset, byteLength, limit - 1, -limit)
+    }
+  
+    var i = 0
+    var mul = 1
+    var sub = 0
+    this[offset] = value & 0xFF
+    while (++i < byteLength && (mul *= 0x100)) {
+      if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+        sub = 1
+      }
+      this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeIntBE = function writeIntBE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      var limit = Math.pow(2, (8 * byteLength) - 1)
+  
+      checkInt(this, value, offset, byteLength, limit - 1, -limit)
+    }
+  
+    var i = byteLength - 1
+    var mul = 1
+    var sub = 0
+    this[offset + i] = value & 0xFF
+    while (--i >= 0 && (mul *= 0x100)) {
+      if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+        sub = 1
+      }
+      this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+    }
+  
+    return offset + byteLength
+  }
+  
+  Buffer.prototype.writeInt8 = function writeInt8 (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 1, 0x7f, -0x80)
+    if (value < 0) value = 0xff + value + 1
+    this[offset] = (value & 0xff)
+    return offset + 1
+  }
+  
+  Buffer.prototype.writeInt16LE = function writeInt16LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeInt16BE = function writeInt16BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+    return offset + 2
+  }
+  
+  Buffer.prototype.writeInt32LE = function writeInt32LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 3] = (value >>> 24)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeInt32BE = function writeInt32BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+    if (value < 0) value = 0xffffffff + value + 1
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+    return offset + 4
+  }
+  
+  function checkIEEE754 (buf, value, offset, ext, max, min) {
+    if (offset + ext > buf.length) throw new RangeError('Index out of range')
+    if (offset < 0) throw new RangeError('Index out of range')
+  }
+  
+  function writeFloat (buf, value, offset, littleEndian, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      checkIEEE754(buf, value, offset, 4, 3.4028234663852886e+38, -3.4028234663852886e+38)
+    }
+    ieee754.write(buf, value, offset, littleEndian, 23, 4)
+    return offset + 4
+  }
+  
+  Buffer.prototype.writeFloatLE = function writeFloatLE (value, offset, noAssert) {
+    return writeFloat(this, value, offset, true, noAssert)
+  }
+  
+  Buffer.prototype.writeFloatBE = function writeFloatBE (value, offset, noAssert) {
+    return writeFloat(this, value, offset, false, noAssert)
+  }
+  
+  function writeDouble (buf, value, offset, littleEndian, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+      checkIEEE754(buf, value, offset, 8, 1.7976931348623157E+308, -1.7976931348623157E+308)
+    }
+    ieee754.write(buf, value, offset, littleEndian, 52, 8)
+    return offset + 8
+  }
+  
+  Buffer.prototype.writeDoubleLE = function writeDoubleLE (value, offset, noAssert) {
+    return writeDouble(this, value, offset, true, noAssert)
+  }
+  
+  Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert) {
+    return writeDouble(this, value, offset, false, noAssert)
+  }
+  
+  // copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
+  Buffer.prototype.copy = function copy (target, targetStart, start, end) {
+    if (!start) start = 0
+    if (!end && end !== 0) end = this.length
+    if (targetStart >= target.length) targetStart = target.length
+    if (!targetStart) targetStart = 0
+    if (end > 0 && end < start) end = start
+  
+    // Copy 0 bytes; we're done
+    if (end === start) return 0
+    if (target.length === 0 || this.length === 0) return 0
+  
+    // Fatal error conditions
+    if (targetStart < 0) {
+      throw new RangeError('targetStart out of bounds')
+    }
+    if (start < 0 || start >= this.length) throw new RangeError('sourceStart out of bounds')
+    if (end < 0) throw new RangeError('sourceEnd out of bounds')
+  
+    // Are we oob?
+    if (end > this.length) end = this.length
+    if (target.length - targetStart < end - start) {
+      end = target.length - targetStart + start
+    }
+  
+    var len = end - start
+    var i
+  
+    if (this === target && start < targetStart && targetStart < end) {
+      // descending copy from end
+      for (i = len - 1; i >= 0; --i) {
+        target[i + targetStart] = this[i + start]
+      }
+    } else if (len < 1000) {
+      // ascending copy from start
+      for (i = 0; i < len; ++i) {
+        target[i + targetStart] = this[i + start]
+      }
+    } else {
+      Uint8Array.prototype.set.call(
+        target,
+        this.subarray(start, start + len),
+        targetStart
+      )
+    }
+  
+    return len
+  }
+  
+  // Usage:
+  //    buffer.fill(number[, offset[, end]])
+  //    buffer.fill(buffer[, offset[, end]])
+  //    buffer.fill(string[, offset[, end]][, encoding])
+  Buffer.prototype.fill = function fill (val, start, end, encoding) {
+    // Handle string cases:
+    if (typeof val === 'string') {
+      if (typeof start === 'string') {
+        encoding = start
+        start = 0
+        end = this.length
+      } else if (typeof end === 'string') {
+        encoding = end
+        end = this.length
+      }
+      if (val.length === 1) {
+        var code = val.charCodeAt(0)
+        if (code < 256) {
+          val = code
+        }
+      }
+      if (encoding !== undefined && typeof encoding !== 'string') {
+        throw new TypeError('encoding must be a string')
+      }
+      if (typeof encoding === 'string' && !Buffer.isEncoding(encoding)) {
+        throw new TypeError('Unknown encoding: ' + encoding)
+      }
+    } else if (typeof val === 'number') {
+      val = val & 255
+    }
+  
+    // Invalid ranges are not set to a default, so can range check early.
+    if (start < 0 || this.length < start || this.length < end) {
+      throw new RangeError('Out of range index')
+    }
+  
+    if (end <= start) {
+      return this
+    }
+  
+    start = start >>> 0
+    end = end === undefined ? this.length : end >>> 0
+  
+    if (!val) val = 0
+  
+    var i
+    if (typeof val === 'number') {
+      for (i = start; i < end; ++i) {
+        this[i] = val
+      }
+    } else {
+      var bytes = Buffer.isBuffer(val)
+        ? val
+        : new Buffer(val, encoding)
+      var len = bytes.length
+      for (i = 0; i < end - start; ++i) {
+        this[i + start] = bytes[i % len]
+      }
+    }
+  
+    return this
+  }
+  
+  // HELPER FUNCTIONS
+  // ================
+  
+  var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g
+  
+  function base64clean (str) {
+    // Node strips out invalid characters like \n and \t from the string, base64-js does not
+    str = str.trim().replace(INVALID_BASE64_RE, '')
+    // Node converts strings with length < 2 to ''
+    if (str.length < 2) return ''
+    // Node allows for non-padded base64 strings (missing trailing ===), base64-js does not
+    while (str.length % 4 !== 0) {
+      str = str + '='
+    }
+    return str
+  }
+  
+  function toHex (n) {
+    if (n < 16) return '0' + n.toString(16)
+    return n.toString(16)
+  }
+  
+  function utf8ToBytes (string, units) {
+    units = units || Infinity
+    var codePoint
+    var length = string.length
+    var leadSurrogate = null
+    var bytes = []
+  
+    for (var i = 0; i < length; ++i) {
+      codePoint = string.charCodeAt(i)
+  
+      // is surrogate component
+      if (codePoint > 0xD7FF && codePoint < 0xE000) {
+        // last char was a lead
+        if (!leadSurrogate) {
+          // no lead yet
+          if (codePoint > 0xDBFF) {
+            // unexpected trail
+            if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+            continue
+          } else if (i + 1 === length) {
+            // unpaired lead
+            if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+            continue
+          }
+  
+          // valid lead
+          leadSurrogate = codePoint
+  
+          continue
+        }
+  
+        // 2 leads in a row
+        if (codePoint < 0xDC00) {
+          if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+          leadSurrogate = codePoint
+          continue
+        }
+  
+        // valid surrogate pair
+        codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000
+      } else if (leadSurrogate) {
+        // valid bmp char, but last char was a lead
+        if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+      }
+  
+      leadSurrogate = null
+  
+      // encode utf8
+      if (codePoint < 0x80) {
+        if ((units -= 1) < 0) break
+        bytes.push(codePoint)
+      } else if (codePoint < 0x800) {
+        if ((units -= 2) < 0) break
+        bytes.push(
+          codePoint >> 0x6 | 0xC0,
+          codePoint & 0x3F | 0x80
+        )
+      } else if (codePoint < 0x10000) {
+        if ((units -= 3) < 0) break
+        bytes.push(
+          codePoint >> 0xC | 0xE0,
+          codePoint >> 0x6 & 0x3F | 0x80,
+          codePoint & 0x3F | 0x80
+        )
+      } else if (codePoint < 0x110000) {
+        if ((units -= 4) < 0) break
+        bytes.push(
+          codePoint >> 0x12 | 0xF0,
+          codePoint >> 0xC & 0x3F | 0x80,
+          codePoint >> 0x6 & 0x3F | 0x80,
+          codePoint & 0x3F | 0x80
+        )
+      } else {
+        throw new Error('Invalid code point')
+      }
+    }
+  
+    return bytes
+  }
+  
+  function asciiToBytes (str) {
+    var byteArray = []
+    for (var i = 0; i < str.length; ++i) {
+      // Node's code seems to be doing this and not & 0x7F..
+      byteArray.push(str.charCodeAt(i) & 0xFF)
+    }
+    return byteArray
+  }
+  
+  function utf16leToBytes (str, units) {
+    var c, hi, lo
+    var byteArray = []
+    for (var i = 0; i < str.length; ++i) {
+      if ((units -= 2) < 0) break
+  
+      c = str.charCodeAt(i)
+      hi = c >> 8
+      lo = c % 256
+      byteArray.push(lo)
+      byteArray.push(hi)
+    }
+  
+    return byteArray
+  }
+  
+  function base64ToBytes (str) {
+    return base64.toByteArray(base64clean(str))
+  }
+  
+  function blitBuffer (src, dst, offset, length) {
+    for (var i = 0; i < length; ++i) {
+      if ((i + offset >= dst.length) || (i >= src.length)) break
+      dst[i + offset] = src[i]
+    }
+    return i
+  }
+  
+  // ArrayBuffers from another context (i.e. an iframe) do not pass the `instanceof` check
+  // but they should be treated as valid. See: https://github.com/feross/buffer/issues/166
+  function isArrayBuffer (obj) {
+    return obj instanceof ArrayBuffer ||
+      (obj != null && obj.constructor != null && obj.constructor.name === 'ArrayBuffer' &&
+        typeof obj.byteLength === 'number')
+  }
+  
+  // Node 0.10 supports `ArrayBuffer` but lacks `ArrayBuffer.isView`
+  function isArrayBufferView (obj) {
+    return (typeof ArrayBuffer.isView === 'function') && ArrayBuffer.isView(obj)
+  }
+  
+  function numberIsNaN (obj) {
+    return obj !== obj // eslint-disable-line no-self-compare
+  }
+  
+  },{"base64-js":2,"ieee754":20}],9:[function(require,module,exports){
+  /**
+   * @license
+   * https://github.com/bitcoincashjs/cashaddr
+   * Copyright (c) 2017-2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  'use strict';
+  
+  var validate = require('./validation').validate;
+  
+  /**
+   * Base32 encoding and decoding.
+   *
+   * @module base32
+   */
+  
+  /**
+   * Charset containing the 32 symbols used in the base32 encoding.
+   * @private
+   */
+  var CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  
+  /**
+   * Inverted index mapping each symbol into its index within the charset.
+   * @private
+   */
+  var CHARSET_INVERSE_INDEX = {
+    'q': 0, 'p': 1, 'z': 2, 'r': 3, 'y': 4, '9': 5, 'x': 6, '8': 7,
+    'g': 8, 'f': 9, '2': 10, 't': 11, 'v': 12, 'd': 13, 'w': 14, '0': 15,
+    's': 16, '3': 17, 'j': 18, 'n': 19, '5': 20, '4': 21, 'k': 22, 'h': 23,
+    'c': 24, 'e': 25, '6': 26, 'm': 27, 'u': 28, 'a': 29, '7': 30, 'l': 31,
+  };
+  
+  /**
+   * Encodes the given array of 5-bit integers as a base32-encoded string.
+   *
+   * @static
+   * @param {Uint8Array} data Array of integers between 0 and 31 inclusive.
+   * @returns {string}
+   * @throws {ValidationError}
+   */
+  function encode(data) {
+    validate(data instanceof Uint8Array, 'Invalid data: ' + data + '.');
+    var base32 = '';
+    for (var i = 0; i < data.length; ++i) {
+      var value = data[i];
+      validate(0 <= value && value < 32, 'Invalid value: ' + value + '.');
+      base32 += CHARSET[value];
+    }
+    return base32;
+  }
+  
+  /**
+   * Decodes the given base32-encoded string into an array of 5-bit integers.
+   *
+   * @static
+   * @param {string} string
+   * @returns {Uint8Array}
+   * @throws {ValidationError}
+   */
+  function decode(string) {
+    validate(typeof string === 'string', 'Invalid base32-encoded string: ' + string + '.');
+    var data = new Uint8Array(string.length);
+    for (var i = 0; i < string.length; ++i) {
+      var value = string[i];
+      validate(value in CHARSET_INVERSE_INDEX, 'Invalid value: ' + value + '.');
+      data[i] = CHARSET_INVERSE_INDEX[value];
+    }
+    return data;
+  }
+  
+  module.exports = {
+    encode: encode,
+    decode: decode,
+  };
+  
+  },{"./validation":12}],10:[function(require,module,exports){
+  /**
+   * @license
+   * https://github.com/bitcoincashjs/cashaddr
+   * Copyright (c) 2017-2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  'use strict';
+  
+  var base32 = require('./base32');
+  var bigInt = require('big-integer');
+  var convertBits = require('./convertBits');
+  var validation = require('./validation');
+  var validate = validation.validate;
+  
+  /**
+   * Encoding and decoding of the new Cash Address format for Bitcoin Cash. <br />
+   * Compliant with the original cashaddr specification:
+   * {@link https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md}
+   * @module cashaddr
+   */
+  
+  /**
+   * Encodes a hash from a given type into a Bitcoin Cash address with the given prefix.
+   * 
+   * @static
+   * @param {string} prefix Network prefix. E.g.: 'bitcoincash'.
+   * @param {string} type Type of address to generate. Either 'P2PKH' or 'P2SH'.
+   * @param {Uint8Array} hash Hash to encode represented as an array of 8-bit integers.
+   * @returns {string}
+   * @throws {ValidationError}
+   */
+  function encode(prefix, type, hash) {
+    validate(typeof prefix === 'string' && isValidPrefix(prefix), 'Invalid prefix: ' + prefix + '.');
+    validate(typeof type === 'string', 'Invalid type: ' + type + '.');
+    validate(hash instanceof Uint8Array, 'Invalid hash: ' + hash + '.');
+    var prefixData = concat(prefixToUint5Array(prefix), new Uint8Array(1));
+    var versionByte = getTypeBits(type) + getHashSizeBits(hash);
+    var payloadData = toUint5Array(concat(Uint8Array.of(versionByte), hash));
+    var checksumData = concat(concat(prefixData, payloadData), new Uint8Array(8));
+    var payload = concat(payloadData, checksumToUint5Array(polymod(checksumData)));
+    return prefix + ':' + base32.encode(payload);
+  }
+  
+  /**
+   * Decodes the given address into its constituting prefix, type and hash. See [#encode()]{@link encode}.
+   * 
+   * @static
+   * @param {string} address Address to decode. E.g.: 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a'.
+   * @returns {object}
+   * @throws {ValidationError}
+   */
+  function decode(address) {
+    validate(typeof address === 'string' && hasSingleCase(address), 'Invalid address: ' + address + '.');
+    var pieces = address.toLowerCase().split(':');
+    validate(pieces.length === 2, 'Missing prefix: ' + address + '.');
+    var prefix = pieces[0];
+    var payload = base32.decode(pieces[1]);
+    validate(validChecksum(prefix, payload), 'Invalid checksum: ' + address + '.');
+    var payloadData = fromUint5Array(payload.slice(0, -8));
+    var versionByte = payloadData[0];
+    var hash = payloadData.slice(1);
+    validate(getHashSize(versionByte) === hash.length * 8, 'Invalid hash size: ' + address + '.');
+    var type = getType(versionByte);
+    return {
+      prefix: prefix,
+      type: type,
+      hash: hash,
+    };
+  }
+  
+  /**
+   * Error thrown when encoding or decoding fail due to invalid input.
+   *
+   * @constructor ValidationError
+   * @param {string} message Error description.
+   */
+  var ValidationError = validation.ValidationError;
+  
+  /**
+   * Valid address prefixes.
+   *
+   * @private
+   */
+  var VALID_PREFIXES = ['bitcoincash', 'bchtest', 'bchreg'];
+  
+  /**
+   * Checks whether a string is a valid prefix; ie., it has a single letter case
+   * and is one of 'bitcoincash', 'bchtest', or 'bchreg'.
+   *
+   * @private
+   * @param {string} prefix 
+   * @returns {boolean}
+   */
+  function isValidPrefix(prefix) {
+    return hasSingleCase(prefix) && VALID_PREFIXES.indexOf(prefix.toLowerCase()) !== -1;
+  }
+  
+  /**
+   * Derives an array from the given prefix to be used in the computation
+   * of the address' checksum.
+   *
+   * @private
+   * @param {string} prefix Network prefix. E.g.: 'bitcoincash'. 
+   * @returns {Uint8Array}
+   */
+  function prefixToUint5Array(prefix) {
+    var result = new Uint8Array(prefix.length);
+    for (var i = 0; i < prefix.length; ++i) {
+      result[i] = prefix[i].charCodeAt(0) & 31;
+    }
+    return result;
+  }
+  
+  /**
+   * Returns an array representation of the given checksum to be encoded
+   * within the address' payload.
+   *
+   * @private
+   * @param {BigInteger} checksum Computed checksum.
+   * @returns {Uint8Array}
+   */
+  function checksumToUint5Array(checksum) {
+    var result = new Uint8Array(8);
+    for (var i = 0; i < 8; ++i) {
+      result[7 - i] = checksum.and(31).toJSNumber();
+      checksum = checksum.shiftRight(5);
+    }
+    return result;
+  }
+  
+  /**
+   * Returns the bit representation of the given type within the version
+   * byte.
+   *
+   * @private
+   * @param {string} type Address type. Either 'P2PKH' or 'P2SH'.
+   * @returns {number}
+   * @throws {ValidationError}
+   */
+  function getTypeBits(type) {
+    switch (type) {
+    case 'P2PKH':
+      return 0;
+    case 'P2SH':
+      return 8;
+    default:
+      throw new ValidationError('Invalid type: ' + type + '.');
+    }
+  }
+  
+  /**
+   * Retrieves the address type from its bit representation within the
+   * version byte.
+   *
+   * @private
+   * @param {number} versionByte
+   * @returns {string}
+   * @throws {ValidationError}
+   */
+  function getType(versionByte) {
+    switch (versionByte & 120) {
+    case 0:
+      return 'P2PKH';
+    case 8:
+      return 'P2SH';
+    default:
+      throw new ValidationError('Invalid address type in version byte: ' + versionByte + '.');
+    }
+  }
+  
+  /**
+   * Returns the bit representation of the length in bits of the given
+   * hash within the version byte.
+   *
+   * @private
+   * @param {Uint8Array} hash Hash to encode represented as an array of 8-bit integers.
+   * @returns {number}
+   * @throws {ValidationError}
+   */
+  function getHashSizeBits(hash) {
+    switch (hash.length * 8) {
+    case 160:
+      return 0;
+    case 192:
+      return 1;
+    case 224:
+      return 2;
+    case 256:
+      return 3;
+    case 320:
+      return 4;
+    case 384:
+      return 5;
+    case 448:
+      return 6;
+    case 512:
+      return 7;
+    default:
+      throw new ValidationError('Invalid hash size: ' + hash.length + '.');
+    }
+  }
+  
+  /**
+   * Retrieves the the length in bits of the encoded hash from its bit
+   * representation within the version byte.
+   *
+   * @private
+   * @param {number} versionByte
+   * @returns {number}
+   */
+  function getHashSize(versionByte) {
+    switch (versionByte & 7) {
+    case 0:
+      return 160;
+    case 1:
+      return 192;
+    case 2:
+      return 224;
+    case 3:
+      return 256;
+    case 4:
+      return 320;
+    case 5:
+      return 384;
+    case 6:
+      return 448;
+    case 7:
+      return 512;
+    }
+  }
+  
+  /**
+   * Converts an array of 8-bit integers into an array of 5-bit integers,
+   * right-padding with zeroes if necessary.
+   *
+   * @private
+   * @param {Uint8Array} data
+   * @returns {Uint8Array}
+   */
+  function toUint5Array(data) {
+    return convertBits(data, 8, 5);
+  }
+  
+  /**
+   * Converts an array of 5-bit integers back into an array of 8-bit integers,
+   * removing extra zeroes left from padding if necessary.
+   * Throws a {@link ValidationError} if input is not a zero-padded array of 8-bit integers.
+   *
+   * @private
+   * @param {Uint8Array} data
+   * @returns {Uint8Array}
+   * @throws {ValidationError}
+   */
+  function fromUint5Array(data) {
+    return convertBits(data, 5, 8, true);
+  }
+  
+  /**
+   * Returns the concatenation a and b.
+   *
+   * @private
+   * @param {Uint8Array} a 
+   * @param {Uint8Array} b 
+   * @returns {Uint8Array}
+   * @throws {ValidationError}
+   */
+  function concat(a, b) {
+    var ab = new Uint8Array(a.length + b.length);
+    ab.set(a);
+    ab.set(b, a.length);
+    return ab;
+  }
+  
+  /**
+   * Computes a checksum from the given input data as specified for the CashAddr
+   * format: https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md.
+   *
+   * @private
+   * @param {Uint8Array} data Array of 5-bit integers over which the checksum is to be computed.
+   * @returns {BigInteger}
+   */
+  function polymod(data) {
+    var GENERATOR = [0x98f2bc8e61, 0x79b76d99e2, 0xf33e5fb3c4, 0xae2eabe2a8, 0x1e4f43e470];
+    var checksum = bigInt(1);
+    for (var i = 0; i < data.length; ++i) {
+      var value = data[i];
+      var topBits = checksum.shiftRight(35);
+      checksum = checksum.and(0x07ffffffff).shiftLeft(5).xor(value);
+      for (var j = 0; j < GENERATOR.length; ++j) {
+        if (topBits.shiftRight(j).and(1).equals(1)) {
+          checksum = checksum.xor(GENERATOR[j]);
+        }
+      }
+    }
+    return checksum.xor(1);
+  }
+  
+  /**
+   * Verify that the payload has not been corrupted by checking that the
+   * checksum is valid.
+   * 
+   * @private
+   * @param {string} prefix Network prefix. E.g.: 'bitcoincash'.
+   * @param {Uint8Array} payload Array of 5-bit integers containing the address' payload.
+   * @returns {boolean}
+   */
+  function validChecksum(prefix, payload) {
+    var prefixData = concat(prefixToUint5Array(prefix), new Uint8Array(1));
+    var checksumData = concat(prefixData, payload);
+    return polymod(checksumData).equals(0);
+  }
+  
+  /**
+   * Returns true if, and only if, the given string contains either uppercase
+   * or lowercase letters, but not both.
+   *
+   * @private
+   * @param {string} string Input string.
+   * @returns {boolean}
+   */
+  function hasSingleCase(string) {
+    return string === string.toLowerCase() || string === string.toUpperCase();
+  }
+  
+  module.exports = {
+    encode: encode,
+    decode: decode,
+    ValidationError: ValidationError,
+  };
+  
+  },{"./base32":9,"./convertBits":11,"./validation":12,"big-integer":3}],11:[function(require,module,exports){
+  // Copyright (c) 2017-2018 Emilio Almansi
+  // Copyright (c) 2017 Pieter Wuille
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a copy
+  // of this software and associated documentation files (the "Software"), to deal
+  // in the Software without restriction, including without limitation the rights
+  // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  // copies of the Software, and to permit persons to whom the Software is
+  // furnished to do so, subject to the following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included in
+  // all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  // THE SOFTWARE.
+  
+  'use strict';
+  
+  var validate = require('./validation').validate;
+  
+  /**
+   * Converts an array of integers made up of 'from' bits into an
+   * array of integers made up of 'to' bits. The output array is
+   * zero-padded if necessary, unless strict mode is true.
+   * Throws a {@link ValidationError} if input is invalid.
+   * Original by Pieter Wuille: https://github.com/sipa/bech32.
+   *
+   * @param {Uint8Array} data Array of integers made up of 'from' bits.
+   * @param {number} from Length in bits of elements in the input array.
+   * @param {number} to Length in bits of elements in the output array.
+   * @param {bool} strictMode Require the conversion to be completed without padding.
+   * @returns {Uint8Array}
+   */
+  module.exports = function(data, from, to, strictMode) {
+    var length = strictMode
+      ? Math.floor(data.length * from / to)
+      : Math.ceil(data.length * from / to);
+    var mask = (1 << to) - 1;
+    var result = new Uint8Array(length);
+    var index = 0;
+    var accumulator = 0;
+    var bits = 0;
+    for (var i = 0; i < data.length; ++i) {
+      var value = data[i];
+      validate(0 <= value && (value >> from) === 0, 'Invalid value: ' + value + '.');
+      accumulator = (accumulator << from) | value;
+      bits += from;
+      while (bits >= to) {
+        bits -= to;
+        result[index] = (accumulator >> bits) & mask;
+        ++index;
+      }
+    }
+    if (!strictMode) {
+      if (bits > 0) {
+        result[index] = (accumulator << (to - bits)) & mask;
+        ++index;
+      }
+    } else {
+      validate(
+        bits < from && ((accumulator << (to - bits)) & mask) === 0,
+        'Input cannot be converted to ' + to + ' bits without padding, but strict mode was used.'
+      );
+    }
+    return result;
+  };
+  
+  },{"./validation":12}],12:[function(require,module,exports){
+  /**
+   * @license
+   * https://github.com/bitcoincashjs/cashaddr
+   * Copyright (c) 2017-2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  'use strict';
+  
+  /**
+   * Validation utility.
+   *
+   * @module validation
+   */
+  
+  /**
+   * Error thrown when encoding or decoding fail due to invalid input.
+   *
+   * @constructor ValidationError
+   * @param {string} message Error description.
+   */
+  function ValidationError(message) {
+    var error = new Error();
+    this.name = error.name = 'ValidationError';
+    this.message = error.message = message;
+    this.stack = error.stack;
+  }
+  
+  ValidationError.prototype = Object.create(Error.prototype);
+  
+  /**
+   * Validates a given condition, throwing a {@link ValidationError} if
+   * the given condition does not hold.
+   *
+   * @static
+   * @param {boolean} condition Condition to validate.
+   * @param {string} message Error message in case the condition does not hold.
+   */
+  function validate(condition, message) {
+    if (!condition) {
+      throw new ValidationError(message);
+    }
+  }
+  
+  module.exports = {
+    ValidationError: ValidationError,
+    validate: validate,
+  };
+  
+  },{}],13:[function(require,module,exports){
+  var Buffer = require('safe-buffer').Buffer
+  var Transform = require('stream').Transform
+  var StringDecoder = require('string_decoder').StringDecoder
+  var inherits = require('inherits')
+  
+  function CipherBase (hashMode) {
+    Transform.call(this)
+    this.hashMode = typeof hashMode === 'string'
+    if (this.hashMode) {
+      this[hashMode] = this._finalOrDigest
+    } else {
+      this.final = this._finalOrDigest
+    }
+    if (this._final) {
+      this.__final = this._final
+      this._final = null
+    }
+    this._decoder = null
+    this._encoding = null
+  }
+  inherits(CipherBase, Transform)
+  
+  CipherBase.prototype.update = function (data, inputEnc, outputEnc) {
+    if (typeof data === 'string') {
+      data = Buffer.from(data, inputEnc)
+    }
+  
+    var outData = this._update(data)
+    if (this.hashMode) return this
+  
+    if (outputEnc) {
+      outData = this._toString(outData, outputEnc)
+    }
+  
+    return outData
+  }
+  
+  CipherBase.prototype.setAutoPadding = function () {}
+  CipherBase.prototype.getAuthTag = function () {
+    throw new Error('trying to get auth tag in unsupported state')
+  }
+  
+  CipherBase.prototype.setAuthTag = function () {
+    throw new Error('trying to set auth tag in unsupported state')
+  }
+  
+  CipherBase.prototype.setAAD = function () {
+    throw new Error('trying to set aad in unsupported state')
+  }
+  
+  CipherBase.prototype._transform = function (data, _, next) {
+    var err
+    try {
+      if (this.hashMode) {
+        this._update(data)
+      } else {
+        this.push(this._update(data))
+      }
+    } catch (e) {
+      err = e
+    } finally {
+      next(err)
+    }
+  }
+  CipherBase.prototype._flush = function (done) {
+    var err
+    try {
+      this.push(this.__final())
+    } catch (e) {
+      err = e
+    }
+  
+    done(err)
+  }
+  CipherBase.prototype._finalOrDigest = function (outputEnc) {
+    var outData = this.__final() || Buffer.alloc(0)
+    if (outputEnc) {
+      outData = this._toString(outData, outputEnc, true)
+    }
+    return outData
+  }
+  
+  CipherBase.prototype._toString = function (value, enc, fin) {
+    if (!this._decoder) {
+      this._decoder = new StringDecoder(enc)
+      this._encoding = enc
+    }
+  
+    if (this._encoding !== enc) throw new Error('can\'t switch encodings')
+  
+    var out = this._decoder.write(value)
+    if (fin) {
+      out += this._decoder.end()
+    }
+  
+    return out
+  }
+  
+  module.exports = CipherBase
+  
+  },{"inherits":21,"safe-buffer":40,"stream":49,"string_decoder":50}],14:[function(require,module,exports){
+  (function (Buffer){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // NOTE: These type checking functions intentionally don't use `instanceof`
+  // because it is fragile and can be easily faked with `Object.create()`.
+  
+  function isArray(arg) {
+    if (Array.isArray) {
+      return Array.isArray(arg);
+    }
+    return objectToString(arg) === '[object Array]';
+  }
+  exports.isArray = isArray;
+  
+  function isBoolean(arg) {
+    return typeof arg === 'boolean';
+  }
+  exports.isBoolean = isBoolean;
+  
+  function isNull(arg) {
+    return arg === null;
+  }
+  exports.isNull = isNull;
+  
+  function isNullOrUndefined(arg) {
+    return arg == null;
+  }
+  exports.isNullOrUndefined = isNullOrUndefined;
+  
+  function isNumber(arg) {
+    return typeof arg === 'number';
+  }
+  exports.isNumber = isNumber;
+  
+  function isString(arg) {
+    return typeof arg === 'string';
+  }
+  exports.isString = isString;
+  
+  function isSymbol(arg) {
+    return typeof arg === 'symbol';
+  }
+  exports.isSymbol = isSymbol;
+  
+  function isUndefined(arg) {
+    return arg === void 0;
+  }
+  exports.isUndefined = isUndefined;
+  
+  function isRegExp(re) {
+    return objectToString(re) === '[object RegExp]';
+  }
+  exports.isRegExp = isRegExp;
+  
+  function isObject(arg) {
+    return typeof arg === 'object' && arg !== null;
+  }
+  exports.isObject = isObject;
+  
+  function isDate(d) {
+    return objectToString(d) === '[object Date]';
+  }
+  exports.isDate = isDate;
+  
+  function isError(e) {
+    return (objectToString(e) === '[object Error]' || e instanceof Error);
+  }
+  exports.isError = isError;
+  
+  function isFunction(arg) {
+    return typeof arg === 'function';
+  }
+  exports.isFunction = isFunction;
+  
+  function isPrimitive(arg) {
+    return arg === null ||
+           typeof arg === 'boolean' ||
+           typeof arg === 'number' ||
+           typeof arg === 'string' ||
+           typeof arg === 'symbol' ||  // ES6 symbol
+           typeof arg === 'undefined';
+  }
+  exports.isPrimitive = isPrimitive;
+  
+  exports.isBuffer = Buffer.isBuffer;
+  
+  function objectToString(o) {
+    return Object.prototype.toString.call(o);
+  }
+  
+  }).call(this,{"isBuffer":require("../../is-buffer/index.js")})
+  },{"../../is-buffer/index.js":22}],15:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var inherits = require('inherits')
+  var md5 = require('./md5')
+  var RIPEMD160 = require('ripemd160')
+  var sha = require('sha.js')
+  
+  var Base = require('cipher-base')
+  
+  function HashNoConstructor (hash) {
+    Base.call(this, 'digest')
+  
+    this._hash = hash
+    this.buffers = []
+  }
+  
+  inherits(HashNoConstructor, Base)
+  
+  HashNoConstructor.prototype._update = function (data) {
+    this.buffers.push(data)
+  }
+  
+  HashNoConstructor.prototype._final = function () {
+    var buf = Buffer.concat(this.buffers)
+    var r = this._hash(buf)
+    this.buffers = null
+  
+    return r
+  }
+  
+  function Hash (hash) {
+    Base.call(this, 'digest')
+  
+    this._hash = hash
+  }
+  
+  inherits(Hash, Base)
+  
+  Hash.prototype._update = function (data) {
+    this._hash.update(data)
+  }
+  
+  Hash.prototype._final = function () {
+    return this._hash.digest()
+  }
+  
+  module.exports = function createHash (alg) {
+    alg = alg.toLowerCase()
+    if (alg === 'md5') return new HashNoConstructor(md5)
+    if (alg === 'rmd160' || alg === 'ripemd160') return new Hash(new RIPEMD160())
+  
+    return new Hash(sha(alg))
+  }
+  
+  }).call(this,require("buffer").Buffer)
+  },{"./md5":17,"buffer":8,"cipher-base":13,"inherits":21,"ripemd160":39,"sha.js":42}],16:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var intSize = 4
+  var zeroBuffer = new Buffer(intSize)
+  zeroBuffer.fill(0)
+  
+  var charSize = 8
+  var hashSize = 16
+  
+  function toArray (buf) {
+    if ((buf.length % intSize) !== 0) {
+      var len = buf.length + (intSize - (buf.length % intSize))
+      buf = Buffer.concat([buf, zeroBuffer], len)
+    }
+  
+    var arr = new Array(buf.length >>> 2)
+    for (var i = 0, j = 0; i < buf.length; i += intSize, j++) {
+      arr[j] = buf.readInt32LE(i)
+    }
+  
+    return arr
+  }
+  
+  module.exports = function hash (buf, fn) {
+    var arr = fn(toArray(buf), buf.length * charSize)
+    buf = new Buffer(hashSize)
+    for (var i = 0; i < arr.length; i++) {
+      buf.writeInt32LE(arr[i], i << 2, true)
+    }
+    return buf
+  }
+  
+  }).call(this,require("buffer").Buffer)
+  },{"buffer":8}],17:[function(require,module,exports){
+  'use strict'
+  /*
+   * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
+   * Digest Algorithm, as defined in RFC 1321.
+   * Version 2.1 Copyright (C) Paul Johnston 1999 - 2002.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   * Distributed under the BSD License
+   * See http://pajhome.org.uk/crypt/md5 for more info.
+   */
+  
+  var makeHash = require('./make-hash')
+  
+  /*
+   * Calculate the MD5 of an array of little-endian words, and a bit length
+   */
+  function core_md5 (x, len) {
+    /* append padding */
+    x[len >> 5] |= 0x80 << ((len) % 32)
+    x[(((len + 64) >>> 9) << 4) + 14] = len
+  
+    var a = 1732584193
+    var b = -271733879
+    var c = -1732584194
+    var d = 271733878
+  
+    for (var i = 0; i < x.length; i += 16) {
+      var olda = a
+      var oldb = b
+      var oldc = c
+      var oldd = d
+  
+      a = md5_ff(a, b, c, d, x[i + 0], 7, -680876936)
+      d = md5_ff(d, a, b, c, x[i + 1], 12, -389564586)
+      c = md5_ff(c, d, a, b, x[i + 2], 17, 606105819)
+      b = md5_ff(b, c, d, a, x[i + 3], 22, -1044525330)
+      a = md5_ff(a, b, c, d, x[i + 4], 7, -176418897)
+      d = md5_ff(d, a, b, c, x[i + 5], 12, 1200080426)
+      c = md5_ff(c, d, a, b, x[i + 6], 17, -1473231341)
+      b = md5_ff(b, c, d, a, x[i + 7], 22, -45705983)
+      a = md5_ff(a, b, c, d, x[i + 8], 7, 1770035416)
+      d = md5_ff(d, a, b, c, x[i + 9], 12, -1958414417)
+      c = md5_ff(c, d, a, b, x[i + 10], 17, -42063)
+      b = md5_ff(b, c, d, a, x[i + 11], 22, -1990404162)
+      a = md5_ff(a, b, c, d, x[i + 12], 7, 1804603682)
+      d = md5_ff(d, a, b, c, x[i + 13], 12, -40341101)
+      c = md5_ff(c, d, a, b, x[i + 14], 17, -1502002290)
+      b = md5_ff(b, c, d, a, x[i + 15], 22, 1236535329)
+  
+      a = md5_gg(a, b, c, d, x[i + 1], 5, -165796510)
+      d = md5_gg(d, a, b, c, x[i + 6], 9, -1069501632)
+      c = md5_gg(c, d, a, b, x[i + 11], 14, 643717713)
+      b = md5_gg(b, c, d, a, x[i + 0], 20, -373897302)
+      a = md5_gg(a, b, c, d, x[i + 5], 5, -701558691)
+      d = md5_gg(d, a, b, c, x[i + 10], 9, 38016083)
+      c = md5_gg(c, d, a, b, x[i + 15], 14, -660478335)
+      b = md5_gg(b, c, d, a, x[i + 4], 20, -405537848)
+      a = md5_gg(a, b, c, d, x[i + 9], 5, 568446438)
+      d = md5_gg(d, a, b, c, x[i + 14], 9, -1019803690)
+      c = md5_gg(c, d, a, b, x[i + 3], 14, -187363961)
+      b = md5_gg(b, c, d, a, x[i + 8], 20, 1163531501)
+      a = md5_gg(a, b, c, d, x[i + 13], 5, -1444681467)
+      d = md5_gg(d, a, b, c, x[i + 2], 9, -51403784)
+      c = md5_gg(c, d, a, b, x[i + 7], 14, 1735328473)
+      b = md5_gg(b, c, d, a, x[i + 12], 20, -1926607734)
+  
+      a = md5_hh(a, b, c, d, x[i + 5], 4, -378558)
+      d = md5_hh(d, a, b, c, x[i + 8], 11, -2022574463)
+      c = md5_hh(c, d, a, b, x[i + 11], 16, 1839030562)
+      b = md5_hh(b, c, d, a, x[i + 14], 23, -35309556)
+      a = md5_hh(a, b, c, d, x[i + 1], 4, -1530992060)
+      d = md5_hh(d, a, b, c, x[i + 4], 11, 1272893353)
+      c = md5_hh(c, d, a, b, x[i + 7], 16, -155497632)
+      b = md5_hh(b, c, d, a, x[i + 10], 23, -1094730640)
+      a = md5_hh(a, b, c, d, x[i + 13], 4, 681279174)
+      d = md5_hh(d, a, b, c, x[i + 0], 11, -358537222)
+      c = md5_hh(c, d, a, b, x[i + 3], 16, -722521979)
+      b = md5_hh(b, c, d, a, x[i + 6], 23, 76029189)
+      a = md5_hh(a, b, c, d, x[i + 9], 4, -640364487)
+      d = md5_hh(d, a, b, c, x[i + 12], 11, -421815835)
+      c = md5_hh(c, d, a, b, x[i + 15], 16, 530742520)
+      b = md5_hh(b, c, d, a, x[i + 2], 23, -995338651)
+  
+      a = md5_ii(a, b, c, d, x[i + 0], 6, -198630844)
+      d = md5_ii(d, a, b, c, x[i + 7], 10, 1126891415)
+      c = md5_ii(c, d, a, b, x[i + 14], 15, -1416354905)
+      b = md5_ii(b, c, d, a, x[i + 5], 21, -57434055)
+      a = md5_ii(a, b, c, d, x[i + 12], 6, 1700485571)
+      d = md5_ii(d, a, b, c, x[i + 3], 10, -1894986606)
+      c = md5_ii(c, d, a, b, x[i + 10], 15, -1051523)
+      b = md5_ii(b, c, d, a, x[i + 1], 21, -2054922799)
+      a = md5_ii(a, b, c, d, x[i + 8], 6, 1873313359)
+      d = md5_ii(d, a, b, c, x[i + 15], 10, -30611744)
+      c = md5_ii(c, d, a, b, x[i + 6], 15, -1560198380)
+      b = md5_ii(b, c, d, a, x[i + 13], 21, 1309151649)
+      a = md5_ii(a, b, c, d, x[i + 4], 6, -145523070)
+      d = md5_ii(d, a, b, c, x[i + 11], 10, -1120210379)
+      c = md5_ii(c, d, a, b, x[i + 2], 15, 718787259)
+      b = md5_ii(b, c, d, a, x[i + 9], 21, -343485551)
+  
+      a = safe_add(a, olda)
+      b = safe_add(b, oldb)
+      c = safe_add(c, oldc)
+      d = safe_add(d, oldd)
+    }
+  
+    return [a, b, c, d]
+  }
+  
+  /*
+   * These functions implement the four basic operations the algorithm uses.
+   */
+  function md5_cmn (q, a, b, x, s, t) {
+    return safe_add(bit_rol(safe_add(safe_add(a, q), safe_add(x, t)), s), b)
+  }
+  
+  function md5_ff (a, b, c, d, x, s, t) {
+    return md5_cmn((b & c) | ((~b) & d), a, b, x, s, t)
+  }
+  
+  function md5_gg (a, b, c, d, x, s, t) {
+    return md5_cmn((b & d) | (c & (~d)), a, b, x, s, t)
+  }
+  
+  function md5_hh (a, b, c, d, x, s, t) {
+    return md5_cmn(b ^ c ^ d, a, b, x, s, t)
+  }
+  
+  function md5_ii (a, b, c, d, x, s, t) {
+    return md5_cmn(c ^ (b | (~d)), a, b, x, s, t)
+  }
+  
+  /*
+   * Add integers, wrapping at 2^32. This uses 16-bit operations internally
+   * to work around bugs in some JS interpreters.
+   */
+  function safe_add (x, y) {
+    var lsw = (x & 0xFFFF) + (y & 0xFFFF)
+    var msw = (x >> 16) + (y >> 16) + (lsw >> 16)
+    return (msw << 16) | (lsw & 0xFFFF)
+  }
+  
+  /*
+   * Bitwise rotate a 32-bit number to the left.
+   */
+  function bit_rol (num, cnt) {
+    return (num << cnt) | (num >>> (32 - cnt))
+  }
+  
+  module.exports = function md5 (buf) {
+    return makeHash(buf, core_md5)
+  }
+  
+  },{"./make-hash":16}],18:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  function EventEmitter() {
+    this._events = this._events || {};
+    this._maxListeners = this._maxListeners || undefined;
+  }
+  module.exports = EventEmitter;
+  
+  // Backwards-compat with node 0.10.x
+  EventEmitter.EventEmitter = EventEmitter;
+  
+  EventEmitter.prototype._events = undefined;
+  EventEmitter.prototype._maxListeners = undefined;
+  
+  // By default EventEmitters will print a warning if more than 10 listeners are
+  // added to it. This is a useful default which helps finding memory leaks.
+  EventEmitter.defaultMaxListeners = 10;
+  
+  // Obviously not all Emitters should be limited to 10. This function allows
+  // that to be increased. Set to zero for unlimited.
+  EventEmitter.prototype.setMaxListeners = function(n) {
+    if (!isNumber(n) || n < 0 || isNaN(n))
+      throw TypeError('n must be a positive number');
+    this._maxListeners = n;
+    return this;
+  };
+  
+  EventEmitter.prototype.emit = function(type) {
+    var er, handler, len, args, i, listeners;
+  
+    if (!this._events)
+      this._events = {};
+  
+    // If there is no 'error' event listener then throw.
+    if (type === 'error') {
+      if (!this._events.error ||
+          (isObject(this._events.error) && !this._events.error.length)) {
+        er = arguments[1];
+        if (er instanceof Error) {
+          throw er; // Unhandled 'error' event
+        } else {
+          // At least give some kind of context to the user
+          var err = new Error('Uncaught, unspecified "error" event. (' + er + ')');
+          err.context = er;
+          throw err;
+        }
+      }
+    }
+  
+    handler = this._events[type];
+  
+    if (isUndefined(handler))
+      return false;
+  
+    if (isFunction(handler)) {
+      switch (arguments.length) {
+        // fast cases
+        case 1:
+          handler.call(this);
+          break;
+        case 2:
+          handler.call(this, arguments[1]);
+          break;
+        case 3:
+          handler.call(this, arguments[1], arguments[2]);
+          break;
+        // slower
+        default:
+          args = Array.prototype.slice.call(arguments, 1);
+          handler.apply(this, args);
+      }
+    } else if (isObject(handler)) {
+      args = Array.prototype.slice.call(arguments, 1);
+      listeners = handler.slice();
+      len = listeners.length;
+      for (i = 0; i < len; i++)
+        listeners[i].apply(this, args);
+    }
+  
+    return true;
+  };
+  
+  EventEmitter.prototype.addListener = function(type, listener) {
+    var m;
+  
+    if (!isFunction(listener))
+      throw TypeError('listener must be a function');
+  
+    if (!this._events)
+      this._events = {};
+  
+    // To avoid recursion in the case that type === "newListener"! Before
+    // adding it to the listeners, first emit "newListener".
+    if (this._events.newListener)
+      this.emit('newListener', type,
+                isFunction(listener.listener) ?
+                listener.listener : listener);
+  
+    if (!this._events[type])
+      // Optimize the case of one listener. Don't need the extra array object.
+      this._events[type] = listener;
+    else if (isObject(this._events[type]))
+      // If we've already got an array, just append.
+      this._events[type].push(listener);
+    else
+      // Adding the second element, need to change to array.
+      this._events[type] = [this._events[type], listener];
+  
+    // Check for listener leak
+    if (isObject(this._events[type]) && !this._events[type].warned) {
+      if (!isUndefined(this._maxListeners)) {
+        m = this._maxListeners;
+      } else {
+        m = EventEmitter.defaultMaxListeners;
+      }
+  
+      if (m && m > 0 && this._events[type].length > m) {
+        this._events[type].warned = true;
+        console.error('(node) warning: possible EventEmitter memory ' +
+                      'leak detected. %d listeners added. ' +
+                      'Use emitter.setMaxListeners() to increase limit.',
+                      this._events[type].length);
+        if (typeof console.trace === 'function') {
+          // not supported in IE 10
+          console.trace();
+        }
+      }
+    }
+  
+    return this;
+  };
+  
+  EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+  
+  EventEmitter.prototype.once = function(type, listener) {
+    if (!isFunction(listener))
+      throw TypeError('listener must be a function');
+  
+    var fired = false;
+  
+    function g() {
+      this.removeListener(type, g);
+  
+      if (!fired) {
+        fired = true;
+        listener.apply(this, arguments);
+      }
+    }
+  
+    g.listener = listener;
+    this.on(type, g);
+  
+    return this;
+  };
+  
+  // emits a 'removeListener' event iff the listener was removed
+  EventEmitter.prototype.removeListener = function(type, listener) {
+    var list, position, length, i;
+  
+    if (!isFunction(listener))
+      throw TypeError('listener must be a function');
+  
+    if (!this._events || !this._events[type])
+      return this;
+  
+    list = this._events[type];
+    length = list.length;
+    position = -1;
+  
+    if (list === listener ||
+        (isFunction(list.listener) && list.listener === listener)) {
+      delete this._events[type];
+      if (this._events.removeListener)
+        this.emit('removeListener', type, listener);
+  
+    } else if (isObject(list)) {
+      for (i = length; i-- > 0;) {
+        if (list[i] === listener ||
+            (list[i].listener && list[i].listener === listener)) {
+          position = i;
+          break;
+        }
+      }
+  
+      if (position < 0)
+        return this;
+  
+      if (list.length === 1) {
+        list.length = 0;
+        delete this._events[type];
+      } else {
+        list.splice(position, 1);
+      }
+  
+      if (this._events.removeListener)
+        this.emit('removeListener', type, listener);
+    }
+  
+    return this;
+  };
+  
+  EventEmitter.prototype.removeAllListeners = function(type) {
+    var key, listeners;
+  
+    if (!this._events)
+      return this;
+  
+    // not listening for removeListener, no need to emit
+    if (!this._events.removeListener) {
+      if (arguments.length === 0)
+        this._events = {};
+      else if (this._events[type])
+        delete this._events[type];
+      return this;
+    }
+  
+    // emit removeListener for all listeners on all events
+    if (arguments.length === 0) {
+      for (key in this._events) {
+        if (key === 'removeListener') continue;
+        this.removeAllListeners(key);
+      }
+      this.removeAllListeners('removeListener');
+      this._events = {};
+      return this;
+    }
+  
+    listeners = this._events[type];
+  
+    if (isFunction(listeners)) {
+      this.removeListener(type, listeners);
+    } else if (listeners) {
+      // LIFO order
+      while (listeners.length)
+        this.removeListener(type, listeners[listeners.length - 1]);
+    }
+    delete this._events[type];
+  
+    return this;
+  };
+  
+  EventEmitter.prototype.listeners = function(type) {
+    var ret;
+    if (!this._events || !this._events[type])
+      ret = [];
+    else if (isFunction(this._events[type]))
+      ret = [this._events[type]];
+    else
+      ret = this._events[type].slice();
+    return ret;
+  };
+  
+  EventEmitter.prototype.listenerCount = function(type) {
+    if (this._events) {
+      var evlistener = this._events[type];
+  
+      if (isFunction(evlistener))
+        return 1;
+      else if (evlistener)
+        return evlistener.length;
+    }
+    return 0;
+  };
+  
+  EventEmitter.listenerCount = function(emitter, type) {
+    return emitter.listenerCount(type);
+  };
+  
+  function isFunction(arg) {
+    return typeof arg === 'function';
+  }
+  
+  function isNumber(arg) {
+    return typeof arg === 'number';
+  }
+  
+  function isObject(arg) {
+    return typeof arg === 'object' && arg !== null;
+  }
+  
+  function isUndefined(arg) {
+    return arg === void 0;
+  }
+  
+  },{}],19:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var Transform = require('stream').Transform
+  var inherits = require('inherits')
+  
+  function HashBase (blockSize) {
+    Transform.call(this)
+  
+    this._block = new Buffer(blockSize)
+    this._blockSize = blockSize
+    this._blockOffset = 0
+    this._length = [0, 0, 0, 0]
+  
+    this._finalized = false
+  }
+  
+  inherits(HashBase, Transform)
+  
+  HashBase.prototype._transform = function (chunk, encoding, callback) {
+    var error = null
+    try {
+      if (encoding !== 'buffer') chunk = new Buffer(chunk, encoding)
+      this.update(chunk)
+    } catch (err) {
+      error = err
+    }
+  
+    callback(error)
+  }
+  
+  HashBase.prototype._flush = function (callback) {
+    var error = null
+    try {
+      this.push(this._digest())
+    } catch (err) {
+      error = err
+    }
+  
+    callback(error)
+  }
+  
+  HashBase.prototype.update = function (data, encoding) {
+    if (!Buffer.isBuffer(data) && typeof data !== 'string') throw new TypeError('Data must be a string or a buffer')
+    if (this._finalized) throw new Error('Digest already called')
+    if (!Buffer.isBuffer(data)) data = new Buffer(data, encoding || 'binary')
+  
+    // consume data
+    var block = this._block
+    var offset = 0
+    while (this._blockOffset + data.length - offset >= this._blockSize) {
+      for (var i = this._blockOffset; i < this._blockSize;) block[i++] = data[offset++]
+      this._update()
+      this._blockOffset = 0
+    }
+    while (offset < data.length) block[this._blockOffset++] = data[offset++]
+  
+    // update length
+    for (var j = 0, carry = data.length * 8; carry > 0; ++j) {
+      this._length[j] += carry
+      carry = (this._length[j] / 0x0100000000) | 0
+      if (carry > 0) this._length[j] -= 0x0100000000 * carry
+    }
+  
+    return this
+  }
+  
+  HashBase.prototype._update = function (data) {
+    throw new Error('_update is not implemented')
+  }
+  
+  HashBase.prototype.digest = function (encoding) {
+    if (this._finalized) throw new Error('Digest already called')
+    this._finalized = true
+  
+    var digest = this._digest()
+    if (encoding !== undefined) digest = digest.toString(encoding)
+    return digest
+  }
+  
+  HashBase.prototype._digest = function () {
+    throw new Error('_digest is not implemented')
+  }
+  
+  module.exports = HashBase
+  
+  }).call(this,require("buffer").Buffer)
+  },{"buffer":8,"inherits":21,"stream":49}],20:[function(require,module,exports){
+  exports.read = function (buffer, offset, isLE, mLen, nBytes) {
+    var e, m
+    var eLen = nBytes * 8 - mLen - 1
+    var eMax = (1 << eLen) - 1
+    var eBias = eMax >> 1
+    var nBits = -7
+    var i = isLE ? (nBytes - 1) : 0
+    var d = isLE ? -1 : 1
+    var s = buffer[offset + i]
+  
+    i += d
+  
+    e = s & ((1 << (-nBits)) - 1)
+    s >>= (-nBits)
+    nBits += eLen
+    for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+  
+    m = e & ((1 << (-nBits)) - 1)
+    e >>= (-nBits)
+    nBits += mLen
+    for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+  
+    if (e === 0) {
+      e = 1 - eBias
+    } else if (e === eMax) {
+      return m ? NaN : ((s ? -1 : 1) * Infinity)
+    } else {
+      m = m + Math.pow(2, mLen)
+      e = e - eBias
+    }
+    return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
+  }
+  
+  exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
+    var e, m, c
+    var eLen = nBytes * 8 - mLen - 1
+    var eMax = (1 << eLen) - 1
+    var eBias = eMax >> 1
+    var rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0)
+    var i = isLE ? 0 : (nBytes - 1)
+    var d = isLE ? 1 : -1
+    var s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0
+  
+    value = Math.abs(value)
+  
+    if (isNaN(value) || value === Infinity) {
+      m = isNaN(value) ? 1 : 0
+      e = eMax
+    } else {
+      e = Math.floor(Math.log(value) / Math.LN2)
+      if (value * (c = Math.pow(2, -e)) < 1) {
+        e--
+        c *= 2
+      }
+      if (e + eBias >= 1) {
+        value += rt / c
+      } else {
+        value += rt * Math.pow(2, 1 - eBias)
+      }
+      if (value * c >= 2) {
+        e++
+        c /= 2
+      }
+  
+      if (e + eBias >= eMax) {
+        m = 0
+        e = eMax
+      } else if (e + eBias >= 1) {
+        m = (value * c - 1) * Math.pow(2, mLen)
+        e = e + eBias
+      } else {
+        m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
+        e = 0
+      }
+    }
+  
+    for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8) {}
+  
+    e = (e << mLen) | m
+    eLen += mLen
+    for (; eLen > 0; buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8) {}
+  
+    buffer[offset + i - d] |= s * 128
+  }
+  
+  },{}],21:[function(require,module,exports){
+  if (typeof Object.create === 'function') {
+    // implementation from standard node.js 'util' module
+    module.exports = function inherits(ctor, superCtor) {
+      ctor.super_ = superCtor
+      ctor.prototype = Object.create(superCtor.prototype, {
+        constructor: {
+          value: ctor,
+          enumerable: false,
+          writable: true,
+          configurable: true
+        }
+      });
+    };
+  } else {
+    // old school shim for old browsers
+    module.exports = function inherits(ctor, superCtor) {
+      ctor.super_ = superCtor
+      var TempCtor = function () {}
+      TempCtor.prototype = superCtor.prototype
+      ctor.prototype = new TempCtor()
+      ctor.prototype.constructor = ctor
+    }
+  }
+  
+  },{}],22:[function(require,module,exports){
+  /*!
+   * Determine if an object is a Buffer
+   *
+   * @author   Feross Aboukhadijeh <https://feross.org>
+   * @license  MIT
+   */
+  
+  // The _isBuffer check is for Safari 5-7 support, because it's missing
+  // Object.prototype.constructor. Remove this eventually
+  module.exports = function (obj) {
+    return obj != null && (isBuffer(obj) || isSlowBuffer(obj) || !!obj._isBuffer)
+  }
+  
+  function isBuffer (obj) {
+    return !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
+  }
+  
+  // For Node v0.10 support. Remove this eventually.
+  function isSlowBuffer (obj) {
+    return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
+  }
+  
+  },{}],23:[function(require,module,exports){
+  var toString = {}.toString;
+  
+  module.exports = Array.isArray || function (arr) {
+    return toString.call(arr) == '[object Array]';
+  };
+  
+  },{}],24:[function(require,module,exports){
+  (function (process){
+  'use strict';
+  
+  if (!process.version ||
+      process.version.indexOf('v0.') === 0 ||
+      process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
+    module.exports = nextTick;
+  } else {
+    module.exports = process.nextTick;
+  }
+  
+  function nextTick(fn, arg1, arg2, arg3) {
+    if (typeof fn !== 'function') {
+      throw new TypeError('"callback" argument must be a function');
+    }
+    var len = arguments.length;
+    var args, i;
+    switch (len) {
+    case 0:
+    case 1:
+      return process.nextTick(fn);
+    case 2:
+      return process.nextTick(function afterTickOne() {
+        fn.call(null, arg1);
+      });
+    case 3:
+      return process.nextTick(function afterTickTwo() {
+        fn.call(null, arg1, arg2);
+      });
+    case 4:
+      return process.nextTick(function afterTickThree() {
+        fn.call(null, arg1, arg2, arg3);
+      });
+    default:
+      args = new Array(len - 1);
+      i = 0;
+      while (i < args.length) {
+        args[i++] = arguments[i];
+      }
+      return process.nextTick(function afterTick() {
+        fn.apply(null, args);
+      });
+    }
+  }
+  
+  }).call(this,require('_process'))
+  },{"_process":25}],25:[function(require,module,exports){
+  // shim for using process in browser
+  var process = module.exports = {};
+  
+  // cached from whatever global is present so that test runners that stub it
+  // don't break things.  But we need to wrap it in a try catch in case it is
+  // wrapped in strict mode code which doesn't define any globals.  It's inside a
+  // function because try/catches deoptimize in certain engines.
+  
+  var cachedSetTimeout;
+  var cachedClearTimeout;
+  
+  function defaultSetTimout() {
+      throw new Error('setTimeout has not been defined');
+  }
+  function defaultClearTimeout () {
+      throw new Error('clearTimeout has not been defined');
+  }
+  (function () {
+      try {
+          if (typeof setTimeout === 'function') {
+              cachedSetTimeout = setTimeout;
+          } else {
+              cachedSetTimeout = defaultSetTimout;
+          }
+      } catch (e) {
+          cachedSetTimeout = defaultSetTimout;
+      }
+      try {
+          if (typeof clearTimeout === 'function') {
+              cachedClearTimeout = clearTimeout;
+          } else {
+              cachedClearTimeout = defaultClearTimeout;
+          }
+      } catch (e) {
+          cachedClearTimeout = defaultClearTimeout;
+      }
+  } ())
+  function runTimeout(fun) {
+      if (cachedSetTimeout === setTimeout) {
+          //normal enviroments in sane situations
+          return setTimeout(fun, 0);
+      }
+      // if setTimeout wasn't available but was latter defined
+      if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+          cachedSetTimeout = setTimeout;
+          return setTimeout(fun, 0);
+      }
+      try {
+          // when when somebody has screwed with setTimeout but no I.E. maddness
+          return cachedSetTimeout(fun, 0);
+      } catch(e){
+          try {
+              // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+              return cachedSetTimeout.call(null, fun, 0);
+          } catch(e){
+              // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+              return cachedSetTimeout.call(this, fun, 0);
+          }
+      }
+  
+  
+  }
+  function runClearTimeout(marker) {
+      if (cachedClearTimeout === clearTimeout) {
+          //normal enviroments in sane situations
+          return clearTimeout(marker);
+      }
+      // if clearTimeout wasn't available but was latter defined
+      if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+          cachedClearTimeout = clearTimeout;
+          return clearTimeout(marker);
+      }
+      try {
+          // when when somebody has screwed with setTimeout but no I.E. maddness
+          return cachedClearTimeout(marker);
+      } catch (e){
+          try {
+              // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+              return cachedClearTimeout.call(null, marker);
+          } catch (e){
+              // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+              // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+              return cachedClearTimeout.call(this, marker);
+          }
+      }
+  
+  
+  
+  }
+  var queue = [];
+  var draining = false;
+  var currentQueue;
+  var queueIndex = -1;
+  
+  function cleanUpNextTick() {
+      if (!draining || !currentQueue) {
+          return;
+      }
+      draining = false;
+      if (currentQueue.length) {
+          queue = currentQueue.concat(queue);
+      } else {
+          queueIndex = -1;
+      }
+      if (queue.length) {
+          drainQueue();
+      }
+  }
+  
+  function drainQueue() {
+      if (draining) {
+          return;
+      }
+      var timeout = runTimeout(cleanUpNextTick);
+      draining = true;
+  
+      var len = queue.length;
+      while(len) {
+          currentQueue = queue;
+          queue = [];
+          while (++queueIndex < len) {
+              if (currentQueue) {
+                  currentQueue[queueIndex].run();
+              }
+          }
+          queueIndex = -1;
+          len = queue.length;
+      }
+      currentQueue = null;
+      draining = false;
+      runClearTimeout(timeout);
+  }
+  
+  process.nextTick = function (fun) {
+      var args = new Array(arguments.length - 1);
+      if (arguments.length > 1) {
+          for (var i = 1; i < arguments.length; i++) {
+              args[i - 1] = arguments[i];
+          }
+      }
+      queue.push(new Item(fun, args));
+      if (queue.length === 1 && !draining) {
+          runTimeout(drainQueue);
+      }
+  };
+  
+  // v8 likes predictible objects
+  function Item(fun, array) {
+      this.fun = fun;
+      this.array = array;
+  }
+  Item.prototype.run = function () {
+      this.fun.apply(null, this.array);
+  };
+  process.title = 'browser';
+  process.browser = true;
+  process.env = {};
+  process.argv = [];
+  process.version = ''; // empty string to avoid regexp issues
+  process.versions = {};
+  
+  function noop() {}
+  
+  process.on = noop;
+  process.addListener = noop;
+  process.once = noop;
+  process.off = noop;
+  process.removeListener = noop;
+  process.removeAllListeners = noop;
+  process.emit = noop;
+  process.prependListener = noop;
+  process.prependOnceListener = noop;
+  
+  process.listeners = function (name) { return [] }
+  
+  process.binding = function (name) {
+      throw new Error('process.binding is not supported');
+  };
+  
+  process.cwd = function () { return '/' };
+  process.chdir = function (dir) {
+      throw new Error('process.chdir is not supported');
+  };
+  process.umask = function() { return 0; };
+  
+  },{}],26:[function(require,module,exports){
+  module.exports = require('./lib/_stream_duplex.js');
+  
+  },{"./lib/_stream_duplex.js":27}],27:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // a duplex stream is just a stream that is both readable and writable.
+  // Since JS doesn't have multiple prototypal inheritance, this class
+  // prototypally inherits from Readable, and then parasitically from
+  // Writable.
+  
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var objectKeys = Object.keys || function (obj) {
+    var keys = [];
+    for (var key in obj) {
+      keys.push(key);
+    }return keys;
+  };
+  /*</replacement>*/
+  
+  module.exports = Duplex;
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  var Readable = require('./_stream_readable');
+  var Writable = require('./_stream_writable');
+  
+  util.inherits(Duplex, Readable);
+  
+  var keys = objectKeys(Writable.prototype);
+  for (var v = 0; v < keys.length; v++) {
+    var method = keys[v];
+    if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
+  }
+  
+  function Duplex(options) {
+    if (!(this instanceof Duplex)) return new Duplex(options);
+  
+    Readable.call(this, options);
+    Writable.call(this, options);
+  
+    if (options && options.readable === false) this.readable = false;
+  
+    if (options && options.writable === false) this.writable = false;
+  
+    this.allowHalfOpen = true;
+    if (options && options.allowHalfOpen === false) this.allowHalfOpen = false;
+  
+    this.once('end', onend);
+  }
+  
+  // the no-half-open enforcer
+  function onend() {
+    // if we allow half-open state, or if the writable side ended,
+    // then we're ok.
+    if (this.allowHalfOpen || this._writableState.ended) return;
+  
+    // no more data can be written.
+    // But allow more writes to happen in this tick.
+    processNextTick(onEndNT, this);
+  }
+  
+  function onEndNT(self) {
+    self.end();
+  }
+  
+  Object.defineProperty(Duplex.prototype, 'destroyed', {
+    get: function () {
+      if (this._readableState === undefined || this._writableState === undefined) {
+        return false;
+      }
+      return this._readableState.destroyed && this._writableState.destroyed;
+    },
+    set: function (value) {
+      // we ignore the value if the stream
+      // has not been initialized yet
+      if (this._readableState === undefined || this._writableState === undefined) {
+        return;
+      }
+  
+      // backward compatibility, the user is explicitly
+      // managing destroyed
+      this._readableState.destroyed = value;
+      this._writableState.destroyed = value;
+    }
+  });
+  
+  Duplex.prototype._destroy = function (err, cb) {
+    this.push(null);
+    this.end();
+  
+    processNextTick(cb, err);
+  };
+  
+  function forEach(xs, f) {
+    for (var i = 0, l = xs.length; i < l; i++) {
+      f(xs[i], i);
+    }
+  }
+  },{"./_stream_readable":29,"./_stream_writable":31,"core-util-is":14,"inherits":21,"process-nextick-args":24}],28:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // a passthrough stream.
+  // basically just the most minimal sort of Transform stream.
+  // Every written chunk gets output as-is.
+  
+  'use strict';
+  
+  module.exports = PassThrough;
+  
+  var Transform = require('./_stream_transform');
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  util.inherits(PassThrough, Transform);
+  
+  function PassThrough(options) {
+    if (!(this instanceof PassThrough)) return new PassThrough(options);
+  
+    Transform.call(this, options);
+  }
+  
+  PassThrough.prototype._transform = function (chunk, encoding, cb) {
+    cb(null, chunk);
+  };
+  },{"./_stream_transform":30,"core-util-is":14,"inherits":21}],29:[function(require,module,exports){
+  (function (process,global){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  module.exports = Readable;
+  
+  /*<replacement>*/
+  var isArray = require('isarray');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Duplex;
+  /*</replacement>*/
+  
+  Readable.ReadableState = ReadableState;
+  
+  /*<replacement>*/
+  var EE = require('events').EventEmitter;
+  
+  var EElistenerCount = function (emitter, type) {
+    return emitter.listeners(type).length;
+  };
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Stream = require('./internal/streams/stream');
+  /*</replacement>*/
+  
+  // TODO(bmeurer): Change this back to const once hole checks are
+  // properly optimized away early in Ignition+TurboFan.
+  /*<replacement>*/
+  var Buffer = require('safe-buffer').Buffer;
+  var OurUint8Array = global.Uint8Array || function () {};
+  function _uint8ArrayToBuffer(chunk) {
+    return Buffer.from(chunk);
+  }
+  function _isUint8Array(obj) {
+    return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
+  }
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var debugUtil = require('util');
+  var debug = void 0;
+  if (debugUtil && debugUtil.debuglog) {
+    debug = debugUtil.debuglog('stream');
+  } else {
+    debug = function () {};
+  }
+  /*</replacement>*/
+  
+  var BufferList = require('./internal/streams/BufferList');
+  var destroyImpl = require('./internal/streams/destroy');
+  var StringDecoder;
+  
+  util.inherits(Readable, Stream);
+  
+  var kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
+  
+  function prependListener(emitter, event, fn) {
+    // Sadly this is not cacheable as some libraries bundle their own
+    // event emitter implementation with them.
+    if (typeof emitter.prependListener === 'function') {
+      return emitter.prependListener(event, fn);
+    } else {
+      // This is a hack to make sure that our error handler is attached before any
+      // userland ones.  NEVER DO THIS. This is here only because this code needs
+      // to continue to work with older versions of Node.js that do not include
+      // the prependListener() method. The goal is to eventually remove this hack.
+      if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
+    }
+  }
+  
+  function ReadableState(options, stream) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    options = options || {};
+  
+    // object stream flag. Used to make read(n) ignore n and to
+    // make all the buffer merging and length checks go away
+    this.objectMode = !!options.objectMode;
+  
+    if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.readableObjectMode;
+  
+    // the point at which it stops calling _read() to fill the buffer
+    // Note: 0 is a valid value, means "don't call _read preemptively ever"
+    var hwm = options.highWaterMark;
+    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+    this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+  
+    // cast to ints.
+    this.highWaterMark = Math.floor(this.highWaterMark);
+  
+    // A linked list is used to store data chunks instead of an array because the
+    // linked list can remove elements from the beginning faster than
+    // array.shift()
+    this.buffer = new BufferList();
+    this.length = 0;
+    this.pipes = null;
+    this.pipesCount = 0;
+    this.flowing = null;
+    this.ended = false;
+    this.endEmitted = false;
+    this.reading = false;
+  
+    // a flag to be able to tell if the event 'readable'/'data' is emitted
+    // immediately, or on a later tick.  We set this to true at first, because
+    // any actions that shouldn't happen until "later" should generally also
+    // not happen before the first read call.
+    this.sync = true;
+  
+    // whenever we return null, then we set a flag to say
+    // that we're awaiting a 'readable' event emission.
+    this.needReadable = false;
+    this.emittedReadable = false;
+    this.readableListening = false;
+    this.resumeScheduled = false;
+  
+    // has it been destroyed
+    this.destroyed = false;
+  
+    // Crypto is kind of old and crusty.  Historically, its default string
+    // encoding is 'binary' so we have to make this configurable.
+    // Everything else in the universe uses 'utf8', though.
+    this.defaultEncoding = options.defaultEncoding || 'utf8';
+  
+    // the number of writers that are awaiting a drain event in .pipe()s
+    this.awaitDrain = 0;
+  
+    // if true, a maybeReadMore has been scheduled
+    this.readingMore = false;
+  
+    this.decoder = null;
+    this.encoding = null;
+    if (options.encoding) {
+      if (!StringDecoder) StringDecoder = require('string_decoder/').StringDecoder;
+      this.decoder = new StringDecoder(options.encoding);
+      this.encoding = options.encoding;
+    }
+  }
+  
+  function Readable(options) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    if (!(this instanceof Readable)) return new Readable(options);
+  
+    this._readableState = new ReadableState(options, this);
+  
+    // legacy
+    this.readable = true;
+  
+    if (options) {
+      if (typeof options.read === 'function') this._read = options.read;
+  
+      if (typeof options.destroy === 'function') this._destroy = options.destroy;
+    }
+  
+    Stream.call(this);
+  }
+  
+  Object.defineProperty(Readable.prototype, 'destroyed', {
+    get: function () {
+      if (this._readableState === undefined) {
+        return false;
+      }
+      return this._readableState.destroyed;
+    },
+    set: function (value) {
+      // we ignore the value if the stream
+      // has not been initialized yet
+      if (!this._readableState) {
+        return;
+      }
+  
+      // backward compatibility, the user is explicitly
+      // managing destroyed
+      this._readableState.destroyed = value;
+    }
+  });
+  
+  Readable.prototype.destroy = destroyImpl.destroy;
+  Readable.prototype._undestroy = destroyImpl.undestroy;
+  Readable.prototype._destroy = function (err, cb) {
+    this.push(null);
+    cb(err);
+  };
+  
+  // Manually shove something into the read() buffer.
+  // This returns true if the highWaterMark has not been hit yet,
+  // similar to how Writable.write() returns true if you should
+  // write() some more.
+  Readable.prototype.push = function (chunk, encoding) {
+    var state = this._readableState;
+    var skipChunkCheck;
+  
+    if (!state.objectMode) {
+      if (typeof chunk === 'string') {
+        encoding = encoding || state.defaultEncoding;
+        if (encoding !== state.encoding) {
+          chunk = Buffer.from(chunk, encoding);
+          encoding = '';
+        }
+        skipChunkCheck = true;
+      }
+    } else {
+      skipChunkCheck = true;
+    }
+  
+    return readableAddChunk(this, chunk, encoding, false, skipChunkCheck);
+  };
+  
+  // Unshift should *always* be something directly out of read()
+  Readable.prototype.unshift = function (chunk) {
+    return readableAddChunk(this, chunk, null, true, false);
+  };
+  
+  function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
+    var state = stream._readableState;
+    if (chunk === null) {
+      state.reading = false;
+      onEofChunk(stream, state);
+    } else {
+      var er;
+      if (!skipChunkCheck) er = chunkInvalid(state, chunk);
+      if (er) {
+        stream.emit('error', er);
+      } else if (state.objectMode || chunk && chunk.length > 0) {
+        if (typeof chunk !== 'string' && !state.objectMode && Object.getPrototypeOf(chunk) !== Buffer.prototype) {
+          chunk = _uint8ArrayToBuffer(chunk);
+        }
+  
+        if (addToFront) {
+          if (state.endEmitted) stream.emit('error', new Error('stream.unshift() after end event'));else addChunk(stream, state, chunk, true);
+        } else if (state.ended) {
+          stream.emit('error', new Error('stream.push() after EOF'));
+        } else {
+          state.reading = false;
+          if (state.decoder && !encoding) {
+            chunk = state.decoder.write(chunk);
+            if (state.objectMode || chunk.length !== 0) addChunk(stream, state, chunk, false);else maybeReadMore(stream, state);
+          } else {
+            addChunk(stream, state, chunk, false);
+          }
+        }
+      } else if (!addToFront) {
+        state.reading = false;
+      }
+    }
+  
+    return needMoreData(state);
+  }
+  
+  function addChunk(stream, state, chunk, addToFront) {
+    if (state.flowing && state.length === 0 && !state.sync) {
+      stream.emit('data', chunk);
+      stream.read(0);
+    } else {
+      // update the buffer info.
+      state.length += state.objectMode ? 1 : chunk.length;
+      if (addToFront) state.buffer.unshift(chunk);else state.buffer.push(chunk);
+  
+      if (state.needReadable) emitReadable(stream);
+    }
+    maybeReadMore(stream, state);
+  }
+  
+  function chunkInvalid(state, chunk) {
+    var er;
+    if (!_isUint8Array(chunk) && typeof chunk !== 'string' && chunk !== undefined && !state.objectMode) {
+      er = new TypeError('Invalid non-string/buffer chunk');
+    }
+    return er;
+  }
+  
+  // if it's past the high water mark, we can push in some more.
+  // Also, if we have no data yet, we can stand some
+  // more bytes.  This is to work around cases where hwm=0,
+  // such as the repl.  Also, if the push() triggered a
+  // readable event, and the user called read(largeNumber) such that
+  // needReadable was set, then we ought to push more, so that another
+  // 'readable' event will be triggered.
+  function needMoreData(state) {
+    return !state.ended && (state.needReadable || state.length < state.highWaterMark || state.length === 0);
+  }
+  
+  Readable.prototype.isPaused = function () {
+    return this._readableState.flowing === false;
+  };
+  
+  // backwards compatibility.
+  Readable.prototype.setEncoding = function (enc) {
+    if (!StringDecoder) StringDecoder = require('string_decoder/').StringDecoder;
+    this._readableState.decoder = new StringDecoder(enc);
+    this._readableState.encoding = enc;
+    return this;
+  };
+  
+  // Don't raise the hwm > 8MB
+  var MAX_HWM = 0x800000;
+  function computeNewHighWaterMark(n) {
+    if (n >= MAX_HWM) {
+      n = MAX_HWM;
+    } else {
+      // Get the next highest power of 2 to prevent increasing hwm excessively in
+      // tiny amounts
+      n--;
+      n |= n >>> 1;
+      n |= n >>> 2;
+      n |= n >>> 4;
+      n |= n >>> 8;
+      n |= n >>> 16;
+      n++;
+    }
+    return n;
+  }
+  
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function howMuchToRead(n, state) {
+    if (n <= 0 || state.length === 0 && state.ended) return 0;
+    if (state.objectMode) return 1;
+    if (n !== n) {
+      // Only flow one buffer at a time
+      if (state.flowing && state.length) return state.buffer.head.data.length;else return state.length;
+    }
+    // If we're asking for more than the current hwm, then raise the hwm.
+    if (n > state.highWaterMark) state.highWaterMark = computeNewHighWaterMark(n);
+    if (n <= state.length) return n;
+    // Don't have enough
+    if (!state.ended) {
+      state.needReadable = true;
+      return 0;
+    }
+    return state.length;
+  }
+  
+  // you can override either this method, or the async _read(n) below.
+  Readable.prototype.read = function (n) {
+    debug('read', n);
+    n = parseInt(n, 10);
+    var state = this._readableState;
+    var nOrig = n;
+  
+    if (n !== 0) state.emittedReadable = false;
+  
+    // if we're doing read(0) to trigger a readable event, but we
+    // already have a bunch of data in the buffer, then just trigger
+    // the 'readable' event and move on.
+    if (n === 0 && state.needReadable && (state.length >= state.highWaterMark || state.ended)) {
+      debug('read: emitReadable', state.length, state.ended);
+      if (state.length === 0 && state.ended) endReadable(this);else emitReadable(this);
+      return null;
+    }
+  
+    n = howMuchToRead(n, state);
+  
+    // if we've ended, and we're now clear, then finish it up.
+    if (n === 0 && state.ended) {
+      if (state.length === 0) endReadable(this);
+      return null;
+    }
+  
+    // All the actual chunk generation logic needs to be
+    // *below* the call to _read.  The reason is that in certain
+    // synthetic stream cases, such as passthrough streams, _read
+    // may be a completely synchronous operation which may change
+    // the state of the read buffer, providing enough data when
+    // before there was *not* enough.
+    //
+    // So, the steps are:
+    // 1. Figure out what the state of things will be after we do
+    // a read from the buffer.
+    //
+    // 2. If that resulting state will trigger a _read, then call _read.
+    // Note that this may be asynchronous, or synchronous.  Yes, it is
+    // deeply ugly to write APIs this way, but that still doesn't mean
+    // that the Readable class should behave improperly, as streams are
+    // designed to be sync/async agnostic.
+    // Take note if the _read call is sync or async (ie, if the read call
+    // has returned yet), so that we know whether or not it's safe to emit
+    // 'readable' etc.
+    //
+    // 3. Actually pull the requested chunks out of the buffer and return.
+  
+    // if we need a readable event, then we need to do some reading.
+    var doRead = state.needReadable;
+    debug('need readable', doRead);
+  
+    // if we currently have less than the highWaterMark, then also read some
+    if (state.length === 0 || state.length - n < state.highWaterMark) {
+      doRead = true;
+      debug('length less than watermark', doRead);
+    }
+  
+    // however, if we've ended, then there's no point, and if we're already
+    // reading, then it's unnecessary.
+    if (state.ended || state.reading) {
+      doRead = false;
+      debug('reading or ended', doRead);
+    } else if (doRead) {
+      debug('do read');
+      state.reading = true;
+      state.sync = true;
+      // if the length is currently zero, then we *need* a readable event.
+      if (state.length === 0) state.needReadable = true;
+      // call internal read method
+      this._read(state.highWaterMark);
+      state.sync = false;
+      // If _read pushed data synchronously, then `reading` will be false,
+      // and we need to re-evaluate how much data we can return to the user.
+      if (!state.reading) n = howMuchToRead(nOrig, state);
+    }
+  
+    var ret;
+    if (n > 0) ret = fromList(n, state);else ret = null;
+  
+    if (ret === null) {
+      state.needReadable = true;
+      n = 0;
+    } else {
+      state.length -= n;
+    }
+  
+    if (state.length === 0) {
+      // If we have nothing in the buffer, then we want to know
+      // as soon as we *do* get something into the buffer.
+      if (!state.ended) state.needReadable = true;
+  
+      // If we tried to read() past the EOF, then emit end on the next tick.
+      if (nOrig !== n && state.ended) endReadable(this);
+    }
+  
+    if (ret !== null) this.emit('data', ret);
+  
+    return ret;
+  };
+  
+  function onEofChunk(stream, state) {
+    if (state.ended) return;
+    if (state.decoder) {
+      var chunk = state.decoder.end();
+      if (chunk && chunk.length) {
+        state.buffer.push(chunk);
+        state.length += state.objectMode ? 1 : chunk.length;
+      }
+    }
+    state.ended = true;
+  
+    // emit 'readable' now to make sure it gets picked up.
+    emitReadable(stream);
+  }
+  
+  // Don't emit readable right away in sync mode, because this can trigger
+  // another read() call => stack overflow.  This way, it might trigger
+  // a nextTick recursion warning, but that's not so bad.
+  function emitReadable(stream) {
+    var state = stream._readableState;
+    state.needReadable = false;
+    if (!state.emittedReadable) {
+      debug('emitReadable', state.flowing);
+      state.emittedReadable = true;
+      if (state.sync) processNextTick(emitReadable_, stream);else emitReadable_(stream);
+    }
+  }
+  
+  function emitReadable_(stream) {
+    debug('emit readable');
+    stream.emit('readable');
+    flow(stream);
+  }
+  
+  // at this point, the user has presumably seen the 'readable' event,
+  // and called read() to consume some data.  that may have triggered
+  // in turn another _read(n) call, in which case reading = true if
+  // it's in progress.
+  // However, if we're not ended, or reading, and the length < hwm,
+  // then go ahead and try to read some more preemptively.
+  function maybeReadMore(stream, state) {
+    if (!state.readingMore) {
+      state.readingMore = true;
+      processNextTick(maybeReadMore_, stream, state);
+    }
+  }
+  
+  function maybeReadMore_(stream, state) {
+    var len = state.length;
+    while (!state.reading && !state.flowing && !state.ended && state.length < state.highWaterMark) {
+      debug('maybeReadMore read 0');
+      stream.read(0);
+      if (len === state.length)
+        // didn't get any data, stop spinning.
+        break;else len = state.length;
+    }
+    state.readingMore = false;
+  }
+  
+  // abstract method.  to be overridden in specific implementation classes.
+  // call cb(er, data) where data is <= n in length.
+  // for virtual (non-string, non-buffer) streams, "length" is somewhat
+  // arbitrary, and perhaps not very meaningful.
+  Readable.prototype._read = function (n) {
+    this.emit('error', new Error('_read() is not implemented'));
+  };
+  
+  Readable.prototype.pipe = function (dest, pipeOpts) {
+    var src = this;
+    var state = this._readableState;
+  
+    switch (state.pipesCount) {
+      case 0:
+        state.pipes = dest;
+        break;
+      case 1:
+        state.pipes = [state.pipes, dest];
+        break;
+      default:
+        state.pipes.push(dest);
+        break;
+    }
+    state.pipesCount += 1;
+    debug('pipe count=%d opts=%j', state.pipesCount, pipeOpts);
+  
+    var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
+  
+    var endFn = doEnd ? onend : unpipe;
+    if (state.endEmitted) processNextTick(endFn);else src.once('end', endFn);
+  
+    dest.on('unpipe', onunpipe);
+    function onunpipe(readable, unpipeInfo) {
+      debug('onunpipe');
+      if (readable === src) {
+        if (unpipeInfo && unpipeInfo.hasUnpiped === false) {
+          unpipeInfo.hasUnpiped = true;
+          cleanup();
+        }
+      }
+    }
+  
+    function onend() {
+      debug('onend');
+      dest.end();
+    }
+  
+    // when the dest drains, it reduces the awaitDrain counter
+    // on the source.  This would be more elegant with a .once()
+    // handler in flow(), but adding and removing repeatedly is
+    // too slow.
+    var ondrain = pipeOnDrain(src);
+    dest.on('drain', ondrain);
+  
+    var cleanedUp = false;
+    function cleanup() {
+      debug('cleanup');
+      // cleanup event handlers once the pipe is broken
+      dest.removeListener('close', onclose);
+      dest.removeListener('finish', onfinish);
+      dest.removeListener('drain', ondrain);
+      dest.removeListener('error', onerror);
+      dest.removeListener('unpipe', onunpipe);
+      src.removeListener('end', onend);
+      src.removeListener('end', unpipe);
+      src.removeListener('data', ondata);
+  
+      cleanedUp = true;
+  
+      // if the reader is waiting for a drain event from this
+      // specific writer, then it would cause it to never start
+      // flowing again.
+      // So, if this is awaiting a drain, then we just call it now.
+      // If we don't know, then assume that we are waiting for one.
+      if (state.awaitDrain && (!dest._writableState || dest._writableState.needDrain)) ondrain();
+    }
+  
+    // If the user pushes more data while we're writing to dest then we'll end up
+    // in ondata again. However, we only want to increase awaitDrain once because
+    // dest will only emit one 'drain' event for the multiple writes.
+    // => Introduce a guard on increasing awaitDrain.
+    var increasedAwaitDrain = false;
+    src.on('data', ondata);
+    function ondata(chunk) {
+      debug('ondata');
+      increasedAwaitDrain = false;
+      var ret = dest.write(chunk);
+      if (false === ret && !increasedAwaitDrain) {
+        // If the user unpiped during `dest.write()`, it is possible
+        // to get stuck in a permanently paused state if that write
+        // also returned false.
+        // => Check whether `dest` is still a piping destination.
+        if ((state.pipesCount === 1 && state.pipes === dest || state.pipesCount > 1 && indexOf(state.pipes, dest) !== -1) && !cleanedUp) {
+          debug('false write response, pause', src._readableState.awaitDrain);
+          src._readableState.awaitDrain++;
+          increasedAwaitDrain = true;
+        }
+        src.pause();
+      }
+    }
+  
+    // if the dest has an error, then stop piping into it.
+    // however, don't suppress the throwing behavior for this.
+    function onerror(er) {
+      debug('onerror', er);
+      unpipe();
+      dest.removeListener('error', onerror);
+      if (EElistenerCount(dest, 'error') === 0) dest.emit('error', er);
+    }
+  
+    // Make sure our error handler is attached before userland ones.
+    prependListener(dest, 'error', onerror);
+  
+    // Both close and finish should trigger unpipe, but only once.
+    function onclose() {
+      dest.removeListener('finish', onfinish);
+      unpipe();
+    }
+    dest.once('close', onclose);
+    function onfinish() {
+      debug('onfinish');
+      dest.removeListener('close', onclose);
+      unpipe();
+    }
+    dest.once('finish', onfinish);
+  
+    function unpipe() {
+      debug('unpipe');
+      src.unpipe(dest);
+    }
+  
+    // tell the dest that it's being piped to
+    dest.emit('pipe', src);
+  
+    // start the flow if it hasn't been started already.
+    if (!state.flowing) {
+      debug('pipe resume');
+      src.resume();
+    }
+  
+    return dest;
+  };
+  
+  function pipeOnDrain(src) {
+    return function () {
+      var state = src._readableState;
+      debug('pipeOnDrain', state.awaitDrain);
+      if (state.awaitDrain) state.awaitDrain--;
+      if (state.awaitDrain === 0 && EElistenerCount(src, 'data')) {
+        state.flowing = true;
+        flow(src);
+      }
+    };
+  }
+  
+  Readable.prototype.unpipe = function (dest) {
+    var state = this._readableState;
+    var unpipeInfo = { hasUnpiped: false };
+  
+    // if we're not piping anywhere, then do nothing.
+    if (state.pipesCount === 0) return this;
+  
+    // just one destination.  most common case.
+    if (state.pipesCount === 1) {
+      // passed in one, but it's not the right one.
+      if (dest && dest !== state.pipes) return this;
+  
+      if (!dest) dest = state.pipes;
+  
+      // got a match.
+      state.pipes = null;
+      state.pipesCount = 0;
+      state.flowing = false;
+      if (dest) dest.emit('unpipe', this, unpipeInfo);
+      return this;
+    }
+  
+    // slow case. multiple pipe destinations.
+  
+    if (!dest) {
+      // remove all.
+      var dests = state.pipes;
+      var len = state.pipesCount;
+      state.pipes = null;
+      state.pipesCount = 0;
+      state.flowing = false;
+  
+      for (var i = 0; i < len; i++) {
+        dests[i].emit('unpipe', this, unpipeInfo);
+      }return this;
+    }
+  
+    // try to find the right one.
+    var index = indexOf(state.pipes, dest);
+    if (index === -1) return this;
+  
+    state.pipes.splice(index, 1);
+    state.pipesCount -= 1;
+    if (state.pipesCount === 1) state.pipes = state.pipes[0];
+  
+    dest.emit('unpipe', this, unpipeInfo);
+  
+    return this;
+  };
+  
+  // set up data events if they are asked for
+  // Ensure readable listeners eventually get something
+  Readable.prototype.on = function (ev, fn) {
+    var res = Stream.prototype.on.call(this, ev, fn);
+  
+    if (ev === 'data') {
+      // Start flowing on next tick if stream isn't explicitly paused
+      if (this._readableState.flowing !== false) this.resume();
+    } else if (ev === 'readable') {
+      var state = this._readableState;
+      if (!state.endEmitted && !state.readableListening) {
+        state.readableListening = state.needReadable = true;
+        state.emittedReadable = false;
+        if (!state.reading) {
+          processNextTick(nReadingNextTick, this);
+        } else if (state.length) {
+          emitReadable(this);
+        }
+      }
+    }
+  
+    return res;
+  };
+  Readable.prototype.addListener = Readable.prototype.on;
+  
+  function nReadingNextTick(self) {
+    debug('readable nexttick read 0');
+    self.read(0);
+  }
+  
+  // pause() and resume() are remnants of the legacy readable stream API
+  // If the user uses them, then switch into old mode.
+  Readable.prototype.resume = function () {
+    var state = this._readableState;
+    if (!state.flowing) {
+      debug('resume');
+      state.flowing = true;
+      resume(this, state);
+    }
+    return this;
+  };
+  
+  function resume(stream, state) {
+    if (!state.resumeScheduled) {
+      state.resumeScheduled = true;
+      processNextTick(resume_, stream, state);
+    }
+  }
+  
+  function resume_(stream, state) {
+    if (!state.reading) {
+      debug('resume read 0');
+      stream.read(0);
+    }
+  
+    state.resumeScheduled = false;
+    state.awaitDrain = 0;
+    stream.emit('resume');
+    flow(stream);
+    if (state.flowing && !state.reading) stream.read(0);
+  }
+  
+  Readable.prototype.pause = function () {
+    debug('call pause flowing=%j', this._readableState.flowing);
+    if (false !== this._readableState.flowing) {
+      debug('pause');
+      this._readableState.flowing = false;
+      this.emit('pause');
+    }
+    return this;
+  };
+  
+  function flow(stream) {
+    var state = stream._readableState;
+    debug('flow', state.flowing);
+    while (state.flowing && stream.read() !== null) {}
+  }
+  
+  // wrap an old-style stream as the async data source.
+  // This is *not* part of the readable stream interface.
+  // It is an ugly unfortunate mess of history.
+  Readable.prototype.wrap = function (stream) {
+    var state = this._readableState;
+    var paused = false;
+  
+    var self = this;
+    stream.on('end', function () {
+      debug('wrapped end');
+      if (state.decoder && !state.ended) {
+        var chunk = state.decoder.end();
+        if (chunk && chunk.length) self.push(chunk);
+      }
+  
+      self.push(null);
+    });
+  
+    stream.on('data', function (chunk) {
+      debug('wrapped data');
+      if (state.decoder) chunk = state.decoder.write(chunk);
+  
+      // don't skip over falsy values in objectMode
+      if (state.objectMode && (chunk === null || chunk === undefined)) return;else if (!state.objectMode && (!chunk || !chunk.length)) return;
+  
+      var ret = self.push(chunk);
+      if (!ret) {
+        paused = true;
+        stream.pause();
+      }
+    });
+  
+    // proxy all the other methods.
+    // important when wrapping filters and duplexes.
+    for (var i in stream) {
+      if (this[i] === undefined && typeof stream[i] === 'function') {
+        this[i] = function (method) {
+          return function () {
+            return stream[method].apply(stream, arguments);
+          };
+        }(i);
+      }
+    }
+  
+    // proxy certain important events.
+    for (var n = 0; n < kProxyEvents.length; n++) {
+      stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+    }
+  
+    // when we try to consume some more bytes, simply unpause the
+    // underlying stream.
+    self._read = function (n) {
+      debug('wrapped _read', n);
+      if (paused) {
+        paused = false;
+        stream.resume();
+      }
+    };
+  
+    return self;
+  };
+  
+  // exposed for testing purposes only.
+  Readable._fromList = fromList;
+  
+  // Pluck off n bytes from an array of buffers.
+  // Length is the combined lengths of all the buffers in the list.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function fromList(n, state) {
+    // nothing buffered
+    if (state.length === 0) return null;
+  
+    var ret;
+    if (state.objectMode) ret = state.buffer.shift();else if (!n || n >= state.length) {
+      // read it all, truncate the list
+      if (state.decoder) ret = state.buffer.join('');else if (state.buffer.length === 1) ret = state.buffer.head.data;else ret = state.buffer.concat(state.length);
+      state.buffer.clear();
+    } else {
+      // read part of list
+      ret = fromListPartial(n, state.buffer, state.decoder);
+    }
+  
+    return ret;
+  }
+  
+  // Extracts only enough buffered data to satisfy the amount requested.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function fromListPartial(n, list, hasStrings) {
+    var ret;
+    if (n < list.head.data.length) {
+      // slice is the same for buffers and strings
+      ret = list.head.data.slice(0, n);
+      list.head.data = list.head.data.slice(n);
+    } else if (n === list.head.data.length) {
+      // first chunk is a perfect match
+      ret = list.shift();
+    } else {
+      // result spans more than one buffer
+      ret = hasStrings ? copyFromBufferString(n, list) : copyFromBuffer(n, list);
+    }
+    return ret;
+  }
+  
+  // Copies a specified amount of characters from the list of buffered data
+  // chunks.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function copyFromBufferString(n, list) {
+    var p = list.head;
+    var c = 1;
+    var ret = p.data;
+    n -= ret.length;
+    while (p = p.next) {
+      var str = p.data;
+      var nb = n > str.length ? str.length : n;
+      if (nb === str.length) ret += str;else ret += str.slice(0, n);
+      n -= nb;
+      if (n === 0) {
+        if (nb === str.length) {
+          ++c;
+          if (p.next) list.head = p.next;else list.head = list.tail = null;
+        } else {
+          list.head = p;
+          p.data = str.slice(nb);
+        }
+        break;
+      }
+      ++c;
+    }
+    list.length -= c;
+    return ret;
+  }
+  
+  // Copies a specified amount of bytes from the list of buffered data chunks.
+  // This function is designed to be inlinable, so please take care when making
+  // changes to the function body.
+  function copyFromBuffer(n, list) {
+    var ret = Buffer.allocUnsafe(n);
+    var p = list.head;
+    var c = 1;
+    p.data.copy(ret);
+    n -= p.data.length;
+    while (p = p.next) {
+      var buf = p.data;
+      var nb = n > buf.length ? buf.length : n;
+      buf.copy(ret, ret.length - n, 0, nb);
+      n -= nb;
+      if (n === 0) {
+        if (nb === buf.length) {
+          ++c;
+          if (p.next) list.head = p.next;else list.head = list.tail = null;
+        } else {
+          list.head = p;
+          p.data = buf.slice(nb);
+        }
+        break;
+      }
+      ++c;
+    }
+    list.length -= c;
+    return ret;
+  }
+  
+  function endReadable(stream) {
+    var state = stream._readableState;
+  
+    // If we get here before consuming all the bytes, then that is a
+    // bug in node.  Should never happen.
+    if (state.length > 0) throw new Error('"endReadable()" called on non-empty stream');
+  
+    if (!state.endEmitted) {
+      state.ended = true;
+      processNextTick(endReadableNT, state, stream);
+    }
+  }
+  
+  function endReadableNT(state, stream) {
+    // Check that we didn't get one last unshift.
+    if (!state.endEmitted && state.length === 0) {
+      state.endEmitted = true;
+      stream.readable = false;
+      stream.emit('end');
+    }
+  }
+  
+  function forEach(xs, f) {
+    for (var i = 0, l = xs.length; i < l; i++) {
+      f(xs[i], i);
+    }
+  }
+  
+  function indexOf(xs, x) {
+    for (var i = 0, l = xs.length; i < l; i++) {
+      if (xs[i] === x) return i;
+    }
+    return -1;
+  }
+  }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+  },{"./_stream_duplex":27,"./internal/streams/BufferList":32,"./internal/streams/destroy":33,"./internal/streams/stream":34,"_process":25,"core-util-is":14,"events":18,"inherits":21,"isarray":23,"process-nextick-args":24,"safe-buffer":40,"string_decoder/":50,"util":4}],30:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // a transform stream is a readable/writable stream where you do
+  // something with the data.  Sometimes it's called a "filter",
+  // but that's not a great name for it, since that implies a thing where
+  // some bits pass through, and others are simply ignored.  (That would
+  // be a valid example of a transform, of course.)
+  //
+  // While the output is causally related to the input, it's not a
+  // necessarily symmetric or synchronous transformation.  For example,
+  // a zlib stream might take multiple plain-text writes(), and then
+  // emit a single compressed chunk some time in the future.
+  //
+  // Here's how this works:
+  //
+  // The Transform stream has all the aspects of the readable and writable
+  // stream classes.  When you write(chunk), that calls _write(chunk,cb)
+  // internally, and returns false if there's a lot of pending writes
+  // buffered up.  When you call read(), that calls _read(n) until
+  // there's enough pending readable data buffered up.
+  //
+  // In a transform stream, the written data is placed in a buffer.  When
+  // _read(n) is called, it transforms the queued up data, calling the
+  // buffered _write cb's as it consumes chunks.  If consuming a single
+  // written chunk would result in multiple output chunks, then the first
+  // outputted bit calls the readcb, and subsequent chunks just go into
+  // the read buffer, and will cause it to emit 'readable' if necessary.
+  //
+  // This way, back-pressure is actually determined by the reading side,
+  // since _read has to be called to start processing a new chunk.  However,
+  // a pathological inflate type of transform can cause excessive buffering
+  // here.  For example, imagine a stream where every byte of input is
+  // interpreted as an integer from 0-255, and then results in that many
+  // bytes of output.  Writing the 4 bytes {ff,ff,ff,ff} would result in
+  // 1kb of data being output.  In this case, you could write a very small
+  // amount of input, and end up with a very large amount of output.  In
+  // such a pathological inflating mechanism, there'd be no way to tell
+  // the system to stop doing the transform.  A single 4MB write could
+  // cause the system to run out of memory.
+  //
+  // However, even in such a pathological case, only a single written chunk
+  // would be consumed, and then the rest would wait (un-transformed) until
+  // the results of the previous transformed chunk were consumed.
+  
+  'use strict';
+  
+  module.exports = Transform;
+  
+  var Duplex = require('./_stream_duplex');
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  util.inherits(Transform, Duplex);
+  
+  function TransformState(stream) {
+    this.afterTransform = function (er, data) {
+      return afterTransform(stream, er, data);
+    };
+  
+    this.needTransform = false;
+    this.transforming = false;
+    this.writecb = null;
+    this.writechunk = null;
+    this.writeencoding = null;
+  }
+  
+  function afterTransform(stream, er, data) {
+    var ts = stream._transformState;
+    ts.transforming = false;
+  
+    var cb = ts.writecb;
+  
+    if (!cb) {
+      return stream.emit('error', new Error('write callback called multiple times'));
+    }
+  
+    ts.writechunk = null;
+    ts.writecb = null;
+  
+    if (data !== null && data !== undefined) stream.push(data);
+  
+    cb(er);
+  
+    var rs = stream._readableState;
+    rs.reading = false;
+    if (rs.needReadable || rs.length < rs.highWaterMark) {
+      stream._read(rs.highWaterMark);
+    }
+  }
+  
+  function Transform(options) {
+    if (!(this instanceof Transform)) return new Transform(options);
+  
+    Duplex.call(this, options);
+  
+    this._transformState = new TransformState(this);
+  
+    var stream = this;
+  
+    // start out asking for a readable event once data is transformed.
+    this._readableState.needReadable = true;
+  
+    // we have implemented the _read method, and done the other things
+    // that Readable wants before the first _read call, so unset the
+    // sync guard flag.
+    this._readableState.sync = false;
+  
+    if (options) {
+      if (typeof options.transform === 'function') this._transform = options.transform;
+  
+      if (typeof options.flush === 'function') this._flush = options.flush;
+    }
+  
+    // When the writable side finishes, then flush out anything remaining.
+    this.once('prefinish', function () {
+      if (typeof this._flush === 'function') this._flush(function (er, data) {
+        done(stream, er, data);
+      });else done(stream);
+    });
+  }
+  
+  Transform.prototype.push = function (chunk, encoding) {
+    this._transformState.needTransform = false;
+    return Duplex.prototype.push.call(this, chunk, encoding);
+  };
+  
+  // This is the part where you do stuff!
+  // override this function in implementation classes.
+  // 'chunk' is an input chunk.
+  //
+  // Call `push(newChunk)` to pass along transformed output
+  // to the readable side.  You may call 'push' zero or more times.
+  //
+  // Call `cb(err)` when you are done with this chunk.  If you pass
+  // an error, then that'll put the hurt on the whole operation.  If you
+  // never call cb(), then you'll never get another chunk.
+  Transform.prototype._transform = function (chunk, encoding, cb) {
+    throw new Error('_transform() is not implemented');
+  };
+  
+  Transform.prototype._write = function (chunk, encoding, cb) {
+    var ts = this._transformState;
+    ts.writecb = cb;
+    ts.writechunk = chunk;
+    ts.writeencoding = encoding;
+    if (!ts.transforming) {
+      var rs = this._readableState;
+      if (ts.needTransform || rs.needReadable || rs.length < rs.highWaterMark) this._read(rs.highWaterMark);
+    }
+  };
+  
+  // Doesn't matter what the args are here.
+  // _transform does all the work.
+  // That we got here means that the readable side wants more data.
+  Transform.prototype._read = function (n) {
+    var ts = this._transformState;
+  
+    if (ts.writechunk !== null && ts.writecb && !ts.transforming) {
+      ts.transforming = true;
+      this._transform(ts.writechunk, ts.writeencoding, ts.afterTransform);
+    } else {
+      // mark that we need a transform, so that any data that comes in
+      // will get processed, now that we've asked for it.
+      ts.needTransform = true;
+    }
+  };
+  
+  Transform.prototype._destroy = function (err, cb) {
+    var _this = this;
+  
+    Duplex.prototype._destroy.call(this, err, function (err2) {
+      cb(err2);
+      _this.emit('close');
+    });
+  };
+  
+  function done(stream, er, data) {
+    if (er) return stream.emit('error', er);
+  
+    if (data !== null && data !== undefined) stream.push(data);
+  
+    // if there's nothing in the write buffer, then that means
+    // that nothing more will ever be provided
+    var ws = stream._writableState;
+    var ts = stream._transformState;
+  
+    if (ws.length) throw new Error('Calling transform done when ws.length != 0');
+  
+    if (ts.transforming) throw new Error('Calling transform done when still transforming');
+  
+    return stream.push(null);
+  }
+  },{"./_stream_duplex":27,"core-util-is":14,"inherits":21}],31:[function(require,module,exports){
+  (function (process,global){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  // A bit simpler than readable streams.
+  // Implement an async ._write(chunk, encoding, cb), and it'll handle all
+  // the drain event emission and buffering.
+  
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  module.exports = Writable;
+  
+  /* <replacement> */
+  function WriteReq(chunk, encoding, cb) {
+    this.chunk = chunk;
+    this.encoding = encoding;
+    this.callback = cb;
+    this.next = null;
+  }
+  
+  // It seems a linked list but it is not
+  // there will be only 2 of these for each stream
+  function CorkedRequest(state) {
+    var _this = this;
+  
+    this.next = null;
+    this.entry = null;
+    this.finish = function () {
+      onCorkedFinish(_this, state);
+    };
+  }
+  /* </replacement> */
+  
+  /*<replacement>*/
+  var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : processNextTick;
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Duplex;
+  /*</replacement>*/
+  
+  Writable.WritableState = WritableState;
+  
+  /*<replacement>*/
+  var util = require('core-util-is');
+  util.inherits = require('inherits');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var internalUtil = {
+    deprecate: require('util-deprecate')
+  };
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Stream = require('./internal/streams/stream');
+  /*</replacement>*/
+  
+  /*<replacement>*/
+  var Buffer = require('safe-buffer').Buffer;
+  var OurUint8Array = global.Uint8Array || function () {};
+  function _uint8ArrayToBuffer(chunk) {
+    return Buffer.from(chunk);
+  }
+  function _isUint8Array(obj) {
+    return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
+  }
+  /*</replacement>*/
+  
+  var destroyImpl = require('./internal/streams/destroy');
+  
+  util.inherits(Writable, Stream);
+  
+  function nop() {}
+  
+  function WritableState(options, stream) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    options = options || {};
+  
+    // object stream flag to indicate whether or not this stream
+    // contains buffers or objects.
+    this.objectMode = !!options.objectMode;
+  
+    if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.writableObjectMode;
+  
+    // the point at which write() starts returning false
+    // Note: 0 is a valid value, means that we always return false if
+    // the entire buffer is not flushed immediately on write()
+    var hwm = options.highWaterMark;
+    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+    this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+  
+    // cast to ints.
+    this.highWaterMark = Math.floor(this.highWaterMark);
+  
+    // if _final has been called
+    this.finalCalled = false;
+  
+    // drain event flag.
+    this.needDrain = false;
+    // at the start of calling end()
+    this.ending = false;
+    // when end() has been called, and returned
+    this.ended = false;
+    // when 'finish' is emitted
+    this.finished = false;
+  
+    // has it been destroyed
+    this.destroyed = false;
+  
+    // should we decode strings into buffers before passing to _write?
+    // this is here so that some node-core streams can optimize string
+    // handling at a lower level.
+    var noDecode = options.decodeStrings === false;
+    this.decodeStrings = !noDecode;
+  
+    // Crypto is kind of old and crusty.  Historically, its default string
+    // encoding is 'binary' so we have to make this configurable.
+    // Everything else in the universe uses 'utf8', though.
+    this.defaultEncoding = options.defaultEncoding || 'utf8';
+  
+    // not an actual buffer we keep track of, but a measurement
+    // of how much we're waiting to get pushed to some underlying
+    // socket or file.
+    this.length = 0;
+  
+    // a flag to see when we're in the middle of a write.
+    this.writing = false;
+  
+    // when true all writes will be buffered until .uncork() call
+    this.corked = 0;
+  
+    // a flag to be able to tell if the onwrite cb is called immediately,
+    // or on a later tick.  We set this to true at first, because any
+    // actions that shouldn't happen until "later" should generally also
+    // not happen before the first write call.
+    this.sync = true;
+  
+    // a flag to know if we're processing previously buffered items, which
+    // may call the _write() callback in the same tick, so that we don't
+    // end up in an overlapped onwrite situation.
+    this.bufferProcessing = false;
+  
+    // the callback that's passed to _write(chunk,cb)
+    this.onwrite = function (er) {
+      onwrite(stream, er);
+    };
+  
+    // the callback that the user supplies to write(chunk,encoding,cb)
+    this.writecb = null;
+  
+    // the amount that is being written when _write is called.
+    this.writelen = 0;
+  
+    this.bufferedRequest = null;
+    this.lastBufferedRequest = null;
+  
+    // number of pending user-supplied write callbacks
+    // this must be 0 before 'finish' can be emitted
+    this.pendingcb = 0;
+  
+    // emit prefinish if the only thing we're waiting for is _write cbs
+    // This is relevant for synchronous Transform streams
+    this.prefinished = false;
+  
+    // True if the error was already emitted and should not be thrown again
+    this.errorEmitted = false;
+  
+    // count buffered requests
+    this.bufferedRequestCount = 0;
+  
+    // allocate the first CorkedRequest, there is always
+    // one allocated and free to use, and we maintain at most two
+    this.corkedRequestsFree = new CorkedRequest(this);
+  }
+  
+  WritableState.prototype.getBuffer = function getBuffer() {
+    var current = this.bufferedRequest;
+    var out = [];
+    while (current) {
+      out.push(current);
+      current = current.next;
+    }
+    return out;
+  };
+  
+  (function () {
+    try {
+      Object.defineProperty(WritableState.prototype, 'buffer', {
+        get: internalUtil.deprecate(function () {
+          return this.getBuffer();
+        }, '_writableState.buffer is deprecated. Use _writableState.getBuffer ' + 'instead.', 'DEP0003')
+      });
+    } catch (_) {}
+  })();
+  
+  // Test _writableState for inheritance to account for Duplex streams,
+  // whose prototype chain only points to Readable.
+  var realHasInstance;
+  if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.prototype[Symbol.hasInstance] === 'function') {
+    realHasInstance = Function.prototype[Symbol.hasInstance];
+    Object.defineProperty(Writable, Symbol.hasInstance, {
+      value: function (object) {
+        if (realHasInstance.call(this, object)) return true;
+  
+        return object && object._writableState instanceof WritableState;
+      }
+    });
+  } else {
+    realHasInstance = function (object) {
+      return object instanceof this;
+    };
+  }
+  
+  function Writable(options) {
+    Duplex = Duplex || require('./_stream_duplex');
+  
+    // Writable ctor is applied to Duplexes, too.
+    // `realHasInstance` is necessary because using plain `instanceof`
+    // would return false, as no `_writableState` property is attached.
+  
+    // Trying to use the custom `instanceof` for Writable here will also break the
+    // Node.js LazyTransform implementation, which has a non-trivial getter for
+    // `_writableState` that would lead to infinite recursion.
+    if (!realHasInstance.call(Writable, this) && !(this instanceof Duplex)) {
+      return new Writable(options);
+    }
+  
+    this._writableState = new WritableState(options, this);
+  
+    // legacy.
+    this.writable = true;
+  
+    if (options) {
+      if (typeof options.write === 'function') this._write = options.write;
+  
+      if (typeof options.writev === 'function') this._writev = options.writev;
+  
+      if (typeof options.destroy === 'function') this._destroy = options.destroy;
+  
+      if (typeof options.final === 'function') this._final = options.final;
+    }
+  
+    Stream.call(this);
+  }
+  
+  // Otherwise people can pipe Writable streams, which is just wrong.
+  Writable.prototype.pipe = function () {
+    this.emit('error', new Error('Cannot pipe, not readable'));
+  };
+  
+  function writeAfterEnd(stream, cb) {
+    var er = new Error('write after end');
+    // TODO: defer error events consistently everywhere, not just the cb
+    stream.emit('error', er);
+    processNextTick(cb, er);
+  }
+  
+  // Checks that a user-supplied chunk is valid, especially for the particular
+  // mode the stream is in. Currently this means that `null` is never accepted
+  // and undefined/non-string values are only allowed in object mode.
+  function validChunk(stream, state, chunk, cb) {
+    var valid = true;
+    var er = false;
+  
+    if (chunk === null) {
+      er = new TypeError('May not write null values to stream');
+    } else if (typeof chunk !== 'string' && chunk !== undefined && !state.objectMode) {
+      er = new TypeError('Invalid non-string/buffer chunk');
+    }
+    if (er) {
+      stream.emit('error', er);
+      processNextTick(cb, er);
+      valid = false;
+    }
+    return valid;
+  }
+  
+  Writable.prototype.write = function (chunk, encoding, cb) {
+    var state = this._writableState;
+    var ret = false;
+    var isBuf = _isUint8Array(chunk) && !state.objectMode;
+  
+    if (isBuf && !Buffer.isBuffer(chunk)) {
+      chunk = _uint8ArrayToBuffer(chunk);
+    }
+  
+    if (typeof encoding === 'function') {
+      cb = encoding;
+      encoding = null;
+    }
+  
+    if (isBuf) encoding = 'buffer';else if (!encoding) encoding = state.defaultEncoding;
+  
+    if (typeof cb !== 'function') cb = nop;
+  
+    if (state.ended) writeAfterEnd(this, cb);else if (isBuf || validChunk(this, state, chunk, cb)) {
+      state.pendingcb++;
+      ret = writeOrBuffer(this, state, isBuf, chunk, encoding, cb);
+    }
+  
+    return ret;
+  };
+  
+  Writable.prototype.cork = function () {
+    var state = this._writableState;
+  
+    state.corked++;
+  };
+  
+  Writable.prototype.uncork = function () {
+    var state = this._writableState;
+  
+    if (state.corked) {
+      state.corked--;
+  
+      if (!state.writing && !state.corked && !state.finished && !state.bufferProcessing && state.bufferedRequest) clearBuffer(this, state);
+    }
+  };
+  
+  Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
+    // node::ParseEncoding() requires lower case.
+    if (typeof encoding === 'string') encoding = encoding.toLowerCase();
+    if (!(['hex', 'utf8', 'utf-8', 'ascii', 'binary', 'base64', 'ucs2', 'ucs-2', 'utf16le', 'utf-16le', 'raw'].indexOf((encoding + '').toLowerCase()) > -1)) throw new TypeError('Unknown encoding: ' + encoding);
+    this._writableState.defaultEncoding = encoding;
+    return this;
+  };
+  
+  function decodeChunk(state, chunk, encoding) {
+    if (!state.objectMode && state.decodeStrings !== false && typeof chunk === 'string') {
+      chunk = Buffer.from(chunk, encoding);
+    }
+    return chunk;
+  }
+  
+  // if we're already writing something, then just put this
+  // in the queue, and wait our turn.  Otherwise, call _write
+  // If we return false, then we need a drain event, so set that flag.
+  function writeOrBuffer(stream, state, isBuf, chunk, encoding, cb) {
+    if (!isBuf) {
+      var newChunk = decodeChunk(state, chunk, encoding);
+      if (chunk !== newChunk) {
+        isBuf = true;
+        encoding = 'buffer';
+        chunk = newChunk;
+      }
+    }
+    var len = state.objectMode ? 1 : chunk.length;
+  
+    state.length += len;
+  
+    var ret = state.length < state.highWaterMark;
+    // we must ensure that previous needDrain will not be reset to false.
+    if (!ret) state.needDrain = true;
+  
+    if (state.writing || state.corked) {
+      var last = state.lastBufferedRequest;
+      state.lastBufferedRequest = {
+        chunk: chunk,
+        encoding: encoding,
+        isBuf: isBuf,
+        callback: cb,
+        next: null
+      };
+      if (last) {
+        last.next = state.lastBufferedRequest;
+      } else {
+        state.bufferedRequest = state.lastBufferedRequest;
+      }
+      state.bufferedRequestCount += 1;
+    } else {
+      doWrite(stream, state, false, len, chunk, encoding, cb);
+    }
+  
+    return ret;
+  }
+  
+  function doWrite(stream, state, writev, len, chunk, encoding, cb) {
+    state.writelen = len;
+    state.writecb = cb;
+    state.writing = true;
+    state.sync = true;
+    if (writev) stream._writev(chunk, state.onwrite);else stream._write(chunk, encoding, state.onwrite);
+    state.sync = false;
+  }
+  
+  function onwriteError(stream, state, sync, er, cb) {
+    --state.pendingcb;
+  
+    if (sync) {
+      // defer the callback if we are being called synchronously
+      // to avoid piling up things on the stack
+      processNextTick(cb, er);
+      // this can emit finish, and it will always happen
+      // after error
+      processNextTick(finishMaybe, stream, state);
+      stream._writableState.errorEmitted = true;
+      stream.emit('error', er);
+    } else {
+      // the caller expect this to happen before if
+      // it is async
+      cb(er);
+      stream._writableState.errorEmitted = true;
+      stream.emit('error', er);
+      // this can emit finish, but finish must
+      // always follow error
+      finishMaybe(stream, state);
+    }
+  }
+  
+  function onwriteStateUpdate(state) {
+    state.writing = false;
+    state.writecb = null;
+    state.length -= state.writelen;
+    state.writelen = 0;
+  }
+  
+  function onwrite(stream, er) {
+    var state = stream._writableState;
+    var sync = state.sync;
+    var cb = state.writecb;
+  
+    onwriteStateUpdate(state);
+  
+    if (er) onwriteError(stream, state, sync, er, cb);else {
+      // Check if we're actually ready to finish, but don't emit yet
+      var finished = needFinish(state);
+  
+      if (!finished && !state.corked && !state.bufferProcessing && state.bufferedRequest) {
+        clearBuffer(stream, state);
+      }
+  
+      if (sync) {
+        /*<replacement>*/
+        asyncWrite(afterWrite, stream, state, finished, cb);
+        /*</replacement>*/
+      } else {
+        afterWrite(stream, state, finished, cb);
+      }
+    }
+  }
+  
+  function afterWrite(stream, state, finished, cb) {
+    if (!finished) onwriteDrain(stream, state);
+    state.pendingcb--;
+    cb();
+    finishMaybe(stream, state);
+  }
+  
+  // Must force callback to be called on nextTick, so that we don't
+  // emit 'drain' before the write() consumer gets the 'false' return
+  // value, and has a chance to attach a 'drain' listener.
+  function onwriteDrain(stream, state) {
+    if (state.length === 0 && state.needDrain) {
+      state.needDrain = false;
+      stream.emit('drain');
+    }
+  }
+  
+  // if there's something in the buffer waiting, then process it
+  function clearBuffer(stream, state) {
+    state.bufferProcessing = true;
+    var entry = state.bufferedRequest;
+  
+    if (stream._writev && entry && entry.next) {
+      // Fast case, write everything using _writev()
+      var l = state.bufferedRequestCount;
+      var buffer = new Array(l);
+      var holder = state.corkedRequestsFree;
+      holder.entry = entry;
+  
+      var count = 0;
+      var allBuffers = true;
+      while (entry) {
+        buffer[count] = entry;
+        if (!entry.isBuf) allBuffers = false;
+        entry = entry.next;
+        count += 1;
+      }
+      buffer.allBuffers = allBuffers;
+  
+      doWrite(stream, state, true, state.length, buffer, '', holder.finish);
+  
+      // doWrite is almost always async, defer these to save a bit of time
+      // as the hot path ends with doWrite
+      state.pendingcb++;
+      state.lastBufferedRequest = null;
+      if (holder.next) {
+        state.corkedRequestsFree = holder.next;
+        holder.next = null;
+      } else {
+        state.corkedRequestsFree = new CorkedRequest(state);
+      }
+    } else {
+      // Slow case, write chunks one-by-one
+      while (entry) {
+        var chunk = entry.chunk;
+        var encoding = entry.encoding;
+        var cb = entry.callback;
+        var len = state.objectMode ? 1 : chunk.length;
+  
+        doWrite(stream, state, false, len, chunk, encoding, cb);
+        entry = entry.next;
+        // if we didn't call the onwrite immediately, then
+        // it means that we need to wait until it does.
+        // also, that means that the chunk and cb are currently
+        // being processed, so move the buffer counter past them.
+        if (state.writing) {
+          break;
+        }
+      }
+  
+      if (entry === null) state.lastBufferedRequest = null;
+    }
+  
+    state.bufferedRequestCount = 0;
+    state.bufferedRequest = entry;
+    state.bufferProcessing = false;
+  }
+  
+  Writable.prototype._write = function (chunk, encoding, cb) {
+    cb(new Error('_write() is not implemented'));
+  };
+  
+  Writable.prototype._writev = null;
+  
+  Writable.prototype.end = function (chunk, encoding, cb) {
+    var state = this._writableState;
+  
+    if (typeof chunk === 'function') {
+      cb = chunk;
+      chunk = null;
+      encoding = null;
+    } else if (typeof encoding === 'function') {
+      cb = encoding;
+      encoding = null;
+    }
+  
+    if (chunk !== null && chunk !== undefined) this.write(chunk, encoding);
+  
+    // .end() fully uncorks
+    if (state.corked) {
+      state.corked = 1;
+      this.uncork();
+    }
+  
+    // ignore unnecessary end() calls.
+    if (!state.ending && !state.finished) endWritable(this, state, cb);
+  };
+  
+  function needFinish(state) {
+    return state.ending && state.length === 0 && state.bufferedRequest === null && !state.finished && !state.writing;
+  }
+  function callFinal(stream, state) {
+    stream._final(function (err) {
+      state.pendingcb--;
+      if (err) {
+        stream.emit('error', err);
+      }
+      state.prefinished = true;
+      stream.emit('prefinish');
+      finishMaybe(stream, state);
+    });
+  }
+  function prefinish(stream, state) {
+    if (!state.prefinished && !state.finalCalled) {
+      if (typeof stream._final === 'function') {
+        state.pendingcb++;
+        state.finalCalled = true;
+        processNextTick(callFinal, stream, state);
+      } else {
+        state.prefinished = true;
+        stream.emit('prefinish');
+      }
+    }
+  }
+  
+  function finishMaybe(stream, state) {
+    var need = needFinish(state);
+    if (need) {
+      prefinish(stream, state);
+      if (state.pendingcb === 0) {
+        state.finished = true;
+        stream.emit('finish');
+      }
+    }
+    return need;
+  }
+  
+  function endWritable(stream, state, cb) {
+    state.ending = true;
+    finishMaybe(stream, state);
+    if (cb) {
+      if (state.finished) processNextTick(cb);else stream.once('finish', cb);
+    }
+    state.ended = true;
+    stream.writable = false;
+  }
+  
+  function onCorkedFinish(corkReq, state, err) {
+    var entry = corkReq.entry;
+    corkReq.entry = null;
+    while (entry) {
+      var cb = entry.callback;
+      state.pendingcb--;
+      cb(err);
+      entry = entry.next;
+    }
+    if (state.corkedRequestsFree) {
+      state.corkedRequestsFree.next = corkReq;
+    } else {
+      state.corkedRequestsFree = corkReq;
+    }
+  }
+  
+  Object.defineProperty(Writable.prototype, 'destroyed', {
+    get: function () {
+      if (this._writableState === undefined) {
+        return false;
+      }
+      return this._writableState.destroyed;
+    },
+    set: function (value) {
+      // we ignore the value if the stream
+      // has not been initialized yet
+      if (!this._writableState) {
+        return;
+      }
+  
+      // backward compatibility, the user is explicitly
+      // managing destroyed
+      this._writableState.destroyed = value;
+    }
+  });
+  
+  Writable.prototype.destroy = destroyImpl.destroy;
+  Writable.prototype._undestroy = destroyImpl.undestroy;
+  Writable.prototype._destroy = function (err, cb) {
+    this.end();
+    cb(err);
+  };
+  }).call(this,require('_process'),typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+  },{"./_stream_duplex":27,"./internal/streams/destroy":33,"./internal/streams/stream":34,"_process":25,"core-util-is":14,"inherits":21,"process-nextick-args":24,"safe-buffer":40,"util-deprecate":51}],32:[function(require,module,exports){
+  'use strict';
+  
+  /*<replacement>*/
+  
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+  
+  var Buffer = require('safe-buffer').Buffer;
+  /*</replacement>*/
+  
+  function copyBuffer(src, target, offset) {
+    src.copy(target, offset);
+  }
+  
+  module.exports = function () {
+    function BufferList() {
+      _classCallCheck(this, BufferList);
+  
+      this.head = null;
+      this.tail = null;
+      this.length = 0;
+    }
+  
+    BufferList.prototype.push = function push(v) {
+      var entry = { data: v, next: null };
+      if (this.length > 0) this.tail.next = entry;else this.head = entry;
+      this.tail = entry;
+      ++this.length;
+    };
+  
+    BufferList.prototype.unshift = function unshift(v) {
+      var entry = { data: v, next: this.head };
+      if (this.length === 0) this.tail = entry;
+      this.head = entry;
+      ++this.length;
+    };
+  
+    BufferList.prototype.shift = function shift() {
+      if (this.length === 0) return;
+      var ret = this.head.data;
+      if (this.length === 1) this.head = this.tail = null;else this.head = this.head.next;
+      --this.length;
+      return ret;
+    };
+  
+    BufferList.prototype.clear = function clear() {
+      this.head = this.tail = null;
+      this.length = 0;
+    };
+  
+    BufferList.prototype.join = function join(s) {
+      if (this.length === 0) return '';
+      var p = this.head;
+      var ret = '' + p.data;
+      while (p = p.next) {
+        ret += s + p.data;
+      }return ret;
+    };
+  
+    BufferList.prototype.concat = function concat(n) {
+      if (this.length === 0) return Buffer.alloc(0);
+      if (this.length === 1) return this.head.data;
+      var ret = Buffer.allocUnsafe(n >>> 0);
+      var p = this.head;
+      var i = 0;
+      while (p) {
+        copyBuffer(p.data, ret, i);
+        i += p.data.length;
+        p = p.next;
+      }
+      return ret;
+    };
+  
+    return BufferList;
+  }();
+  },{"safe-buffer":40}],33:[function(require,module,exports){
+  'use strict';
+  
+  /*<replacement>*/
+  
+  var processNextTick = require('process-nextick-args');
+  /*</replacement>*/
+  
+  // undocumented cb() API, needed for core, not for public API
+  function destroy(err, cb) {
+    var _this = this;
+  
+    var readableDestroyed = this._readableState && this._readableState.destroyed;
+    var writableDestroyed = this._writableState && this._writableState.destroyed;
+  
+    if (readableDestroyed || writableDestroyed) {
+      if (cb) {
+        cb(err);
+      } else if (err && (!this._writableState || !this._writableState.errorEmitted)) {
+        processNextTick(emitErrorNT, this, err);
+      }
+      return;
+    }
+  
+    // we set destroyed to true before firing error callbacks in order
+    // to make it re-entrance safe in case destroy() is called within callbacks
+  
+    if (this._readableState) {
+      this._readableState.destroyed = true;
+    }
+  
+    // if this is a duplex stream mark the writable part as destroyed as well
+    if (this._writableState) {
+      this._writableState.destroyed = true;
+    }
+  
+    this._destroy(err || null, function (err) {
+      if (!cb && err) {
+        processNextTick(emitErrorNT, _this, err);
+        if (_this._writableState) {
+          _this._writableState.errorEmitted = true;
+        }
+      } else if (cb) {
+        cb(err);
+      }
+    });
+  }
+  
+  function undestroy() {
+    if (this._readableState) {
+      this._readableState.destroyed = false;
+      this._readableState.reading = false;
+      this._readableState.ended = false;
+      this._readableState.endEmitted = false;
+    }
+  
+    if (this._writableState) {
+      this._writableState.destroyed = false;
+      this._writableState.ended = false;
+      this._writableState.ending = false;
+      this._writableState.finished = false;
+      this._writableState.errorEmitted = false;
+    }
+  }
+  
+  function emitErrorNT(self, err) {
+    self.emit('error', err);
+  }
+  
+  module.exports = {
+    destroy: destroy,
+    undestroy: undestroy
+  };
+  },{"process-nextick-args":24}],34:[function(require,module,exports){
+  module.exports = require('events').EventEmitter;
+  
+  },{"events":18}],35:[function(require,module,exports){
+  module.exports = require('./readable').PassThrough
+  
+  },{"./readable":36}],36:[function(require,module,exports){
+  exports = module.exports = require('./lib/_stream_readable.js');
+  exports.Stream = exports;
+  exports.Readable = exports;
+  exports.Writable = require('./lib/_stream_writable.js');
+  exports.Duplex = require('./lib/_stream_duplex.js');
+  exports.Transform = require('./lib/_stream_transform.js');
+  exports.PassThrough = require('./lib/_stream_passthrough.js');
+  
+  },{"./lib/_stream_duplex.js":27,"./lib/_stream_passthrough.js":28,"./lib/_stream_readable.js":29,"./lib/_stream_transform.js":30,"./lib/_stream_writable.js":31}],37:[function(require,module,exports){
+  module.exports = require('./readable').Transform
+  
+  },{"./readable":36}],38:[function(require,module,exports){
+  module.exports = require('./lib/_stream_writable.js');
+  
+  },{"./lib/_stream_writable.js":31}],39:[function(require,module,exports){
+  (function (Buffer){
+  'use strict'
+  var inherits = require('inherits')
+  var HashBase = require('hash-base')
+  
+  function RIPEMD160 () {
+    HashBase.call(this, 64)
+  
+    // state
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
+  }
+  
+  inherits(RIPEMD160, HashBase)
+  
+  RIPEMD160.prototype._update = function () {
+    var m = new Array(16)
+    for (var i = 0; i < 16; ++i) m[i] = this._block.readInt32LE(i * 4)
+  
+    var al = this._a
+    var bl = this._b
+    var cl = this._c
+    var dl = this._d
+    var el = this._e
+  
+    // Mj = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    // K = 0x00000000
+    // Sj = 11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8
+    al = fn1(al, bl, cl, dl, el, m[0], 0x00000000, 11); cl = rotl(cl, 10)
+    el = fn1(el, al, bl, cl, dl, m[1], 0x00000000, 14); bl = rotl(bl, 10)
+    dl = fn1(dl, el, al, bl, cl, m[2], 0x00000000, 15); al = rotl(al, 10)
+    cl = fn1(cl, dl, el, al, bl, m[3], 0x00000000, 12); el = rotl(el, 10)
+    bl = fn1(bl, cl, dl, el, al, m[4], 0x00000000, 5); dl = rotl(dl, 10)
+    al = fn1(al, bl, cl, dl, el, m[5], 0x00000000, 8); cl = rotl(cl, 10)
+    el = fn1(el, al, bl, cl, dl, m[6], 0x00000000, 7); bl = rotl(bl, 10)
+    dl = fn1(dl, el, al, bl, cl, m[7], 0x00000000, 9); al = rotl(al, 10)
+    cl = fn1(cl, dl, el, al, bl, m[8], 0x00000000, 11); el = rotl(el, 10)
+    bl = fn1(bl, cl, dl, el, al, m[9], 0x00000000, 13); dl = rotl(dl, 10)
+    al = fn1(al, bl, cl, dl, el, m[10], 0x00000000, 14); cl = rotl(cl, 10)
+    el = fn1(el, al, bl, cl, dl, m[11], 0x00000000, 15); bl = rotl(bl, 10)
+    dl = fn1(dl, el, al, bl, cl, m[12], 0x00000000, 6); al = rotl(al, 10)
+    cl = fn1(cl, dl, el, al, bl, m[13], 0x00000000, 7); el = rotl(el, 10)
+    bl = fn1(bl, cl, dl, el, al, m[14], 0x00000000, 9); dl = rotl(dl, 10)
+    al = fn1(al, bl, cl, dl, el, m[15], 0x00000000, 8); cl = rotl(cl, 10)
+  
+    // Mj = 7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8
+    // K = 0x5a827999
+    // Sj = 7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12
+    el = fn2(el, al, bl, cl, dl, m[7], 0x5a827999, 7); bl = rotl(bl, 10)
+    dl = fn2(dl, el, al, bl, cl, m[4], 0x5a827999, 6); al = rotl(al, 10)
+    cl = fn2(cl, dl, el, al, bl, m[13], 0x5a827999, 8); el = rotl(el, 10)
+    bl = fn2(bl, cl, dl, el, al, m[1], 0x5a827999, 13); dl = rotl(dl, 10)
+    al = fn2(al, bl, cl, dl, el, m[10], 0x5a827999, 11); cl = rotl(cl, 10)
+    el = fn2(el, al, bl, cl, dl, m[6], 0x5a827999, 9); bl = rotl(bl, 10)
+    dl = fn2(dl, el, al, bl, cl, m[15], 0x5a827999, 7); al = rotl(al, 10)
+    cl = fn2(cl, dl, el, al, bl, m[3], 0x5a827999, 15); el = rotl(el, 10)
+    bl = fn2(bl, cl, dl, el, al, m[12], 0x5a827999, 7); dl = rotl(dl, 10)
+    al = fn2(al, bl, cl, dl, el, m[0], 0x5a827999, 12); cl = rotl(cl, 10)
+    el = fn2(el, al, bl, cl, dl, m[9], 0x5a827999, 15); bl = rotl(bl, 10)
+    dl = fn2(dl, el, al, bl, cl, m[5], 0x5a827999, 9); al = rotl(al, 10)
+    cl = fn2(cl, dl, el, al, bl, m[2], 0x5a827999, 11); el = rotl(el, 10)
+    bl = fn2(bl, cl, dl, el, al, m[14], 0x5a827999, 7); dl = rotl(dl, 10)
+    al = fn2(al, bl, cl, dl, el, m[11], 0x5a827999, 13); cl = rotl(cl, 10)
+    el = fn2(el, al, bl, cl, dl, m[8], 0x5a827999, 12); bl = rotl(bl, 10)
+  
+    // Mj = 3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12
+    // K = 0x6ed9eba1
+    // Sj = 11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5
+    dl = fn3(dl, el, al, bl, cl, m[3], 0x6ed9eba1, 11); al = rotl(al, 10)
+    cl = fn3(cl, dl, el, al, bl, m[10], 0x6ed9eba1, 13); el = rotl(el, 10)
+    bl = fn3(bl, cl, dl, el, al, m[14], 0x6ed9eba1, 6); dl = rotl(dl, 10)
+    al = fn3(al, bl, cl, dl, el, m[4], 0x6ed9eba1, 7); cl = rotl(cl, 10)
+    el = fn3(el, al, bl, cl, dl, m[9], 0x6ed9eba1, 14); bl = rotl(bl, 10)
+    dl = fn3(dl, el, al, bl, cl, m[15], 0x6ed9eba1, 9); al = rotl(al, 10)
+    cl = fn3(cl, dl, el, al, bl, m[8], 0x6ed9eba1, 13); el = rotl(el, 10)
+    bl = fn3(bl, cl, dl, el, al, m[1], 0x6ed9eba1, 15); dl = rotl(dl, 10)
+    al = fn3(al, bl, cl, dl, el, m[2], 0x6ed9eba1, 14); cl = rotl(cl, 10)
+    el = fn3(el, al, bl, cl, dl, m[7], 0x6ed9eba1, 8); bl = rotl(bl, 10)
+    dl = fn3(dl, el, al, bl, cl, m[0], 0x6ed9eba1, 13); al = rotl(al, 10)
+    cl = fn3(cl, dl, el, al, bl, m[6], 0x6ed9eba1, 6); el = rotl(el, 10)
+    bl = fn3(bl, cl, dl, el, al, m[13], 0x6ed9eba1, 5); dl = rotl(dl, 10)
+    al = fn3(al, bl, cl, dl, el, m[11], 0x6ed9eba1, 12); cl = rotl(cl, 10)
+    el = fn3(el, al, bl, cl, dl, m[5], 0x6ed9eba1, 7); bl = rotl(bl, 10)
+    dl = fn3(dl, el, al, bl, cl, m[12], 0x6ed9eba1, 5); al = rotl(al, 10)
+  
+    // Mj = 1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2
+    // K = 0x8f1bbcdc
+    // Sj = 11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12
+    cl = fn4(cl, dl, el, al, bl, m[1], 0x8f1bbcdc, 11); el = rotl(el, 10)
+    bl = fn4(bl, cl, dl, el, al, m[9], 0x8f1bbcdc, 12); dl = rotl(dl, 10)
+    al = fn4(al, bl, cl, dl, el, m[11], 0x8f1bbcdc, 14); cl = rotl(cl, 10)
+    el = fn4(el, al, bl, cl, dl, m[10], 0x8f1bbcdc, 15); bl = rotl(bl, 10)
+    dl = fn4(dl, el, al, bl, cl, m[0], 0x8f1bbcdc, 14); al = rotl(al, 10)
+    cl = fn4(cl, dl, el, al, bl, m[8], 0x8f1bbcdc, 15); el = rotl(el, 10)
+    bl = fn4(bl, cl, dl, el, al, m[12], 0x8f1bbcdc, 9); dl = rotl(dl, 10)
+    al = fn4(al, bl, cl, dl, el, m[4], 0x8f1bbcdc, 8); cl = rotl(cl, 10)
+    el = fn4(el, al, bl, cl, dl, m[13], 0x8f1bbcdc, 9); bl = rotl(bl, 10)
+    dl = fn4(dl, el, al, bl, cl, m[3], 0x8f1bbcdc, 14); al = rotl(al, 10)
+    cl = fn4(cl, dl, el, al, bl, m[7], 0x8f1bbcdc, 5); el = rotl(el, 10)
+    bl = fn4(bl, cl, dl, el, al, m[15], 0x8f1bbcdc, 6); dl = rotl(dl, 10)
+    al = fn4(al, bl, cl, dl, el, m[14], 0x8f1bbcdc, 8); cl = rotl(cl, 10)
+    el = fn4(el, al, bl, cl, dl, m[5], 0x8f1bbcdc, 6); bl = rotl(bl, 10)
+    dl = fn4(dl, el, al, bl, cl, m[6], 0x8f1bbcdc, 5); al = rotl(al, 10)
+    cl = fn4(cl, dl, el, al, bl, m[2], 0x8f1bbcdc, 12); el = rotl(el, 10)
+  
+    // Mj = 4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15, 13
+    // K = 0xa953fd4e
+    // Sj = 9, 15, 5, 11, 6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6
+    bl = fn5(bl, cl, dl, el, al, m[4], 0xa953fd4e, 9); dl = rotl(dl, 10)
+    al = fn5(al, bl, cl, dl, el, m[0], 0xa953fd4e, 15); cl = rotl(cl, 10)
+    el = fn5(el, al, bl, cl, dl, m[5], 0xa953fd4e, 5); bl = rotl(bl, 10)
+    dl = fn5(dl, el, al, bl, cl, m[9], 0xa953fd4e, 11); al = rotl(al, 10)
+    cl = fn5(cl, dl, el, al, bl, m[7], 0xa953fd4e, 6); el = rotl(el, 10)
+    bl = fn5(bl, cl, dl, el, al, m[12], 0xa953fd4e, 8); dl = rotl(dl, 10)
+    al = fn5(al, bl, cl, dl, el, m[2], 0xa953fd4e, 13); cl = rotl(cl, 10)
+    el = fn5(el, al, bl, cl, dl, m[10], 0xa953fd4e, 12); bl = rotl(bl, 10)
+    dl = fn5(dl, el, al, bl, cl, m[14], 0xa953fd4e, 5); al = rotl(al, 10)
+    cl = fn5(cl, dl, el, al, bl, m[1], 0xa953fd4e, 12); el = rotl(el, 10)
+    bl = fn5(bl, cl, dl, el, al, m[3], 0xa953fd4e, 13); dl = rotl(dl, 10)
+    al = fn5(al, bl, cl, dl, el, m[8], 0xa953fd4e, 14); cl = rotl(cl, 10)
+    el = fn5(el, al, bl, cl, dl, m[11], 0xa953fd4e, 11); bl = rotl(bl, 10)
+    dl = fn5(dl, el, al, bl, cl, m[6], 0xa953fd4e, 8); al = rotl(al, 10)
+    cl = fn5(cl, dl, el, al, bl, m[15], 0xa953fd4e, 5); el = rotl(el, 10)
+    bl = fn5(bl, cl, dl, el, al, m[13], 0xa953fd4e, 6); dl = rotl(dl, 10)
+  
+    var ar = this._a
+    var br = this._b
+    var cr = this._c
+    var dr = this._d
+    var er = this._e
+  
+    // M'j = 5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12
+    // K' = 0x50a28be6
+    // S'j = 8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6
+    ar = fn5(ar, br, cr, dr, er, m[5], 0x50a28be6, 8); cr = rotl(cr, 10)
+    er = fn5(er, ar, br, cr, dr, m[14], 0x50a28be6, 9); br = rotl(br, 10)
+    dr = fn5(dr, er, ar, br, cr, m[7], 0x50a28be6, 9); ar = rotl(ar, 10)
+    cr = fn5(cr, dr, er, ar, br, m[0], 0x50a28be6, 11); er = rotl(er, 10)
+    br = fn5(br, cr, dr, er, ar, m[9], 0x50a28be6, 13); dr = rotl(dr, 10)
+    ar = fn5(ar, br, cr, dr, er, m[2], 0x50a28be6, 15); cr = rotl(cr, 10)
+    er = fn5(er, ar, br, cr, dr, m[11], 0x50a28be6, 15); br = rotl(br, 10)
+    dr = fn5(dr, er, ar, br, cr, m[4], 0x50a28be6, 5); ar = rotl(ar, 10)
+    cr = fn5(cr, dr, er, ar, br, m[13], 0x50a28be6, 7); er = rotl(er, 10)
+    br = fn5(br, cr, dr, er, ar, m[6], 0x50a28be6, 7); dr = rotl(dr, 10)
+    ar = fn5(ar, br, cr, dr, er, m[15], 0x50a28be6, 8); cr = rotl(cr, 10)
+    er = fn5(er, ar, br, cr, dr, m[8], 0x50a28be6, 11); br = rotl(br, 10)
+    dr = fn5(dr, er, ar, br, cr, m[1], 0x50a28be6, 14); ar = rotl(ar, 10)
+    cr = fn5(cr, dr, er, ar, br, m[10], 0x50a28be6, 14); er = rotl(er, 10)
+    br = fn5(br, cr, dr, er, ar, m[3], 0x50a28be6, 12); dr = rotl(dr, 10)
+    ar = fn5(ar, br, cr, dr, er, m[12], 0x50a28be6, 6); cr = rotl(cr, 10)
+  
+    // M'j = 6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2
+    // K' = 0x5c4dd124
+    // S'j = 9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11
+    er = fn4(er, ar, br, cr, dr, m[6], 0x5c4dd124, 9); br = rotl(br, 10)
+    dr = fn4(dr, er, ar, br, cr, m[11], 0x5c4dd124, 13); ar = rotl(ar, 10)
+    cr = fn4(cr, dr, er, ar, br, m[3], 0x5c4dd124, 15); er = rotl(er, 10)
+    br = fn4(br, cr, dr, er, ar, m[7], 0x5c4dd124, 7); dr = rotl(dr, 10)
+    ar = fn4(ar, br, cr, dr, er, m[0], 0x5c4dd124, 12); cr = rotl(cr, 10)
+    er = fn4(er, ar, br, cr, dr, m[13], 0x5c4dd124, 8); br = rotl(br, 10)
+    dr = fn4(dr, er, ar, br, cr, m[5], 0x5c4dd124, 9); ar = rotl(ar, 10)
+    cr = fn4(cr, dr, er, ar, br, m[10], 0x5c4dd124, 11); er = rotl(er, 10)
+    br = fn4(br, cr, dr, er, ar, m[14], 0x5c4dd124, 7); dr = rotl(dr, 10)
+    ar = fn4(ar, br, cr, dr, er, m[15], 0x5c4dd124, 7); cr = rotl(cr, 10)
+    er = fn4(er, ar, br, cr, dr, m[8], 0x5c4dd124, 12); br = rotl(br, 10)
+    dr = fn4(dr, er, ar, br, cr, m[12], 0x5c4dd124, 7); ar = rotl(ar, 10)
+    cr = fn4(cr, dr, er, ar, br, m[4], 0x5c4dd124, 6); er = rotl(er, 10)
+    br = fn4(br, cr, dr, er, ar, m[9], 0x5c4dd124, 15); dr = rotl(dr, 10)
+    ar = fn4(ar, br, cr, dr, er, m[1], 0x5c4dd124, 13); cr = rotl(cr, 10)
+    er = fn4(er, ar, br, cr, dr, m[2], 0x5c4dd124, 11); br = rotl(br, 10)
+  
+    // M'j = 15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13
+    // K' = 0x6d703ef3
+    // S'j = 9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5
+    dr = fn3(dr, er, ar, br, cr, m[15], 0x6d703ef3, 9); ar = rotl(ar, 10)
+    cr = fn3(cr, dr, er, ar, br, m[5], 0x6d703ef3, 7); er = rotl(er, 10)
+    br = fn3(br, cr, dr, er, ar, m[1], 0x6d703ef3, 15); dr = rotl(dr, 10)
+    ar = fn3(ar, br, cr, dr, er, m[3], 0x6d703ef3, 11); cr = rotl(cr, 10)
+    er = fn3(er, ar, br, cr, dr, m[7], 0x6d703ef3, 8); br = rotl(br, 10)
+    dr = fn3(dr, er, ar, br, cr, m[14], 0x6d703ef3, 6); ar = rotl(ar, 10)
+    cr = fn3(cr, dr, er, ar, br, m[6], 0x6d703ef3, 6); er = rotl(er, 10)
+    br = fn3(br, cr, dr, er, ar, m[9], 0x6d703ef3, 14); dr = rotl(dr, 10)
+    ar = fn3(ar, br, cr, dr, er, m[11], 0x6d703ef3, 12); cr = rotl(cr, 10)
+    er = fn3(er, ar, br, cr, dr, m[8], 0x6d703ef3, 13); br = rotl(br, 10)
+    dr = fn3(dr, er, ar, br, cr, m[12], 0x6d703ef3, 5); ar = rotl(ar, 10)
+    cr = fn3(cr, dr, er, ar, br, m[2], 0x6d703ef3, 14); er = rotl(er, 10)
+    br = fn3(br, cr, dr, er, ar, m[10], 0x6d703ef3, 13); dr = rotl(dr, 10)
+    ar = fn3(ar, br, cr, dr, er, m[0], 0x6d703ef3, 13); cr = rotl(cr, 10)
+    er = fn3(er, ar, br, cr, dr, m[4], 0x6d703ef3, 7); br = rotl(br, 10)
+    dr = fn3(dr, er, ar, br, cr, m[13], 0x6d703ef3, 5); ar = rotl(ar, 10)
+  
+    // M'j = 8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14
+    // K' = 0x7a6d76e9
+    // S'j = 15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8
+    cr = fn2(cr, dr, er, ar, br, m[8], 0x7a6d76e9, 15); er = rotl(er, 10)
+    br = fn2(br, cr, dr, er, ar, m[6], 0x7a6d76e9, 5); dr = rotl(dr, 10)
+    ar = fn2(ar, br, cr, dr, er, m[4], 0x7a6d76e9, 8); cr = rotl(cr, 10)
+    er = fn2(er, ar, br, cr, dr, m[1], 0x7a6d76e9, 11); br = rotl(br, 10)
+    dr = fn2(dr, er, ar, br, cr, m[3], 0x7a6d76e9, 14); ar = rotl(ar, 10)
+    cr = fn2(cr, dr, er, ar, br, m[11], 0x7a6d76e9, 14); er = rotl(er, 10)
+    br = fn2(br, cr, dr, er, ar, m[15], 0x7a6d76e9, 6); dr = rotl(dr, 10)
+    ar = fn2(ar, br, cr, dr, er, m[0], 0x7a6d76e9, 14); cr = rotl(cr, 10)
+    er = fn2(er, ar, br, cr, dr, m[5], 0x7a6d76e9, 6); br = rotl(br, 10)
+    dr = fn2(dr, er, ar, br, cr, m[12], 0x7a6d76e9, 9); ar = rotl(ar, 10)
+    cr = fn2(cr, dr, er, ar, br, m[2], 0x7a6d76e9, 12); er = rotl(er, 10)
+    br = fn2(br, cr, dr, er, ar, m[13], 0x7a6d76e9, 9); dr = rotl(dr, 10)
+    ar = fn2(ar, br, cr, dr, er, m[9], 0x7a6d76e9, 12); cr = rotl(cr, 10)
+    er = fn2(er, ar, br, cr, dr, m[7], 0x7a6d76e9, 5); br = rotl(br, 10)
+    dr = fn2(dr, er, ar, br, cr, m[10], 0x7a6d76e9, 15); ar = rotl(ar, 10)
+    cr = fn2(cr, dr, er, ar, br, m[14], 0x7a6d76e9, 8); er = rotl(er, 10)
+  
+    // M'j = 12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14, 0, 3, 9, 11
+    // K' = 0x00000000
+    // S'j = 8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11
+    br = fn1(br, cr, dr, er, ar, m[12], 0x00000000, 8); dr = rotl(dr, 10)
+    ar = fn1(ar, br, cr, dr, er, m[15], 0x00000000, 5); cr = rotl(cr, 10)
+    er = fn1(er, ar, br, cr, dr, m[10], 0x00000000, 12); br = rotl(br, 10)
+    dr = fn1(dr, er, ar, br, cr, m[4], 0x00000000, 9); ar = rotl(ar, 10)
+    cr = fn1(cr, dr, er, ar, br, m[1], 0x00000000, 12); er = rotl(er, 10)
+    br = fn1(br, cr, dr, er, ar, m[5], 0x00000000, 5); dr = rotl(dr, 10)
+    ar = fn1(ar, br, cr, dr, er, m[8], 0x00000000, 14); cr = rotl(cr, 10)
+    er = fn1(er, ar, br, cr, dr, m[7], 0x00000000, 6); br = rotl(br, 10)
+    dr = fn1(dr, er, ar, br, cr, m[6], 0x00000000, 8); ar = rotl(ar, 10)
+    cr = fn1(cr, dr, er, ar, br, m[2], 0x00000000, 13); er = rotl(er, 10)
+    br = fn1(br, cr, dr, er, ar, m[13], 0x00000000, 6); dr = rotl(dr, 10)
+    ar = fn1(ar, br, cr, dr, er, m[14], 0x00000000, 5); cr = rotl(cr, 10)
+    er = fn1(er, ar, br, cr, dr, m[0], 0x00000000, 15); br = rotl(br, 10)
+    dr = fn1(dr, er, ar, br, cr, m[3], 0x00000000, 13); ar = rotl(ar, 10)
+    cr = fn1(cr, dr, er, ar, br, m[9], 0x00000000, 11); er = rotl(er, 10)
+    br = fn1(br, cr, dr, er, ar, m[11], 0x00000000, 11); dr = rotl(dr, 10)
+  
+    // change state
+    var t = (this._b + cl + dr) | 0
+    this._b = (this._c + dl + er) | 0
+    this._c = (this._d + el + ar) | 0
+    this._d = (this._e + al + br) | 0
+    this._e = (this._a + bl + cr) | 0
+    this._a = t
+  }
+  
+  RIPEMD160.prototype._digest = function () {
+    // create padding and handle blocks
+    this._block[this._blockOffset++] = 0x80
+    if (this._blockOffset > 56) {
+      this._block.fill(0, this._blockOffset, 64)
+      this._update()
+      this._blockOffset = 0
+    }
+  
+    this._block.fill(0, this._blockOffset, 56)
+    this._block.writeUInt32LE(this._length[0], 56)
+    this._block.writeUInt32LE(this._length[1], 60)
+    this._update()
+  
+    // produce result
+    var buffer = new Buffer(20)
+    buffer.writeInt32LE(this._a, 0)
+    buffer.writeInt32LE(this._b, 4)
+    buffer.writeInt32LE(this._c, 8)
+    buffer.writeInt32LE(this._d, 12)
+    buffer.writeInt32LE(this._e, 16)
+    return buffer
+  }
+  
+  function rotl (x, n) {
+    return (x << n) | (x >>> (32 - n))
+  }
+  
+  function fn1 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + (b ^ c ^ d) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn2 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + ((b & c) | ((~b) & d)) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn3 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + ((b | (~c)) ^ d) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn4 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + ((b & d) | (c & (~d))) + m + k) | 0, s) + e) | 0
+  }
+  
+  function fn5 (a, b, c, d, e, m, k, s) {
+    return (rotl((a + (b ^ (c | (~d))) + m + k) | 0, s) + e) | 0
+  }
+  
+  module.exports = RIPEMD160
+  
+  }).call(this,require("buffer").Buffer)
+  },{"buffer":8,"hash-base":19,"inherits":21}],40:[function(require,module,exports){
+  /* eslint-disable node/no-deprecated-api */
+  var buffer = require('buffer')
+  var Buffer = buffer.Buffer
+  
+  // alternative to using Object.keys for old browsers
+  function copyProps (src, dst) {
+    for (var key in src) {
+      dst[key] = src[key]
+    }
+  }
+  if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+    module.exports = buffer
+  } else {
+    // Copy properties from require('buffer')
+    copyProps(buffer, exports)
+    exports.Buffer = SafeBuffer
+  }
+  
+  function SafeBuffer (arg, encodingOrOffset, length) {
+    return Buffer(arg, encodingOrOffset, length)
+  }
+  
+  // Copy static methods from Buffer
+  copyProps(Buffer, SafeBuffer)
+  
+  SafeBuffer.from = function (arg, encodingOrOffset, length) {
+    if (typeof arg === 'number') {
+      throw new TypeError('Argument must not be a number')
+    }
+    return Buffer(arg, encodingOrOffset, length)
+  }
+  
+  SafeBuffer.alloc = function (size, fill, encoding) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Argument must be a number')
+    }
+    var buf = Buffer(size)
+    if (fill !== undefined) {
+      if (typeof encoding === 'string') {
+        buf.fill(fill, encoding)
+      } else {
+        buf.fill(fill)
+      }
+    } else {
+      buf.fill(0)
+    }
+    return buf
+  }
+  
+  SafeBuffer.allocUnsafe = function (size) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Argument must be a number')
+    }
+    return Buffer(size)
+  }
+  
+  SafeBuffer.allocUnsafeSlow = function (size) {
+    if (typeof size !== 'number') {
+      throw new TypeError('Argument must be a number')
+    }
+    return buffer.SlowBuffer(size)
+  }
+  
+  },{"buffer":8}],41:[function(require,module,exports){
+  var Buffer = require('safe-buffer').Buffer
+  
+  // prototype class for hash functions
+  function Hash (blockSize, finalSize) {
+    this._block = Buffer.alloc(blockSize)
+    this._finalSize = finalSize
+    this._blockSize = blockSize
+    this._len = 0
+  }
+  
+  Hash.prototype.update = function (data, enc) {
+    if (typeof data === 'string') {
+      enc = enc || 'utf8'
+      data = Buffer.from(data, enc)
+    }
+  
+    var block = this._block
+    var blockSize = this._blockSize
+    var length = data.length
+    var accum = this._len
+  
+    for (var offset = 0; offset < length;) {
+      var assigned = accum % blockSize
+      var remainder = Math.min(length - offset, blockSize - assigned)
+  
+      for (var i = 0; i < remainder; i++) {
+        block[assigned + i] = data[offset + i]
+      }
+  
+      accum += remainder
+      offset += remainder
+  
+      if ((accum % blockSize) === 0) {
+        this._update(block)
+      }
+    }
+  
+    this._len += length
+    return this
+  }
+  
+  Hash.prototype.digest = function (enc) {
+    var rem = this._len % this._blockSize
+  
+    this._block[rem] = 0x80
+  
+    // zero (rem + 1) trailing bits, where (rem + 1) is the smallest
+    // non-negative solution to the equation (length + 1 + (rem + 1)) === finalSize mod blockSize
+    this._block.fill(0, rem + 1)
+  
+    if (rem >= this._finalSize) {
+      this._update(this._block)
+      this._block.fill(0)
+    }
+  
+    var bits = this._len * 8
+  
+    // uint32
+    if (bits <= 0xffffffff) {
+      this._block.writeUInt32BE(bits, this._blockSize - 4)
+  
+    // uint64
+    } else {
+      var lowBits = bits & 0xffffffff
+      var highBits = (bits - lowBits) / 0x100000000
+  
+      this._block.writeUInt32BE(highBits, this._blockSize - 8)
+      this._block.writeUInt32BE(lowBits, this._blockSize - 4)
+    }
+  
+    this._update(this._block)
+    var hash = this._hash()
+  
+    return enc ? hash.toString(enc) : hash
+  }
+  
+  Hash.prototype._update = function () {
+    throw new Error('_update must be implemented by subclass')
+  }
+  
+  module.exports = Hash
+  
+  },{"safe-buffer":40}],42:[function(require,module,exports){
+  var exports = module.exports = function SHA (algorithm) {
+    algorithm = algorithm.toLowerCase()
+  
+    var Algorithm = exports[algorithm]
+    if (!Algorithm) throw new Error(algorithm + ' is not supported (we accept pull requests)')
+  
+    return new Algorithm()
+  }
+  
+  exports.sha = require('./sha')
+  exports.sha1 = require('./sha1')
+  exports.sha224 = require('./sha224')
+  exports.sha256 = require('./sha256')
+  exports.sha384 = require('./sha384')
+  exports.sha512 = require('./sha512')
+  
+  },{"./sha":43,"./sha1":44,"./sha224":45,"./sha256":46,"./sha384":47,"./sha512":48}],43:[function(require,module,exports){
+  /*
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-0, as defined
+   * in FIPS PUB 180-1
+   * This source code is derived from sha1.js of the same repository.
+   * The difference between SHA-0 and SHA-1 is just a bitwise rotate left
+   * operation was added.
+   */
+  
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0
+  ]
+  
+  var W = new Array(80)
+  
+  function Sha () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha, Hash)
+  
+  Sha.prototype.init = function () {
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
+  
+    return this
+  }
+  
+  function rotl5 (num) {
+    return (num << 5) | (num >>> 27)
+  }
+  
+  function rotl30 (num) {
+    return (num << 30) | (num >>> 2)
+  }
+  
+  function ft (s, b, c, d) {
+    if (s === 0) return (b & c) | ((~b) & d)
+    if (s === 2) return (b & c) | (b & d) | (c & d)
+    return b ^ c ^ d
+  }
+  
+  Sha.prototype._update = function (M) {
+    var W = this._w
+  
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
+  
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+    for (; i < 80; ++i) W[i] = W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16]
+  
+    for (var j = 0; j < 80; ++j) {
+      var s = ~~(j / 20)
+      var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
+  
+      e = d
+      d = c
+      c = rotl30(b)
+      b = a
+      a = t
+    }
+  
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
+  }
+  
+  Sha.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(20)
+  
+    H.writeInt32BE(this._a | 0, 0)
+    H.writeInt32BE(this._b | 0, 4)
+    H.writeInt32BE(this._c | 0, 8)
+    H.writeInt32BE(this._d | 0, 12)
+    H.writeInt32BE(this._e | 0, 16)
+  
+    return H
+  }
+  
+  module.exports = Sha
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],44:[function(require,module,exports){
+  /*
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
+   * in FIPS PUB 180-1
+   * Version 2.1a Copyright Paul Johnston 2000 - 2002.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   * Distributed under the BSD License
+   * See http://pajhome.org.uk/crypt/md5 for details.
+   */
+  
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x5a827999, 0x6ed9eba1, 0x8f1bbcdc | 0, 0xca62c1d6 | 0
+  ]
+  
+  var W = new Array(80)
+  
+  function Sha1 () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha1, Hash)
+  
+  Sha1.prototype.init = function () {
+    this._a = 0x67452301
+    this._b = 0xefcdab89
+    this._c = 0x98badcfe
+    this._d = 0x10325476
+    this._e = 0xc3d2e1f0
+  
+    return this
+  }
+  
+  function rotl1 (num) {
+    return (num << 1) | (num >>> 31)
+  }
+  
+  function rotl5 (num) {
+    return (num << 5) | (num >>> 27)
+  }
+  
+  function rotl30 (num) {
+    return (num << 30) | (num >>> 2)
+  }
+  
+  function ft (s, b, c, d) {
+    if (s === 0) return (b & c) | ((~b) & d)
+    if (s === 2) return (b & c) | (b & d) | (c & d)
+    return b ^ c ^ d
+  }
+  
+  Sha1.prototype._update = function (M) {
+    var W = this._w
+  
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
+  
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+    for (; i < 80; ++i) W[i] = rotl1(W[i - 3] ^ W[i - 8] ^ W[i - 14] ^ W[i - 16])
+  
+    for (var j = 0; j < 80; ++j) {
+      var s = ~~(j / 20)
+      var t = (rotl5(a) + ft(s, b, c, d) + e + W[j] + K[s]) | 0
+  
+      e = d
+      d = c
+      c = rotl30(b)
+      b = a
+      a = t
+    }
+  
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
+  }
+  
+  Sha1.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(20)
+  
+    H.writeInt32BE(this._a | 0, 0)
+    H.writeInt32BE(this._b | 0, 4)
+    H.writeInt32BE(this._c | 0, 8)
+    H.writeInt32BE(this._d | 0, 12)
+    H.writeInt32BE(this._e | 0, 16)
+  
+    return H
+  }
+  
+  module.exports = Sha1
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],45:[function(require,module,exports){
+  /**
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
+   * in FIPS 180-2
+   * Version 2.2-beta Copyright Angel Marin, Paul Johnston 2000 - 2009.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   *
+   */
+  
+  var inherits = require('inherits')
+  var Sha256 = require('./sha256')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var W = new Array(64)
+  
+  function Sha224 () {
+    this.init()
+  
+    this._w = W // new Array(64)
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha224, Sha256)
+  
+  Sha224.prototype.init = function () {
+    this._a = 0xc1059ed8
+    this._b = 0x367cd507
+    this._c = 0x3070dd17
+    this._d = 0xf70e5939
+    this._e = 0xffc00b31
+    this._f = 0x68581511
+    this._g = 0x64f98fa7
+    this._h = 0xbefa4fa4
+  
+    return this
+  }
+  
+  Sha224.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(28)
+  
+    H.writeInt32BE(this._a, 0)
+    H.writeInt32BE(this._b, 4)
+    H.writeInt32BE(this._c, 8)
+    H.writeInt32BE(this._d, 12)
+    H.writeInt32BE(this._e, 16)
+    H.writeInt32BE(this._f, 20)
+    H.writeInt32BE(this._g, 24)
+  
+    return H
+  }
+  
+  module.exports = Sha224
+  
+  },{"./hash":41,"./sha256":46,"inherits":21,"safe-buffer":40}],46:[function(require,module,exports){
+  /**
+   * A JavaScript implementation of the Secure Hash Algorithm, SHA-256, as defined
+   * in FIPS 180-2
+   * Version 2.2-beta Copyright Angel Marin, Paul Johnston 2000 - 2009.
+   * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+   *
+   */
+  
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+  ]
+  
+  var W = new Array(64)
+  
+  function Sha256 () {
+    this.init()
+  
+    this._w = W // new Array(64)
+  
+    Hash.call(this, 64, 56)
+  }
+  
+  inherits(Sha256, Hash)
+  
+  Sha256.prototype.init = function () {
+    this._a = 0x6a09e667
+    this._b = 0xbb67ae85
+    this._c = 0x3c6ef372
+    this._d = 0xa54ff53a
+    this._e = 0x510e527f
+    this._f = 0x9b05688c
+    this._g = 0x1f83d9ab
+    this._h = 0x5be0cd19
+  
+    return this
+  }
+  
+  function ch (x, y, z) {
+    return z ^ (x & (y ^ z))
+  }
+  
+  function maj (x, y, z) {
+    return (x & y) | (z & (x | y))
+  }
+  
+  function sigma0 (x) {
+    return (x >>> 2 | x << 30) ^ (x >>> 13 | x << 19) ^ (x >>> 22 | x << 10)
+  }
+  
+  function sigma1 (x) {
+    return (x >>> 6 | x << 26) ^ (x >>> 11 | x << 21) ^ (x >>> 25 | x << 7)
+  }
+  
+  function gamma0 (x) {
+    return (x >>> 7 | x << 25) ^ (x >>> 18 | x << 14) ^ (x >>> 3)
+  }
+  
+  function gamma1 (x) {
+    return (x >>> 17 | x << 15) ^ (x >>> 19 | x << 13) ^ (x >>> 10)
+  }
+  
+  Sha256.prototype._update = function (M) {
+    var W = this._w
+  
+    var a = this._a | 0
+    var b = this._b | 0
+    var c = this._c | 0
+    var d = this._d | 0
+    var e = this._e | 0
+    var f = this._f | 0
+    var g = this._g | 0
+    var h = this._h | 0
+  
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4)
+    for (; i < 64; ++i) W[i] = (gamma1(W[i - 2]) + W[i - 7] + gamma0(W[i - 15]) + W[i - 16]) | 0
+  
+    for (var j = 0; j < 64; ++j) {
+      var T1 = (h + sigma1(e) + ch(e, f, g) + K[j] + W[j]) | 0
+      var T2 = (sigma0(a) + maj(a, b, c)) | 0
+  
+      h = g
+      g = f
+      f = e
+      e = (d + T1) | 0
+      d = c
+      c = b
+      b = a
+      a = (T1 + T2) | 0
+    }
+  
+    this._a = (a + this._a) | 0
+    this._b = (b + this._b) | 0
+    this._c = (c + this._c) | 0
+    this._d = (d + this._d) | 0
+    this._e = (e + this._e) | 0
+    this._f = (f + this._f) | 0
+    this._g = (g + this._g) | 0
+    this._h = (h + this._h) | 0
+  }
+  
+  Sha256.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(32)
+  
+    H.writeInt32BE(this._a, 0)
+    H.writeInt32BE(this._b, 4)
+    H.writeInt32BE(this._c, 8)
+    H.writeInt32BE(this._d, 12)
+    H.writeInt32BE(this._e, 16)
+    H.writeInt32BE(this._f, 20)
+    H.writeInt32BE(this._g, 24)
+    H.writeInt32BE(this._h, 28)
+  
+    return H
+  }
+  
+  module.exports = Sha256
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],47:[function(require,module,exports){
+  var inherits = require('inherits')
+  var SHA512 = require('./sha512')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var W = new Array(160)
+  
+  function Sha384 () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 128, 112)
+  }
+  
+  inherits(Sha384, SHA512)
+  
+  Sha384.prototype.init = function () {
+    this._ah = 0xcbbb9d5d
+    this._bh = 0x629a292a
+    this._ch = 0x9159015a
+    this._dh = 0x152fecd8
+    this._eh = 0x67332667
+    this._fh = 0x8eb44a87
+    this._gh = 0xdb0c2e0d
+    this._hh = 0x47b5481d
+  
+    this._al = 0xc1059ed8
+    this._bl = 0x367cd507
+    this._cl = 0x3070dd17
+    this._dl = 0xf70e5939
+    this._el = 0xffc00b31
+    this._fl = 0x68581511
+    this._gl = 0x64f98fa7
+    this._hl = 0xbefa4fa4
+  
+    return this
+  }
+  
+  Sha384.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(48)
+  
+    function writeInt64BE (h, l, offset) {
+      H.writeInt32BE(h, offset)
+      H.writeInt32BE(l, offset + 4)
+    }
+  
+    writeInt64BE(this._ah, this._al, 0)
+    writeInt64BE(this._bh, this._bl, 8)
+    writeInt64BE(this._ch, this._cl, 16)
+    writeInt64BE(this._dh, this._dl, 24)
+    writeInt64BE(this._eh, this._el, 32)
+    writeInt64BE(this._fh, this._fl, 40)
+  
+    return H
+  }
+  
+  module.exports = Sha384
+  
+  },{"./hash":41,"./sha512":48,"inherits":21,"safe-buffer":40}],48:[function(require,module,exports){
+  var inherits = require('inherits')
+  var Hash = require('./hash')
+  var Buffer = require('safe-buffer').Buffer
+  
+  var K = [
+    0x428a2f98, 0xd728ae22, 0x71374491, 0x23ef65cd,
+    0xb5c0fbcf, 0xec4d3b2f, 0xe9b5dba5, 0x8189dbbc,
+    0x3956c25b, 0xf348b538, 0x59f111f1, 0xb605d019,
+    0x923f82a4, 0xaf194f9b, 0xab1c5ed5, 0xda6d8118,
+    0xd807aa98, 0xa3030242, 0x12835b01, 0x45706fbe,
+    0x243185be, 0x4ee4b28c, 0x550c7dc3, 0xd5ffb4e2,
+    0x72be5d74, 0xf27b896f, 0x80deb1fe, 0x3b1696b1,
+    0x9bdc06a7, 0x25c71235, 0xc19bf174, 0xcf692694,
+    0xe49b69c1, 0x9ef14ad2, 0xefbe4786, 0x384f25e3,
+    0x0fc19dc6, 0x8b8cd5b5, 0x240ca1cc, 0x77ac9c65,
+    0x2de92c6f, 0x592b0275, 0x4a7484aa, 0x6ea6e483,
+    0x5cb0a9dc, 0xbd41fbd4, 0x76f988da, 0x831153b5,
+    0x983e5152, 0xee66dfab, 0xa831c66d, 0x2db43210,
+    0xb00327c8, 0x98fb213f, 0xbf597fc7, 0xbeef0ee4,
+    0xc6e00bf3, 0x3da88fc2, 0xd5a79147, 0x930aa725,
+    0x06ca6351, 0xe003826f, 0x14292967, 0x0a0e6e70,
+    0x27b70a85, 0x46d22ffc, 0x2e1b2138, 0x5c26c926,
+    0x4d2c6dfc, 0x5ac42aed, 0x53380d13, 0x9d95b3df,
+    0x650a7354, 0x8baf63de, 0x766a0abb, 0x3c77b2a8,
+    0x81c2c92e, 0x47edaee6, 0x92722c85, 0x1482353b,
+    0xa2bfe8a1, 0x4cf10364, 0xa81a664b, 0xbc423001,
+    0xc24b8b70, 0xd0f89791, 0xc76c51a3, 0x0654be30,
+    0xd192e819, 0xd6ef5218, 0xd6990624, 0x5565a910,
+    0xf40e3585, 0x5771202a, 0x106aa070, 0x32bbd1b8,
+    0x19a4c116, 0xb8d2d0c8, 0x1e376c08, 0x5141ab53,
+    0x2748774c, 0xdf8eeb99, 0x34b0bcb5, 0xe19b48a8,
+    0x391c0cb3, 0xc5c95a63, 0x4ed8aa4a, 0xe3418acb,
+    0x5b9cca4f, 0x7763e373, 0x682e6ff3, 0xd6b2b8a3,
+    0x748f82ee, 0x5defb2fc, 0x78a5636f, 0x43172f60,
+    0x84c87814, 0xa1f0ab72, 0x8cc70208, 0x1a6439ec,
+    0x90befffa, 0x23631e28, 0xa4506ceb, 0xde82bde9,
+    0xbef9a3f7, 0xb2c67915, 0xc67178f2, 0xe372532b,
+    0xca273ece, 0xea26619c, 0xd186b8c7, 0x21c0c207,
+    0xeada7dd6, 0xcde0eb1e, 0xf57d4f7f, 0xee6ed178,
+    0x06f067aa, 0x72176fba, 0x0a637dc5, 0xa2c898a6,
+    0x113f9804, 0xbef90dae, 0x1b710b35, 0x131c471b,
+    0x28db77f5, 0x23047d84, 0x32caab7b, 0x40c72493,
+    0x3c9ebe0a, 0x15c9bebc, 0x431d67c4, 0x9c100d4c,
+    0x4cc5d4be, 0xcb3e42b6, 0x597f299c, 0xfc657e2a,
+    0x5fcb6fab, 0x3ad6faec, 0x6c44198c, 0x4a475817
+  ]
+  
+  var W = new Array(160)
+  
+  function Sha512 () {
+    this.init()
+    this._w = W
+  
+    Hash.call(this, 128, 112)
+  }
+  
+  inherits(Sha512, Hash)
+  
+  Sha512.prototype.init = function () {
+    this._ah = 0x6a09e667
+    this._bh = 0xbb67ae85
+    this._ch = 0x3c6ef372
+    this._dh = 0xa54ff53a
+    this._eh = 0x510e527f
+    this._fh = 0x9b05688c
+    this._gh = 0x1f83d9ab
+    this._hh = 0x5be0cd19
+  
+    this._al = 0xf3bcc908
+    this._bl = 0x84caa73b
+    this._cl = 0xfe94f82b
+    this._dl = 0x5f1d36f1
+    this._el = 0xade682d1
+    this._fl = 0x2b3e6c1f
+    this._gl = 0xfb41bd6b
+    this._hl = 0x137e2179
+  
+    return this
+  }
+  
+  function Ch (x, y, z) {
+    return z ^ (x & (y ^ z))
+  }
+  
+  function maj (x, y, z) {
+    return (x & y) | (z & (x | y))
+  }
+  
+  function sigma0 (x, xl) {
+    return (x >>> 28 | xl << 4) ^ (xl >>> 2 | x << 30) ^ (xl >>> 7 | x << 25)
+  }
+  
+  function sigma1 (x, xl) {
+    return (x >>> 14 | xl << 18) ^ (x >>> 18 | xl << 14) ^ (xl >>> 9 | x << 23)
+  }
+  
+  function Gamma0 (x, xl) {
+    return (x >>> 1 | xl << 31) ^ (x >>> 8 | xl << 24) ^ (x >>> 7)
+  }
+  
+  function Gamma0l (x, xl) {
+    return (x >>> 1 | xl << 31) ^ (x >>> 8 | xl << 24) ^ (x >>> 7 | xl << 25)
+  }
+  
+  function Gamma1 (x, xl) {
+    return (x >>> 19 | xl << 13) ^ (xl >>> 29 | x << 3) ^ (x >>> 6)
+  }
+  
+  function Gamma1l (x, xl) {
+    return (x >>> 19 | xl << 13) ^ (xl >>> 29 | x << 3) ^ (x >>> 6 | xl << 26)
+  }
+  
+  function getCarry (a, b) {
+    return (a >>> 0) < (b >>> 0) ? 1 : 0
+  }
+  
+  Sha512.prototype._update = function (M) {
+    var W = this._w
+  
+    var ah = this._ah | 0
+    var bh = this._bh | 0
+    var ch = this._ch | 0
+    var dh = this._dh | 0
+    var eh = this._eh | 0
+    var fh = this._fh | 0
+    var gh = this._gh | 0
+    var hh = this._hh | 0
+  
+    var al = this._al | 0
+    var bl = this._bl | 0
+    var cl = this._cl | 0
+    var dl = this._dl | 0
+    var el = this._el | 0
+    var fl = this._fl | 0
+    var gl = this._gl | 0
+    var hl = this._hl | 0
+  
+    for (var i = 0; i < 32; i += 2) {
+      W[i] = M.readInt32BE(i * 4)
+      W[i + 1] = M.readInt32BE(i * 4 + 4)
+    }
+    for (; i < 160; i += 2) {
+      var xh = W[i - 15 * 2]
+      var xl = W[i - 15 * 2 + 1]
+      var gamma0 = Gamma0(xh, xl)
+      var gamma0l = Gamma0l(xl, xh)
+  
+      xh = W[i - 2 * 2]
+      xl = W[i - 2 * 2 + 1]
+      var gamma1 = Gamma1(xh, xl)
+      var gamma1l = Gamma1l(xl, xh)
+  
+      // W[i] = gamma0 + W[i - 7] + gamma1 + W[i - 16]
+      var Wi7h = W[i - 7 * 2]
+      var Wi7l = W[i - 7 * 2 + 1]
+  
+      var Wi16h = W[i - 16 * 2]
+      var Wi16l = W[i - 16 * 2 + 1]
+  
+      var Wil = (gamma0l + Wi7l) | 0
+      var Wih = (gamma0 + Wi7h + getCarry(Wil, gamma0l)) | 0
+      Wil = (Wil + gamma1l) | 0
+      Wih = (Wih + gamma1 + getCarry(Wil, gamma1l)) | 0
+      Wil = (Wil + Wi16l) | 0
+      Wih = (Wih + Wi16h + getCarry(Wil, Wi16l)) | 0
+  
+      W[i] = Wih
+      W[i + 1] = Wil
+    }
+  
+    for (var j = 0; j < 160; j += 2) {
+      Wih = W[j]
+      Wil = W[j + 1]
+  
+      var majh = maj(ah, bh, ch)
+      var majl = maj(al, bl, cl)
+  
+      var sigma0h = sigma0(ah, al)
+      var sigma0l = sigma0(al, ah)
+      var sigma1h = sigma1(eh, el)
+      var sigma1l = sigma1(el, eh)
+  
+      // t1 = h + sigma1 + ch + K[j] + W[j]
+      var Kih = K[j]
+      var Kil = K[j + 1]
+  
+      var chh = Ch(eh, fh, gh)
+      var chl = Ch(el, fl, gl)
+  
+      var t1l = (hl + sigma1l) | 0
+      var t1h = (hh + sigma1h + getCarry(t1l, hl)) | 0
+      t1l = (t1l + chl) | 0
+      t1h = (t1h + chh + getCarry(t1l, chl)) | 0
+      t1l = (t1l + Kil) | 0
+      t1h = (t1h + Kih + getCarry(t1l, Kil)) | 0
+      t1l = (t1l + Wil) | 0
+      t1h = (t1h + Wih + getCarry(t1l, Wil)) | 0
+  
+      // t2 = sigma0 + maj
+      var t2l = (sigma0l + majl) | 0
+      var t2h = (sigma0h + majh + getCarry(t2l, sigma0l)) | 0
+  
+      hh = gh
+      hl = gl
+      gh = fh
+      gl = fl
+      fh = eh
+      fl = el
+      el = (dl + t1l) | 0
+      eh = (dh + t1h + getCarry(el, dl)) | 0
+      dh = ch
+      dl = cl
+      ch = bh
+      cl = bl
+      bh = ah
+      bl = al
+      al = (t1l + t2l) | 0
+      ah = (t1h + t2h + getCarry(al, t1l)) | 0
+    }
+  
+    this._al = (this._al + al) | 0
+    this._bl = (this._bl + bl) | 0
+    this._cl = (this._cl + cl) | 0
+    this._dl = (this._dl + dl) | 0
+    this._el = (this._el + el) | 0
+    this._fl = (this._fl + fl) | 0
+    this._gl = (this._gl + gl) | 0
+    this._hl = (this._hl + hl) | 0
+  
+    this._ah = (this._ah + ah + getCarry(this._al, al)) | 0
+    this._bh = (this._bh + bh + getCarry(this._bl, bl)) | 0
+    this._ch = (this._ch + ch + getCarry(this._cl, cl)) | 0
+    this._dh = (this._dh + dh + getCarry(this._dl, dl)) | 0
+    this._eh = (this._eh + eh + getCarry(this._el, el)) | 0
+    this._fh = (this._fh + fh + getCarry(this._fl, fl)) | 0
+    this._gh = (this._gh + gh + getCarry(this._gl, gl)) | 0
+    this._hh = (this._hh + hh + getCarry(this._hl, hl)) | 0
+  }
+  
+  Sha512.prototype._hash = function () {
+    var H = Buffer.allocUnsafe(64)
+  
+    function writeInt64BE (h, l, offset) {
+      H.writeInt32BE(h, offset)
+      H.writeInt32BE(l, offset + 4)
+    }
+  
+    writeInt64BE(this._ah, this._al, 0)
+    writeInt64BE(this._bh, this._bl, 8)
+    writeInt64BE(this._ch, this._cl, 16)
+    writeInt64BE(this._dh, this._dl, 24)
+    writeInt64BE(this._eh, this._el, 32)
+    writeInt64BE(this._fh, this._fl, 40)
+    writeInt64BE(this._gh, this._gl, 48)
+    writeInt64BE(this._hh, this._hl, 56)
+  
+    return H
+  }
+  
+  module.exports = Sha512
+  
+  },{"./hash":41,"inherits":21,"safe-buffer":40}],49:[function(require,module,exports){
+  // Copyright Joyent, Inc. and other Node contributors.
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a
+  // copy of this software and associated documentation files (the
+  // "Software"), to deal in the Software without restriction, including
+  // without limitation the rights to use, copy, modify, merge, publish,
+  // distribute, sublicense, and/or sell copies of the Software, and to permit
+  // persons to whom the Software is furnished to do so, subject to the
+  // following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included
+  // in all copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+  // NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+  // USE OR OTHER DEALINGS IN THE SOFTWARE.
+  
+  module.exports = Stream;
+  
+  var EE = require('events').EventEmitter;
+  var inherits = require('inherits');
+  
+  inherits(Stream, EE);
+  Stream.Readable = require('readable-stream/readable.js');
+  Stream.Writable = require('readable-stream/writable.js');
+  Stream.Duplex = require('readable-stream/duplex.js');
+  Stream.Transform = require('readable-stream/transform.js');
+  Stream.PassThrough = require('readable-stream/passthrough.js');
+  
+  // Backwards-compat with node 0.4.x
+  Stream.Stream = Stream;
+  
+  
+  
+  // old-style streams.  Note that the pipe method (the only relevant
+  // part of this class) is overridden in the Readable class.
+  
+  function Stream() {
+    EE.call(this);
+  }
+  
+  Stream.prototype.pipe = function(dest, options) {
+    var source = this;
+  
+    function ondata(chunk) {
+      if (dest.writable) {
+        if (false === dest.write(chunk) && source.pause) {
+          source.pause();
+        }
+      }
+    }
+  
+    source.on('data', ondata);
+  
+    function ondrain() {
+      if (source.readable && source.resume) {
+        source.resume();
+      }
+    }
+  
+    dest.on('drain', ondrain);
+  
+    // If the 'end' option is not supplied, dest.end() will be called when
+    // source gets the 'end' or 'close' events.  Only dest.end() once.
+    if (!dest._isStdio && (!options || options.end !== false)) {
+      source.on('end', onend);
+      source.on('close', onclose);
+    }
+  
+    var didOnEnd = false;
+    function onend() {
+      if (didOnEnd) return;
+      didOnEnd = true;
+  
+      dest.end();
+    }
+  
+  
+    function onclose() {
+      if (didOnEnd) return;
+      didOnEnd = true;
+  
+      if (typeof dest.destroy === 'function') dest.destroy();
+    }
+  
+    // don't leave dangling pipes when there are errors.
+    function onerror(er) {
+      cleanup();
+      if (EE.listenerCount(this, 'error') === 0) {
+        throw er; // Unhandled stream error in pipe.
+      }
+    }
+  
+    source.on('error', onerror);
+    dest.on('error', onerror);
+  
+    // remove all the event listeners that were added.
+    function cleanup() {
+      source.removeListener('data', ondata);
+      dest.removeListener('drain', ondrain);
+  
+      source.removeListener('end', onend);
+      source.removeListener('close', onclose);
+  
+      source.removeListener('error', onerror);
+      dest.removeListener('error', onerror);
+  
+      source.removeListener('end', cleanup);
+      source.removeListener('close', cleanup);
+  
+      dest.removeListener('close', cleanup);
+    }
+  
+    source.on('end', cleanup);
+    source.on('close', cleanup);
+  
+    dest.on('close', cleanup);
+  
+    dest.emit('pipe', source);
+  
+    // Allow for unix-like usage: A.pipe(B).pipe(C)
+    return dest;
+  };
+  
+  },{"events":18,"inherits":21,"readable-stream/duplex.js":26,"readable-stream/passthrough.js":35,"readable-stream/readable.js":36,"readable-stream/transform.js":37,"readable-stream/writable.js":38}],50:[function(require,module,exports){
+  'use strict';
+  
+  var Buffer = require('safe-buffer').Buffer;
+  
+  var isEncoding = Buffer.isEncoding || function (encoding) {
+    encoding = '' + encoding;
+    switch (encoding && encoding.toLowerCase()) {
+      case 'hex':case 'utf8':case 'utf-8':case 'ascii':case 'binary':case 'base64':case 'ucs2':case 'ucs-2':case 'utf16le':case 'utf-16le':case 'raw':
+        return true;
+      default:
+        return false;
+    }
+  };
+  
+  function _normalizeEncoding(enc) {
+    if (!enc) return 'utf8';
+    var retried;
+    while (true) {
+      switch (enc) {
+        case 'utf8':
+        case 'utf-8':
+          return 'utf8';
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+          return 'utf16le';
+        case 'latin1':
+        case 'binary':
+          return 'latin1';
+        case 'base64':
+        case 'ascii':
+        case 'hex':
+          return enc;
+        default:
+          if (retried) return; // undefined
+          enc = ('' + enc).toLowerCase();
+          retried = true;
+      }
+    }
+  };
+  
+  // Do not cache `Buffer.isEncoding` when checking encoding names as some
+  // modules monkey-patch it to support additional encodings
+  function normalizeEncoding(enc) {
+    var nenc = _normalizeEncoding(enc);
+    if (typeof nenc !== 'string' && (Buffer.isEncoding === isEncoding || !isEncoding(enc))) throw new Error('Unknown encoding: ' + enc);
+    return nenc || enc;
+  }
+  
+  // StringDecoder provides an interface for efficiently splitting a series of
+  // buffers into a series of JS strings without breaking apart multi-byte
+  // characters.
+  exports.StringDecoder = StringDecoder;
+  function StringDecoder(encoding) {
+    this.encoding = normalizeEncoding(encoding);
+    var nb;
+    switch (this.encoding) {
+      case 'utf16le':
+        this.text = utf16Text;
+        this.end = utf16End;
+        nb = 4;
+        break;
+      case 'utf8':
+        this.fillLast = utf8FillLast;
+        nb = 4;
+        break;
+      case 'base64':
+        this.text = base64Text;
+        this.end = base64End;
+        nb = 3;
+        break;
+      default:
+        this.write = simpleWrite;
+        this.end = simpleEnd;
+        return;
+    }
+    this.lastNeed = 0;
+    this.lastTotal = 0;
+    this.lastChar = Buffer.allocUnsafe(nb);
+  }
+  
+  StringDecoder.prototype.write = function (buf) {
+    if (buf.length === 0) return '';
+    var r;
+    var i;
+    if (this.lastNeed) {
+      r = this.fillLast(buf);
+      if (r === undefined) return '';
+      i = this.lastNeed;
+      this.lastNeed = 0;
+    } else {
+      i = 0;
+    }
+    if (i < buf.length) return r ? r + this.text(buf, i) : this.text(buf, i);
+    return r || '';
+  };
+  
+  StringDecoder.prototype.end = utf8End;
+  
+  // Returns only complete characters in a Buffer
+  StringDecoder.prototype.text = utf8Text;
+  
+  // Attempts to complete a partial non-UTF-8 character using bytes from a Buffer
+  StringDecoder.prototype.fillLast = function (buf) {
+    if (this.lastNeed <= buf.length) {
+      buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, this.lastNeed);
+      return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+    }
+    buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, buf.length);
+    this.lastNeed -= buf.length;
+  };
+  
+  // Checks the type of a UTF-8 byte, whether it's ASCII, a leading byte, or a
+  // continuation byte.
+  function utf8CheckByte(byte) {
+    if (byte <= 0x7F) return 0;else if (byte >> 5 === 0x06) return 2;else if (byte >> 4 === 0x0E) return 3;else if (byte >> 3 === 0x1E) return 4;
+    return -1;
+  }
+  
+  // Checks at most 3 bytes at the end of a Buffer in order to detect an
+  // incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
+  // needed to complete the UTF-8 character (if applicable) are returned.
+  function utf8CheckIncomplete(self, buf, i) {
+    var j = buf.length - 1;
+    if (j < i) return 0;
+    var nb = utf8CheckByte(buf[j]);
+    if (nb >= 0) {
+      if (nb > 0) self.lastNeed = nb - 1;
+      return nb;
+    }
+    if (--j < i) return 0;
+    nb = utf8CheckByte(buf[j]);
+    if (nb >= 0) {
+      if (nb > 0) self.lastNeed = nb - 2;
+      return nb;
+    }
+    if (--j < i) return 0;
+    nb = utf8CheckByte(buf[j]);
+    if (nb >= 0) {
+      if (nb > 0) {
+        if (nb === 2) nb = 0;else self.lastNeed = nb - 3;
+      }
+      return nb;
+    }
+    return 0;
+  }
+  
+  // Validates as many continuation bytes for a multi-byte UTF-8 character as
+  // needed or are available. If we see a non-continuation byte where we expect
+  // one, we "replace" the validated continuation bytes we've seen so far with
+  // UTF-8 replacement characters ('\ufffd'), to match v8's UTF-8 decoding
+  // behavior. The continuation byte check is included three times in the case
+  // where all of the continuation bytes for a character exist in the same buffer.
+  // It is also done this way as a slight performance increase instead of using a
+  // loop.
+  function utf8CheckExtraBytes(self, buf, p) {
+    if ((buf[0] & 0xC0) !== 0x80) {
+      self.lastNeed = 0;
+      return '\ufffd'.repeat(p);
+    }
+    if (self.lastNeed > 1 && buf.length > 1) {
+      if ((buf[1] & 0xC0) !== 0x80) {
+        self.lastNeed = 1;
+        return '\ufffd'.repeat(p + 1);
+      }
+      if (self.lastNeed > 2 && buf.length > 2) {
+        if ((buf[2] & 0xC0) !== 0x80) {
+          self.lastNeed = 2;
+          return '\ufffd'.repeat(p + 2);
+        }
+      }
+    }
+  }
+  
+  // Attempts to complete a multi-byte UTF-8 character using bytes from a Buffer.
+  function utf8FillLast(buf) {
+    var p = this.lastTotal - this.lastNeed;
+    var r = utf8CheckExtraBytes(this, buf, p);
+    if (r !== undefined) return r;
+    if (this.lastNeed <= buf.length) {
+      buf.copy(this.lastChar, p, 0, this.lastNeed);
+      return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+    }
+    buf.copy(this.lastChar, p, 0, buf.length);
+    this.lastNeed -= buf.length;
+  }
+  
+  // Returns all complete UTF-8 characters in a Buffer. If the Buffer ended on a
+  // partial character, the character's bytes are buffered until the required
+  // number of bytes are available.
+  function utf8Text(buf, i) {
+    var total = utf8CheckIncomplete(this, buf, i);
+    if (!this.lastNeed) return buf.toString('utf8', i);
+    this.lastTotal = total;
+    var end = buf.length - (total - this.lastNeed);
+    buf.copy(this.lastChar, 0, end);
+    return buf.toString('utf8', i, end);
+  }
+  
+  // For UTF-8, a replacement character for each buffered byte of a (partial)
+  // character needs to be added to the output.
+  function utf8End(buf) {
+    var r = buf && buf.length ? this.write(buf) : '';
+    if (this.lastNeed) return r + '\ufffd'.repeat(this.lastTotal - this.lastNeed);
+    return r;
+  }
+  
+  // UTF-16LE typically needs two bytes per character, but even if we have an even
+  // number of bytes available, we need to check if we end on a leading/high
+  // surrogate. In that case, we need to wait for the next two bytes in order to
+  // decode the last character properly.
+  function utf16Text(buf, i) {
+    if ((buf.length - i) % 2 === 0) {
+      var r = buf.toString('utf16le', i);
+      if (r) {
+        var c = r.charCodeAt(r.length - 1);
+        if (c >= 0xD800 && c <= 0xDBFF) {
+          this.lastNeed = 2;
+          this.lastTotal = 4;
+          this.lastChar[0] = buf[buf.length - 2];
+          this.lastChar[1] = buf[buf.length - 1];
+          return r.slice(0, -1);
+        }
+      }
+      return r;
+    }
+    this.lastNeed = 1;
+    this.lastTotal = 2;
+    this.lastChar[0] = buf[buf.length - 1];
+    return buf.toString('utf16le', i, buf.length - 1);
+  }
+  
+  // For UTF-16LE we do not explicitly append special replacement characters if we
+  // end on a partial character, we simply let v8 handle that.
+  function utf16End(buf) {
+    var r = buf && buf.length ? this.write(buf) : '';
+    if (this.lastNeed) {
+      var end = this.lastTotal - this.lastNeed;
+      return r + this.lastChar.toString('utf16le', 0, end);
+    }
+    return r;
+  }
+  
+  function base64Text(buf, i) {
+    var n = (buf.length - i) % 3;
+    if (n === 0) return buf.toString('base64', i);
+    this.lastNeed = 3 - n;
+    this.lastTotal = 3;
+    if (n === 1) {
+      this.lastChar[0] = buf[buf.length - 1];
+    } else {
+      this.lastChar[0] = buf[buf.length - 2];
+      this.lastChar[1] = buf[buf.length - 1];
+    }
+    return buf.toString('base64', i, buf.length - n);
+  }
+  
+  function base64End(buf) {
+    var r = buf && buf.length ? this.write(buf) : '';
+    if (this.lastNeed) return r + this.lastChar.toString('base64', 0, 3 - this.lastNeed);
+    return r;
+  }
+  
+  // Pass bytes on through for single-byte encodings (e.g. ascii, latin1, hex)
+  function simpleWrite(buf) {
+    return buf.toString(this.encoding);
+  }
+  
+  function simpleEnd(buf) {
+    return buf && buf.length ? this.write(buf) : '';
+  }
+  },{"safe-buffer":40}],51:[function(require,module,exports){
+  (function (global){
+  
+  /**
+   * Module exports.
+   */
+  
+  module.exports = deprecate;
+  
+  /**
+   * Mark that a method should not be used.
+   * Returns a modified function which warns once by default.
+   *
+   * If `localStorage.noDeprecation = true` is set, then it is a no-op.
+   *
+   * If `localStorage.throwDeprecation = true` is set, then deprecated functions
+   * will throw an Error when invoked.
+   *
+   * If `localStorage.traceDeprecation = true` is set, then deprecated functions
+   * will invoke `console.trace()` instead of `console.error()`.
+   *
+   * @param {Function} fn - the function to deprecate
+   * @param {String} msg - the string to print to the console when `fn` is invoked
+   * @returns {Function} a new "deprecated" version of `fn`
+   * @api public
+   */
+  
+  function deprecate (fn, msg) {
+    if (config('noDeprecation')) {
+      return fn;
+    }
+  
+    var warned = false;
+    function deprecated() {
+      if (!warned) {
+        if (config('throwDeprecation')) {
+          throw new Error(msg);
+        } else if (config('traceDeprecation')) {
+          console.trace(msg);
+        } else {
+          console.warn(msg);
+        }
+        warned = true;
+      }
+      return fn.apply(this, arguments);
+    }
+  
+    return deprecated;
+  }
+  
+  /**
+   * Checks `localStorage` for boolean values for the given `name`.
+   *
+   * @param {String} name
+   * @returns {Boolean}
+   * @api private
+   */
+  
+  function config (name) {
+    // accessing global.localStorage can trigger a DOMException in sandboxed iframes
+    try {
+      if (!global.localStorage) return false;
+    } catch (_) {
+      return false;
+    }
+    var val = global.localStorage[name];
+    if (null == val) return false;
+    return String(val).toLowerCase() === 'true';
+  }
+  
+  }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+  },{}],52:[function(require,module,exports){
+  (function (Buffer){
+  /***
+   * @license
+   * https://github.com/bitcoincashjs/bchaddr
+   * Copyright (c) 2018 Emilio Almansi
+   * Distributed under the MIT software license, see the accompanying
+   * file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+   */
+  
+  var bs58check = require('bs58check')
+  var cashaddr = require('cashaddrjs')
+  
+  /**
+   * General purpose Bitcoin Cash address detection and translation.<br />
+   * Supports all major Bitcoin Cash address formats.<br />
+   * Currently:
+   * <ul>
+   *    <li> Legacy format </li>
+   *    <li> Bitpay format </li>
+   *    <li> Cashaddr format </li>
+   * </ul>
+   * @module bchaddr
+   */
+  
+  /**
+   * @static
+   * Supported Bitcoin Cash address formats.
+   */
+  var Format = {}
+  Format.Legacy = 'legacy'
+  Format.Bitpay = 'bitpay'
+  Format.Cashaddr = 'cashaddr'
+  
+  /**
+   * @static
+   * Supported networks.
+   */
+  var Network = {}
+  Network.Mainnet = 'mainnet'
+  Network.Testnet = 'testnet'
+  
+  /**
+   * @static
+   * Supported address types.
+   */
+  var Type = {}
+  Type.P2PKH = 'p2pkh'
+  Type.P2SH = 'p2sh'
+  
+  /**
+   * Detects what is the given address' format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function detectAddressFormat (address) {
+    return decodeAddress(address).format
+  }
+  
+  /**
+   * Detects what is the given address' network.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function detectAddressNetwork (address) {
+    return decodeAddress(address).network
+  }
+  
+  /**
+   * Detects what is the given address' type.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function detectAddressType (address) {
+    return decodeAddress(address).type
+  }
+  
+  /**
+   * Translates the given address into legacy format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function toLegacyAddress (address) {
+    var decoded = decodeAddress(address)
+    if (decoded.format === Format.Legacy) {
+      return address
+    }
+    return encodeAsLegacy(decoded)
+  }
+  
+  /**
+   * Translates the given address into bitpay format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function toBitpayAddress (address) {
+    var decoded = decodeAddress(address)
+    if (decoded.format === Format.Bitpay) {
+      return address
+    }
+    return encodeAsBitpay(decoded)
+  }
+  
+  /**
+   * Translates the given address into cashaddr format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {string}
+   * @throws {InvalidAddressError}
+   */
+  function toCashAddress (address) {
+    var decoded = decodeAddress(address)
+    if (decoded.format === Format.Cashaddr) {
+      return address
+    }
+    return encodeAsCashaddr(decoded)
+  }
+  
+  /**
+   * Version byte table for base58 formats.
+   * @private
+   */
+  var VERSION_BYTE = {}
+  VERSION_BYTE[Format.Legacy] = {}
+  VERSION_BYTE[Format.Legacy][Network.Mainnet] = {}
+  VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2PKH] = 0
+  VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2SH] = 5
+  VERSION_BYTE[Format.Legacy][Network.Testnet] = {}
+  VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2PKH] = 111
+  VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2SH] = 196
+  VERSION_BYTE[Format.Bitpay] = {}
+  VERSION_BYTE[Format.Bitpay][Network.Mainnet] = {}
+  VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2PKH] = 28
+  VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2SH] = 40
+  VERSION_BYTE[Format.Bitpay][Network.Testnet] = {}
+  VERSION_BYTE[Format.Bitpay][Network.Testnet][Type.P2PKH] = 111
+  VERSION_BYTE[Format.Bitpay][Network.Testnet][Type.P2SH] = 196
+  
+  /**
+   * Decodes the given address into its constituting hash, format, network and type.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeAddress (address) {
+    try {
+      return decodeBase58Address(address)
+    } catch (error) {
+    }
+    try {
+      return decodeCashAddress(address)
+    } catch (error) {
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Attempts to decode the given address assuming it is a base58 address.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeBase58Address (address) {
+    try {
+      var payload = bs58check.decode(address)
+      var versionByte = payload[0]
+      var hash = Array.prototype.slice.call(payload, 1)
+      switch (versionByte) {
+        case VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2PKH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Mainnet,
+            type: Type.P2PKH
+          }
+        case VERSION_BYTE[Format.Legacy][Network.Mainnet][Type.P2SH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Mainnet,
+            type: Type.P2SH
+          }
+        case VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2PKH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Testnet,
+            type: Type.P2PKH
+          }
+        case VERSION_BYTE[Format.Legacy][Network.Testnet][Type.P2SH]:
+          return {
+            hash: hash,
+            format: Format.Legacy,
+            network: Network.Testnet,
+            type: Type.P2SH
+          }
+        case VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2PKH]:
+          return {
+            hash: hash,
+            format: Format.Bitpay,
+            network: Network.Mainnet,
+            type: Type.P2PKH
+          }
+        case VERSION_BYTE[Format.Bitpay][Network.Mainnet][Type.P2SH]:
+          return {
+            hash: hash,
+            format: Format.Bitpay,
+            network: Network.Mainnet,
+            type: Type.P2SH
+          }
+      }
+    } catch (error) {
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Attempts to decode the given address assuming it is a cashaddr address.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeCashAddress (address) {
+    if (address.indexOf(':') !== -1) {
+      try {
+        return decodeCashAddressWithPrefix(address)
+      } catch (error) {
+      }
+    } else {
+      var prefixes = ['bitcoincash', 'bchtest', 'regtest']
+      for (var i = 0; i < prefixes.length; ++i) {
+        try {
+          var prefix = prefixes[i]
+          return decodeCashAddressWithPrefix(prefix + ':' + address)
+        } catch (error) {
+        }
+      }
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Attempts to decode the given address assuming it is a cashaddr address with explicit prefix.
+   * @private
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @return {object}
+   * @throws {InvalidAddressError}
+   */
+  function decodeCashAddressWithPrefix (address) {
+    try {
+      var decoded = cashaddr.decode(address)
+      var hash = Array.prototype.slice.call(decoded.hash, 0)
+      var type = decoded.type === 'P2PKH' ? Type.P2PKH : Type.P2SH
+      switch (decoded.prefix) {
+        case 'bitcoincash':
+          return {
+            hash: hash,
+            format: Format.Cashaddr,
+            network: Network.Mainnet,
+            type: type
+          }
+        case 'bchtest':
+        case 'regtest':
+          return {
+            hash: hash,
+            format: Format.Cashaddr,
+            network: Network.Testnet,
+            type: type
+          }
+      }
+    } catch (error) {
+    }
+    throw new InvalidAddressError()
+  }
+  
+  /**
+   * Encodes the given decoded address into legacy format.
+   * @private
+   * @param {object} decoded
+   * @returns {string}
+   */
+  function encodeAsLegacy (decoded) {
+    var versionByte = VERSION_BYTE[Format.Legacy][decoded.network][decoded.type]
+    var buffer = Buffer.alloc(1 + decoded.hash.length)
+    buffer[0] = versionByte
+    buffer.set(decoded.hash, 1)
+    return bs58check.encode(buffer)
+  }
+  
+  /**
+   * Encodes the given decoded address into bitpay format.
+   * @private
+   * @param {object} decoded
+   * @returns {string}
+   */
+  function encodeAsBitpay (decoded) {
+    var versionByte = VERSION_BYTE[Format.Bitpay][decoded.network][decoded.type]
+    var buffer = Buffer.alloc(1 + decoded.hash.length)
+    buffer[0] = versionByte
+    buffer.set(decoded.hash, 1)
+    return bs58check.encode(buffer)
+  }
+  
+  /**
+   * Encodes the given decoded address into cashaddr format.
+   * @private
+   * @param {object} decoded
+   * @returns {string}
+   */
+  function encodeAsCashaddr (decoded) {
+    var prefix = decoded.network === Network.Mainnet ? 'bitcoincash' : 'bchtest'
+    var type = decoded.type === Type.P2PKH ? 'P2PKH' : 'P2SH'
+    var hash = Uint8Array.from(decoded.hash)
+    return cashaddr.encode(prefix, type, hash)
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is in legacy format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isLegacyAddress (address) {
+    return detectAddressFormat(address) === Format.Legacy
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is in bitpay format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isBitpayAddress (address) {
+    return detectAddressFormat(address) === Format.Bitpay
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is in cashaddr format.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isCashAddress (address) {
+    return detectAddressFormat(address) === Format.Cashaddr
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a mainnet address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isMainnetAddress (address) {
+    return detectAddressNetwork(address) === Network.Mainnet
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a testnet address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isTestnetAddress (address) {
+    return detectAddressNetwork(address) === Network.Testnet
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a p2pkh address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isP2PKHAddress (address) {
+    return detectAddressType(address) === Type.P2PKH
+  }
+  
+  /**
+   * Returns a boolean indicating whether the address is a p2sh address.
+   * @static
+   * @param {string} address - A valid Bitcoin Cash address in any format.
+   * @returns {boolean}
+   * @throws {InvalidAddressError}
+   */
+  function isP2SHAddress (address) {
+    return detectAddressType(address) === Type.P2SH
+  }
+  
+  /**
+   * Error thrown when the address given as input is not a valid Bitcoin Cash address.
+   * @constructor
+   * InvalidAddressError
+   */
+  function InvalidAddressError () {
+    var error = new Error()
+    this.name = error.name = 'InvalidAddressError'
+    this.message = error.message = 'Received an invalid Bitcoin Cash address as input.'
+    this.stack = error.stack
+  }
+  
+  InvalidAddressError.prototype = Object.create(Error.prototype)
+  
+  module.exports = {
+    Format: Format,
+    Network: Network,
+    Type: Type,
+    detectAddressFormat: detectAddressFormat,
+    detectAddressNetwork: detectAddressNetwork,
+    detectAddressType: detectAddressType,
+    toLegacyAddress: toLegacyAddress,
+    toBitpayAddress: toBitpayAddress,
+    toCashAddress: toCashAddress,
+    isLegacyAddress: isLegacyAddress,
+    isBitpayAddress: isBitpayAddress,
+    isCashAddress: isCashAddress,
+    isMainnetAddress: isMainnetAddress,
+    isTestnetAddress: isTestnetAddress,
+    isP2PKHAddress: isP2PKHAddress,
+    isP2SHAddress: isP2SHAddress,
+    InvalidAddressError: InvalidAddressError
+  }
+  
+  }).call(this,require("buffer").Buffer)
+  },{"bs58check":7,"buffer":8,"cashaddrjs":10}]},{},[52])(52)
+  });

--- a/src/bitaddress-ui.html
+++ b/src/bitaddress-ui.html
@@ -50,6 +50,9 @@
 	<meta charset="utf-8">
 
 	<script type="text/javascript">
+//bchaddr.js	
+	</script>
+	<script type="text/javascript">
 //cryptojs.js	
 	</script>
 	<script type="text/javascript">
@@ -488,7 +491,7 @@
 						<span class="statusicon" id="statusunittests" onclick="ninja.status.showUnitTests();">...</span>
 						<span class="statusicon" id="statuskeypool" onclick="ninja.status.showKeyPool();">&#8803;</span>
 					</span>
-					<span class="item"><span id="footerlabeldonations">Bitcoin Cash Donations for hosting (Do not send BTC):</span> 1AqBBnvDqhaXvzaLnZxSwxBVQ7JnEMBihS</span>
+					<span class="item"><span id="footerlabeldonations">Bitcoin Cash Donations:</span> bitcoincash:qp4atx0z6h6atuzchuaqssnkdqag95ecdqtt5nx8z8</span>
 					<span class="item" id="footerlabeltranslatedby"></span>
 				</div>
 			</div>

--- a/src/culture/el.js
+++ b/src/culture/el.js
@@ -30,7 +30,7 @@
 
 		// footer html
 		"footerlabeldonations": "Δωρεές:",
-		"footerlabeltranslatedby": "Μετάφραση: <a href='http://BitcoinX.gr/'><b>BitcoinX.gr</b></a>BTC 1BitcoiNxkUPcTFxwMqxhRiPEiQRzYskf6",
+		"footerlabeltranslatedby": "Μετάφραση: <a href='http://BitcoinX.gr/'><b>BitcoinX.gr</b></a> BTC 1BitcoiNxkUPcTFxwMqxhRiPEiQRzYskf6",
 		"footerlabelpgp": "PGP",
 		"footerlabelversion": "ιστορικό εκδόσεων",
 		"footerlabelgithub": "Αποθετήριο GitHub",

--- a/src/culture/es.js
+++ b/src/culture/es.js
@@ -33,7 +33,7 @@
 
 		// footer html
 		"footerlabeldonations": "Donaciones:",
-		"footerlabeltranslatedby": "Traducción: <b>Francisco Salvado</b> 34asTQaYjY1wViisS7ydueY3Kx3Cw5dVLW",
+		"footerlabeltranslatedby": "Traducción: <b>Francisco Salvado</b> bitcoincash:pq0ma5q7rtmyty47qr5s54hys0uqu472nu37ge98q9",
 		"footerlabelpgp": "PGP",
 		"footerlabelversion": "Histórico de versiones",
 		"footerlabelgithub": "Repositorio GitHub",

--- a/src/culture/fr.js
+++ b/src/culture/fr.js
@@ -33,7 +33,7 @@
 
 		// footer html
 		"footerlabeldonations": "Don:",
-		"footerlabeltranslatedby": "Traduction: <b>checksum0</b> 1EsQy5Ry8guF6BuUgWCgBCQt11PCQhXqHA",
+		"footerlabeltranslatedby": "Traduction: <b>checksum0</b> bitcoincash:qzvzyuy4kshwfqcuavcmrx00s04uze2dgvj3gh0qhl",
 		"footerlabelpgp": "PGP",
 		"footerlabelversion": "Historique des versions",
 		"footerlabelgithub": "Dépôt Github",

--- a/src/main.css
+++ b/src/main.css
@@ -6,6 +6,7 @@ a { position: relative; z-index: 20; }
 .right { text-align: right; }
 .walletarea, #paperarea { display: none; }
 hr { margin: 20px 0; border-top: 2px dashed #008000; }
+#paperkeyarea .keyarea { height: 110px; }
 .keyarea { text-align: left; position: relative; padding: 5px; }
 .keyarea .public { float: left; }
 .keyarea .pubaddress { display: inline-block; height: 40px; padding: 0 0 0 10px; float: left; }
@@ -59,7 +60,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
                                         padding: 5px 5px 2px 5px; }
 #paperarea .artwallet .btcaddress  
 {
-    position: absolute; top: 240px; left: 139px; z-index: 100; font-size: 10px; background-color: transparent;
+    position: absolute; top: 225px; left: 142px; z-index: 100; font-size: 8px; background-color: transparent;
     font-weight:bold; color: #000000; margin: 0;
         -webkit-transform-origin:top left; -webkit-transform:rotate(-90deg);
         -moz-transform-origin:top left;    -moz-transform:rotate(-90deg);
@@ -89,7 +90,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 }
 #bulkarea .body { padding: 5px 0 0 0; }
 #bulkarea .format { font-style: italic; font-size: 90%; }
-#bulktextarea { font-size: 90%; width: 98%; margin: 4px 0 0 0; }
+#bulktextarea { font-size: 85%; width: 98%; margin: 4px 0 0 0; }
 #detailkeyarea { padding: 10px; }
 #detailarea { margin: 0; text-align: left; }
 #detailarea .notes { text-align: left; font-size: 80%; padding: 0 0 20px 0; }
@@ -206,7 +207,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 
     .footer { font-size: 90%; clear: both; padding: 10px 0 10px 0; margin: 0; border-top: 2px solid #4cca47; }
     .footer div span.item { padding: 10px; }
-    .footer .authorbtc { float: left; width: 450px; }
+    .footer .authorbtc { float: left; width: 500px; }
     .footer .authorbtc span.item { text-align: left; display: block; padding: 0 20px; }
     .footer .authorbtc div { position: relative; z-index: 100; }
     .footer .github { position: relative; }

--- a/src/ninja.bulkwallet.js
+++ b/src/ninja.bulkwallet.js
@@ -62,7 +62,7 @@
 						Bitcoin.KeyPool.push(new Bitcoin.Bip38Key(address, encryptedKey));
 
 						bulk.csv.push((bulk.csvRowLimit - bulk.csvRowsRemaining + bulk.csvStartIndex)
-										+ ",\"" + address + "\",\"" + encryptedKey
+										+ ",\"" + bchaddr.toCashAddress(address) + "\",\"" + encryptedKey
 										+ "\"");
 						document.getElementById("bulktextarea").value = translator.get("bulkgeneratingaddresses") + bulk.csvRowsRemaining;
 
@@ -75,7 +75,7 @@
 					var key = new Bitcoin.ECKey(false);
 					key.setCompressed(bulk.compressedAddrs);
 					bulk.csv.push((bulk.csvRowLimit - bulk.csvRowsRemaining + bulk.csvStartIndex)
-										+ ",\"" + key.getBitcoinAddress() + "\",\"" + key.toString("wif")
+										+ ",\"" + bchaddr.toCashAddress(key.getBitcoinAddress()) + "\",\"" + key.toString("wif")
 										//+	"\",\"" + key.toString("wifcomp")    // uncomment these lines to add different private key formats to the CSV
 										//+ "\",\"" + key.getBitcoinHexFormat() 
 										//+ "\",\"" + key.toString("base64") 

--- a/src/ninja.detailwallet.js
+++ b/src/ninja.detailwallet.js
@@ -155,13 +155,13 @@
 				btcKey.setCompressed(false);
 				document.getElementById("detailprivhex").innerHTML = btcKey.toString().toUpperCase();
 				document.getElementById("detailprivb64").innerHTML = btcKey.toString("base64");
-				var bitcoinAddress = btcKey.getBitcoinAddress();
+				var bitcoinAddress = bchaddr.toCashAddress(btcKey.getBitcoinAddress());
 				var wif = btcKey.getBitcoinWalletImportFormat();
 				document.getElementById("detailpubkey").innerHTML = btcKey.getPubKeyHex();
 				document.getElementById("detailaddress").innerHTML = bitcoinAddress;
 				document.getElementById("detailprivwif").innerHTML = wif;
 				btcKey.setCompressed(true);
-				var bitcoinAddressComp = btcKey.getBitcoinAddress();
+				var bitcoinAddressComp = bchaddr.toCashAddress(btcKey.getBitcoinAddress());
 				var wifComp = btcKey.getBitcoinWalletImportFormat();			
 				document.getElementById("detailpubkeycomp").innerHTML = btcKey.getPubKeyHex();
 				document.getElementById("detailaddresscomp").innerHTML = bitcoinAddressComp;

--- a/src/ninja.paperwallet.js
+++ b/src/ninja.paperwallet.js
@@ -104,7 +104,7 @@ ninja.wallets.paperwallet = {
 			ninja.privateKey.BIP38GenerateECAddressAsync(ninja.wallets.paperwallet.intermediatePoint, compressed, function (address, encryptedKey) {
 				Bitcoin.KeyPool.push(new Bitcoin.Bip38Key(address, encryptedKey));
 				if (ninja.wallets.paperwallet.useArtisticWallet) {
-					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
+					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, address, encryptedKey);
 				}
 				else {
 					ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
@@ -117,7 +117,7 @@ ninja.wallets.paperwallet = {
 			var bitcoinAddress = key.getBitcoinAddress();
 			var privateKeyWif = key.getBitcoinWalletImportFormat();
 			if (ninja.wallets.paperwallet.useArtisticWallet) {
-				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);
+				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bitcoinAddress, privateKeyWif);
 			}
 			else {
 				ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);

--- a/src/ninja.paperwallet.js
+++ b/src/ninja.paperwallet.js
@@ -186,7 +186,7 @@ ninja.wallets.paperwallet = {
 		keyValuePair["qrcode_public" + idPostFix] = bchaddr.toCashAddress(bitcoinAddress);
 		keyValuePair["qrcode_private" + idPostFix] = privateKey;
 		ninja.qrCode.showQrCode(keyValuePair, 2.5);
-		document.getElementById("btcaddress" + idPostFix).innerHTML = bchaddr.toCashAddress(bitcoinAddress).replace(/^bitcoincash:/, '');
+		document.getElementById("btcaddress" + idPostFix).innerHTML = bchaddr.toCashAddress(bitcoinAddress).replace(/^.*:/, '');
 
 		if (ninja.wallets.paperwallet.encrypt) {
 			var half = privateKey.length / 2;

--- a/src/ninja.paperwallet.js
+++ b/src/ninja.paperwallet.js
@@ -104,10 +104,10 @@ ninja.wallets.paperwallet = {
 			ninja.privateKey.BIP38GenerateECAddressAsync(ninja.wallets.paperwallet.intermediatePoint, compressed, function (address, encryptedKey) {
 				Bitcoin.KeyPool.push(new Bitcoin.Bip38Key(address, encryptedKey));
 				if (ninja.wallets.paperwallet.useArtisticWallet) {
-					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, address, encryptedKey);
+					ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
 				}
 				else {
-					ninja.wallets.paperwallet.showWallet(idPostFix, address, encryptedKey);
+					ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(address), encryptedKey);
 				}
 			});
 		}
@@ -117,10 +117,10 @@ ninja.wallets.paperwallet = {
 			var bitcoinAddress = key.getBitcoinAddress();
 			var privateKeyWif = key.getBitcoinWalletImportFormat();
 			if (ninja.wallets.paperwallet.useArtisticWallet) {
-				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bitcoinAddress, privateKeyWif);
+				ninja.wallets.paperwallet.showArtisticWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);
 			}
 			else {
-				ninja.wallets.paperwallet.showWallet(idPostFix, bitcoinAddress, privateKeyWif);
+				ninja.wallets.paperwallet.showWallet(idPostFix, bchaddr.toCashAddress(bitcoinAddress), privateKeyWif);
 			}
 		}
 	},
@@ -183,10 +183,10 @@ ninja.wallets.paperwallet = {
 
 	showArtisticWallet: function (idPostFix, bitcoinAddress, privateKey) {
 		var keyValuePair = {};
-		keyValuePair["qrcode_public" + idPostFix] = bitcoinAddress;
+		keyValuePair["qrcode_public" + idPostFix] = bchaddr.toCashAddress(bitcoinAddress);
 		keyValuePair["qrcode_private" + idPostFix] = privateKey;
 		ninja.qrCode.showQrCode(keyValuePair, 2.5);
-		document.getElementById("btcaddress" + idPostFix).innerHTML = bitcoinAddress;
+		document.getElementById("btcaddress" + idPostFix).innerHTML = bchaddr.toCashAddress(bitcoinAddress).replace(/^bitcoincash:/, '');
 
 		if (ninja.wallets.paperwallet.encrypt) {
 			var half = privateKey.length / 2;
@@ -228,7 +228,7 @@ ninja.wallets.paperwallet = {
 		var limit;
 		var limitperpage;
 
-		document.getElementById("paperkeyarea").style.fontSize = "100%";
+		document.getElementById("paperkeyarea").style.fontSize = "95%";
 		if (!hideArt.checked) {
 			limit = ninja.wallets.paperwallet.pageBreakAtArtisticDefault;
 			limitperpage = ninja.wallets.paperwallet.pageBreakAtArtisticDefault;

--- a/src/ninja.qrcode.js
+++ b/src/ninja.qrcode.js
@@ -62,7 +62,9 @@
 			for (var key in keyValuePair) {
 				var value = keyValuePair[key];
 				origValueSize = value.length;
-				value = ninja.qrCode.scheme() + value;
+				if (!value.startsWith(ninja.qrCode.scheme())) {
+					value = ninja.qrCode.scheme() + value;
+				}
 				valueSize = value.length;
 				adjustment = 0;
 				// Tweak adjustment for addresses and regular
@@ -71,6 +73,8 @@
 					adjustment = 0.065;
 				} else if (value.length == 64) {
 					adjustment = 0.1;
+				} else if (valueSize == 54) {
+					adjustment = -0.2;
 				}
 				multiplier = sizeMultiplier * ((origValueSize/valueSize) + adjustment);
 				try {

--- a/src/ninja.qrcode.js
+++ b/src/ninja.qrcode.js
@@ -62,7 +62,7 @@
 			for (var key in keyValuePair) {
 				var value = keyValuePair[key];
 				origValueSize = value.length;
-				if (!value.startsWith(ninja.qrCode.scheme())) {
+				if (!value.startsWith(ninja.qrCode.scheme()) && (key.match(/addr/) || key.match(/public/))) {
 					value = ninja.qrCode.scheme() + value;
 				}
 				valueSize = value.length;

--- a/src/ninja.singlewallet.js
+++ b/src/ninja.singlewallet.js
@@ -20,7 +20,7 @@
 			try {
 				var key = new Bitcoin.ECKey(false);
 				key.setCompressed(true);
-				var bitcoinAddress = key.getBitcoinAddress();
+				var bitcoinAddress = bchaddr.toCashAddress(key.getBitcoinAddress());
 				var privateKeyWif = key.getBitcoinWalletImportFormat();
 				document.getElementById("btcaddress").innerHTML = bitcoinAddress;
 				document.getElementById("btcprivwif").innerHTML = privateKeyWif;

--- a/src/ninja.splitwallet.js
+++ b/src/ninja.splitwallet.js
@@ -55,8 +55,8 @@ ninja.wallets.splitwallet = {
 			var output = document.createElement("div");
 			output.setAttribute("id", "splitoutput");
 			var m = {};
-			output.appendChild(this.mkOutputRow(bitcoinAddress, "split_addr", "Bitcoin Address:    "));
-			m["split_addr"] = bitcoinAddress;
+			output.appendChild(this.mkOutputRow(bchaddr.toCashAddress(bitcoinAddress), "split_addr", "Bitcoin Cash Address:    "));
+			m["split_addr"] = bchaddr.toCashAddress(bitcoinAddress);
 
 			for (var i = 0; i < shares.length; i++) {
 				var id = "split_qr_" + i;
@@ -65,7 +65,7 @@ ninja.wallets.splitwallet = {
 			}
 
 			document.getElementById("splitstep1area").innerHTML = output.innerHTML;
-			ninja.qrCode.showQrCode(m);
+			ninja.qrCode.showQrCode(m, 4);
 
 			document.getElementById("splitstep1area").style.display = "block";
 			document.getElementById("splitstep1icon").setAttribute("class", "less");

--- a/src/ninja.translator.js
+++ b/src/ninja.translator.js
@@ -53,7 +53,7 @@
 			"en": {
 				// javascript alerts or messages
 				"testneteditionactivated": "TESTNET EDITION ACTIVATED",
-				"paperlabelbitcoinaddress": "Bitcoin Address:",
+				"paperlabelbitcoinaddress": "Bitcoin Cash Address:",
 				"paperlabelprivatekey": "Private Key:",
 				"paperlabelencryptedkey": "Encrypted Private Key (Password required)",
 				"bulkgeneratingaddresses": "Generating addresses... ",


### PR DESCRIPTION
I have updated everything to present cashaddr style addresses. The only tab I didn't update was the Vanity Wallet, since it requires the old format, and is pretty neat.

* All QR codes should now use cashaddr.
* The paper wallet discards the 'bitcoincash:' prefix to save space, but the QR codes are for the full address.
* Updated BCH donation addresses to cashaddr style.
* Removed prefix from private key QR codes to fix sweeps.

Please review, would love to get this rockin.

NOTE: Using https://github.com/bitcoincashjs/bchaddrjs for the conversions.